### PR TITLE
Fix meta handling in event logging

### DIFF
--- a/backend_app.py
+++ b/backend_app.py
@@ -793,7 +793,7 @@ def mark_played(channel_pk: int, request_id: int, db: Session = Depends(get_db))
 # =====================================
 @app.post("/channels/{channel_pk}/events", response_model=dict, dependencies=[Depends(require_token)])
 def log_event(channel_pk: int, payload: EventIn, db: Session = Depends(get_db)):
-    meta_str = json.dumps(payload.metadata or {})
+    meta_str = json.dumps(payload.meta or {})
     ev = Event(channel_id=channel_pk, event_type=payload.type, user_id=payload.user_id, meta=meta_str)
     db.add(ev)
     db.commit()
@@ -803,8 +803,8 @@ def log_event(channel_pk: int, payload: EventIn, db: Session = Depends(get_db)):
         if payload.user_id:
             award_prio_points(db, channel_pk, payload.user_id, 1)
     elif payload.type == "gift_sub":
-        # metadata expects {"count": N}
-        count = int((payload.metadata or {}).get("count", 1))
+        # meta expects {"count": N}
+        count = int((payload.meta or {}).get("count", 1))
         if payload.user_id:  # gifter
             award_prio_points(db, channel_pk, payload.user_id, count)
     elif payload.type == "sub":


### PR DESCRIPTION
## Summary
- read event metadata from `payload.meta`
- adjust gift sub point awards to use `payload.meta`

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b41ffdd2d4832895a968ebe4311dda