### PR TITLE
Parameterize ports via environment variables

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,8 @@ FROM python:3.12-slim
 
 ENV PYTHONUNBUFFERED=1 \
     ADMIN_TOKEN=change-me \
-    DB_URL=sqlite:////data/db.sqlite
+    DB_URL=sqlite:////data/db.sqlite \
+    API_PORT=8000
 
 WORKDIR /app
 COPY requirements.txt ./
@@ -11,5 +12,5 @@ COPY backend_app.py ./backend_app.py
 COPY run.sh ./run.sh
 RUN chmod +x run.sh
 VOLUME ["/data"]
-EXPOSE 8000
-CMD ["uvicorn", "backend_app:app", "--host", "0.0.0.0", "--port", "8000"]
+EXPOSE ${API_PORT}
+CMD ["sh", "-c", "uvicorn backend_app:app --host 0.0.0.0 --port ${API_PORT}"]

--- a/bot/bot_app.py
+++ b/bot/bot_app.py
@@ -8,7 +8,8 @@ import aiohttp
 from twitchio.ext import commands
 
 # ---- Env ----
-BACKEND_URL = os.getenv('BACKEND_BASE_URL', 'http://api:8000')
+API_PORT = os.getenv('API_PORT', '8000')
+BACKEND_URL = os.getenv('BACKEND_BASE_URL', f'http://api:{API_PORT}')
 ADMIN_TOKEN = os.getenv('BACKEND_ADMIN_TOKEN', 'change-me')
 CHANNELS = [c.strip() for c in os.getenv('CHANNELS', '').split(',') if c.strip()]
 BOT_TOKEN = os.getenv('TWITCH_BOT_TOKEN')  # token without 'oauth:'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,8 +6,9 @@ services:
       - ADMIN_TOKEN=${ADMIN_TOKEN}
       - DB_URL=sqlite:////data/db.sqlite
       - RESET_DB="1"   # remove after the first successful start
+      - API_PORT=${API_PORT:-8000}
     ports:
-      - "8000:8000"
+      - "${API_PORT:-8000}:${API_PORT:-8000}"
     volumes:
       - ./data:/data
   bot:
@@ -15,7 +16,7 @@ services:
       context: .
       dockerfile: bot/Dockerfile
     environment:
-      BACKEND_BASE_URL: http://api:8000
+      BACKEND_BASE_URL: http://api:${API_PORT:-8000}
       BACKEND_ADMIN_TOKEN: ${ADMIN_TOKEN}
       TWITCH_BOT_TOKEN: ${TWITCH_OAUTH_TOKEN}
       BOT_NICK: ${BOT_NICK}
@@ -35,5 +36,5 @@ services:
       dockerfile: web/Dockerfile
     container_name: songqueue-web
     ports:
-      - "8080:80"
+      - "${WEB_PORT:-8080}:80"
     restart: unless-stopped

--- a/docs/README.md
+++ b/docs/README.md
@@ -19,7 +19,7 @@ Additional directories include:
    ```bash
    docker-compose up --build
    ```
-   This launches the API on port 8000, the bot, and the web UI on port 8080.
+   This launches the API on port 8000 (set with `API_PORT`), the bot, and the web UI on port 8080 (set with `WEB_PORT`).
 
 ## Backend Highlights
 - Uses SQLite by default (`DB_URL` configurable) and defines models for channels, songs, users, stream sessions, and requests.

--- a/run.sh
+++ b/run.sh
@@ -18,5 +18,4 @@ backend_app.Base.metadata.create_all(bind=backend_app.engine)
 print("DB ready at", os.getenv("DB_URL"))
 PY
 
-
-uvicorn backend_app:app --host 0.0.0.0 --port 8000
+uvicorn backend_app:app --host 0.0.0.0 --port "${API_PORT:-8000}"


### PR DESCRIPTION
## Summary
- expose backend port via `API_PORT` env var and use it throughout Dockerfile, run script, and docker compose
- allow docker compose web port to be configured with `WEB_PORT`
- adjust bot configuration and documentation for configurable ports

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c32abf8e788328b2491e8e2fcfcae3