### PR TITLE
Support archived stream listing and viewing

### DIFF
--- a/backend_app.py
+++ b/backend_app.py
@@ -229,6 +229,14 @@ class EventOut(BaseModel):
     class Config:
         from_attributes = True
 
+class StreamOut(BaseModel):
+    id: int
+    started_at: datetime
+    ended_at: Optional[datetime]
+
+    class Config:
+        from_attributes = True
+
 # =====================================
 # FastAPI app and deps
 # =====================================
@@ -848,6 +856,15 @@ def list_events(channel_pk: int, type: Optional[str] = None, since: Optional[str
 # =====================================
 # Routes: Streams
 # =====================================
+@app.get("/channels/{channel_pk}/streams", response_model=List[StreamOut])
+def list_streams(channel_pk: int, db: Session = Depends(get_db)):
+    return (
+        db.query(StreamSession)
+        .filter(StreamSession.channel_id == channel_pk)
+        .order_by(StreamSession.started_at.asc())
+        .all()
+    )
+
 @app.post("/channels/{channel_pk}/streams/start", response_model=dict, dependencies=[Depends(require_token)])
 def start_stream(channel_pk: int, db: Session = Depends(get_db)):
     sid = current_stream(db, channel_pk)

--- a/docs/backend_api.md
+++ b/docs/backend_api.md
@@ -66,6 +66,7 @@ Certain events award priority points:
 ## Streams
 | Method | Path | Description |
 |--------|------|-------------|
+| GET | `/channels/{channel_pk}/streams` | List stream sessions for a channel. |
 | POST | `/channels/{channel_pk}/streams/start` | Ensure a stream session exists and return its ID (admin). |
 | POST | `/channels/{channel_pk}/streams/archive` | Close the current stream and start a new session (admin). |
 

--- a/html/overlay.html
+++ b/html/overlay.html
@@ -20,11 +20,15 @@
 const params = new URLSearchParams(location.search);
 const BACKEND = (params.get('backend') || 'http://localhost:8000').replace(/\/$/, '');
 const CHANNEL = params.get('channel') || '1';
+const STREAM  = params.get('stream');
 
 async function api(p){ const r = await fetch(`${BACKEND}${p}`); return r.json(); }
 
 async function refresh(){
-  const queue = await api(`/channels/${CHANNEL}/queue`);
+  const endpoint = STREAM
+    ? `/channels/${CHANNEL}/streams/${STREAM}/queue`
+    : `/channels/${CHANNEL}/queue`;
+  const queue = await api(endpoint);
   const pending = queue.filter(q=>q.played===0);
   const prio = pending.filter(q=>q.is_priority===1);
   const non  = pending.filter(q=>q.is_priority===0);
@@ -45,9 +49,11 @@ async function refresh(){
 
 // initial render
 refresh();
-// live updates
-const es = new EventSource(`${BACKEND}/channels/${CHANNEL}/queue/stream`);
-es.addEventListener('queue', ()=> refresh());
+// live updates for current stream only
+if(!STREAM){
+  const es = new EventSource(`${BACKEND}/channels/${CHANNEL}/queue/stream`);
+  es.addEventListener('queue', ()=> refresh());
+}
 </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- expose `GET /channels/{channel}/streams` to list past stream sessions
- refresh archive list in web UI and allow overlay to view specific streams
- auto-select latest stream in archive view so archived queues are immediately visible

## Testing
- `python - <<'PY' ... PY` — verified archiving creates a new stream and listing/queue endpoints work
- `pytest` — no tests collected


------
https://chatgpt.com/codex/tasks/task_e_68b48487d1ec83289a8b75bc52820061