### PR TITLE
Simplify environment configuration and add web backend auto detection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -571,6 +571,3 @@ poetry.toml
 pyrightconfig.json
 
 # End of https://www.toptal.com/developers/gitignore/api/python,csharp
-
-# Local environment overrides
-stack.env

--- a/.gitignore
+++ b/.gitignore
@@ -571,3 +571,6 @@ poetry.toml
 pyrightconfig.json
 
 # End of https://www.toptal.com/developers/gitignore/api/python,csharp
+
+# Local environment overrides
+stack.env

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,5 +9,6 @@ COPY backend_app.py ./backend_app.py
 COPY run.sh ./run.sh
 RUN chmod +x run.sh
 VOLUME ["/data"]
-EXPOSE ${API_PORT}
-CMD ["sh", "-c", "uvicorn backend_app:app --host 0.0.0.0 --port ${API_PORT}"]
+# The API always listens on port 7070 inside the container.
+EXPOSE 7070
+CMD ["sh", "-c", "uvicorn backend_app:app --host 0.0.0.0 --port 7070"]

--- a/README.md
+++ b/README.md
@@ -2,4 +2,5 @@
 
 Songbot is a Twitch song request system consisting of a FastAPI backend, a TwitchIO bot, and a small web interface. It lets viewers request and prioritize songs in channel chats.
 
-See the [docs](docs/README.md) for a full project overview and setup instructions.
+See the [docs](docs/README.md) for a full project overview and setup instructions. To get started quickly, copy `example.env` to
+`stack.env`, adjust the values, then run `docker-compose --env-file stack.env up --build`.

--- a/backend_app.py
+++ b/backend_app.py
@@ -18,8 +18,13 @@ from sqlalchemy.orm import declarative_base, relationship, sessionmaker, Session
 # =====================================
 # Config
 # =====================================
-DB_URL = os.getenv("DB_URL", "sqlite:///./db.sqlite")
-ADMIN_TOKEN = os.getenv("ADMIN_TOKEN", "defaultpw")
+# SQLite database lives in the container's /data directory; the path is
+# fixed so the stack does not require an environment variable for it.
+DB_URL = "sqlite:////data/db.sqlite"
+
+# Authentication token for admin endpoints; can still be overridden via
+# environment variable when the backend starts.
+ADMIN_TOKEN = os.getenv("ADMIN_TOKEN", "change-me")
 
 engine = create_engine(DB_URL, connect_args={"check_same_thread": False} if DB_URL.startswith("sqlite") else {})
 SessionLocal = sessionmaker(bind=engine, autoflush=False, autocommit=False)

--- a/bot/bot_app.py
+++ b/bot/bot_app.py
@@ -8,9 +8,10 @@ import aiohttp
 from twitchio.ext import commands
 
 # ---- Env ----
-API_PORT = os.getenv('API_PORT', '8000')
-BACKEND_URL = os.getenv('BACKEND_BASE_URL', f'http://api:{API_PORT}')
-ADMIN_TOKEN = os.getenv('BACKEND_ADMIN_TOKEN', 'change-me')
+# Full URL of the backend API, defaulting to the docker-compose service name.
+BACKEND_URL = os.getenv('BACKEND_URL', 'http://api:7070')
+# Token used for privileged requests to the backend.
+ADMIN_TOKEN = os.getenv('ADMIN_TOKEN', 'change-me')
 CHANNELS = [c.strip() for c in os.getenv('CHANNELS', '').split(',') if c.strip()]
 BOT_TOKEN = os.getenv('TWITCH_BOT_TOKEN')  # token without 'oauth:'
 BOT_NICK = os.getenv('BOT_NICK')

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,13 +4,11 @@ services:
     container_name: twitch-q-backend
     environment:
       - ADMIN_TOKEN=${ADMIN_TOKEN}
-      - DB_URL=sqlite:////data/db.sqlite
       - RESET_DB="0"
-      - API_PORT=${API_PORT:-7070}
     env_file:
       - stack.env
     ports:
-      - "${API_PORT:-7070}:${API_PORT:-7070}"
+      - "7070:7070"
     volumes:
       - ./data:/data
   bot:
@@ -18,8 +16,8 @@ services:
       context: .
       dockerfile: bot/Dockerfile
     environment:
-      BACKEND_BASE_URL: http://api:${API_PORT:-7070}
-      BACKEND_ADMIN_TOKEN: ${ADMIN_TOKEN}
+      BACKEND_URL: ${BACKEND_URL:-http://api:7070}
+      ADMIN_TOKEN: ${ADMIN_TOKEN}
       TWITCH_BOT_TOKEN: ${TWITCH_OAUTH_TOKEN}
       BOT_NICK: ${BOT_NICK}
       CHANNELS: ${TWITCH_CHANNELS}         # comma-separated
@@ -39,6 +37,8 @@ services:
       context: .
       dockerfile: web/Dockerfile
     container_name: songqueue-web
+    environment:
+      BACKEND_URL: ${BACKEND_URL:-http://api:7070}
     env_file:
       - stack.env
     ports:

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,15 +14,19 @@ Additional directories include:
 - **data/** – persistent SQLite database storage.
 
 ## Running with Docker
-1. Set environment variables such as `ADMIN_TOKEN`, `TWITCH_OAUTH_TOKEN`, `BOT_NICK`, and `TWITCH_CHANNELS`.
+1. Copy `example.env` to `stack.env` and adjust values such as `ADMIN_TOKEN`,
+   `TWITCH_OAUTH_TOKEN`, `BOT_NICK`, and `TWITCH_CHANNELS`. When exposing the
+   stack outside of Docker, set `BACKEND_URL` to the public URL of the API so
+   the bot and web UI can reach it.
 2. Start the stack:
    ```bash
-   docker-compose up --build
+   docker-compose --env-file stack.env up --build
    ```
-   This launches the API on port 8000 (set with `API_PORT`), the bot, and the web UI on port 8080 (set with `WEB_PORT`).
+   This launches the API on port 7070, the bot, and the web UI on port 7000
+   (overridden with `WEB_PORT`).
 
 ## Backend Highlights
-- Uses SQLite by default (`DB_URL` configurable) and defines models for channels, songs, users, stream sessions, and requests.
+- Uses a SQLite database stored at `/data/db.sqlite` and defines models for channels, songs, users, stream sessions, and requests.
 - Exposes REST endpoints for managing songs and queue entries, plus an SSE stream for real‑time events.
 - `run.sh` initializes the database and starts the server with Uvicorn.
 

--- a/example.env
+++ b/example.env
@@ -1,0 +1,17 @@
+# Example environment configuration for the Songbot stack.
+# Copy this file to 'stack.env' and adjust the values before starting
+# the services.
+
+# Shared secret for privileged backend endpoints
+ADMIN_TOKEN=change-me
+
+# URL reachable by the bot and web UI to access the backend API
+BACKEND_URL=http://api:7070
+
+# Twitch bot credentials
+TWITCH_OAUTH_TOKEN=your_twitch_oauth_token
+BOT_NICK=your_bot_nick
+TWITCH_CHANNELS=channel1,channel2
+
+# Port for exposing the web interface (optional)
+WEB_PORT=7000

--- a/run.sh
+++ b/run.sh
@@ -2,8 +2,6 @@
 set -euo pipefail
 export ADMIN_TOKEN=${ADMIN_TOKEN:-change-me}
 
-set -e
-
 # one-shot reset when you want a fresh DB
 if [ "${RESET_DB:-0}" = "1" ]; then
   rm -f /data/db.sqlite
@@ -11,11 +9,9 @@ fi
 
 # create tables if missing
 python - <<'PY'
-import os
-os.environ.setdefault("DB_URL", os.getenv("DB_URL","sqlite:////data/db.sqlite"))
 import backend_app
 backend_app.Base.metadata.create_all(bind=backend_app.engine)
-print("DB ready at", os.getenv("DB_URL"))
+print("DB ready at", backend_app.DB_URL)
 PY
 
-uvicorn backend_app:app --host 0.0.0.0 --port "${API_PORT:-8000}"
+uvicorn backend_app:app --host 0.0.0.0 --port 7070

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -1,3 +1,12 @@
 FROM nginx:alpine
+
+# `envsubst` (from gettext) is used to inject environment variables into the
+# static configuration served by nginx.
+RUN apk add --no-cache gettext
+
 COPY web/nginx.conf /etc/nginx/conf.d/default.conf
 COPY web/public/ /usr/share/nginx/html/
+COPY web/entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/web/entrypoint.sh
+++ b/web/entrypoint.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+set -e
+: "${BACKEND_URL:=http://api:7070}"
+# Substitute environment variable into config.js
+envsubst '${BACKEND_URL}' < /usr/share/nginx/html/config.js.template > /usr/share/nginx/html/config.js
+exec nginx -g 'daemon off;'

--- a/web/public/app.js
+++ b/web/public/app.js
@@ -1,6 +1,8 @@
-// Config via query string: ?backend=http://localhost:8000&channel=1
+// Configuration is primarily driven by environment variables exposed via
+// `config.js`. Query parameters still allow overrides for debugging:
+// ?backend=http://localhost:7070&channel=1
 const qs = new URLSearchParams(location.search);
-const BACKEND = (qs.get('backend') || 'http://localhost:8000').replace(/\/$/, '');
+const BACKEND = (qs.get('backend') || window.BACKEND_URL || 'http://localhost:7070').replace(/\/$/, '');
 const CHANNEL = qs.get('channel') || '1';
 
 const el = (sel) => document.querySelector(sel);

--- a/web/public/config.js.template
+++ b/web/public/config.js.template
@@ -1,0 +1,1 @@
+window.BACKEND_URL = "${BACKEND_URL}";

--- a/web/public/index.html
+++ b/web/public/index.html
@@ -54,6 +54,7 @@
   </div>
 </div>
 
+<script src="config.js"></script>
 <script src="app.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Hardcode SQLite database location and drop DB_URL
- Use BACKEND_URL/ADMIN_TOKEN across services and fix docker-compose
- Serve web UI with env-injected backend URL
- Expose API on 7070 and web UI on 7000 by default
- Add example environment file and document stack env usage

## Testing
- `python -m py_compile backend_app.py bot/bot_app.py`
- `bash -n run.sh`
- `sh -n web/entrypoint.sh`


------
https://chatgpt.com/codex/tasks/task_e_68c55615a8988328b4c31a0ed1f728c3