### PR TITLE
Document bits and gifted sub event point awards

### DIFF
--- a/docs/backend_api.md
+++ b/docs/backend_api.md
@@ -55,8 +55,13 @@ This document summarizes the REST endpoints exposed by `backend_app.py`.
 ## Events
 | Method | Path | Description |
 |--------|------|-------------|
-| POST | `/channels/{channel_pk}/events` | Log a channel event such as follows or subscriptions (admin). |
+| POST | `/channels/{channel_pk}/events` | Log a channel event such as follows, subscriptions, or bits (admin). |
 | GET | `/channels/{channel_pk}/events` | Retrieve logged events with optional filtering by type and time. |
+
+Certain events award priority points:
+
+- `bits` events grant 1 point for any cheer of at least 200 bits.
+- Gifted subs (`gift_sub` events) grant 1 point for every 5 subscriptions gifted.
 
 ## Streams
 | Method | Path | Description |


### PR DESCRIPTION
## Summary
- clarify bits events award 1 point for cheers of at least 200 bits
- note that gifted subs grant 1 point per 5 gifts

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b42891d3c88328829fd9e46f38e956