### PR TITLE
Use channel names in API paths

### DIFF
--- a/docs/backend_api.md
+++ b/docs/backend_api.md
@@ -12,51 +12,51 @@ This document summarizes the REST endpoints exposed by `backend_app.py`.
 |--------|------|-------------|
 | GET | `/channels` | List all configured channels. |
 | POST | `/channels` | Add a new channel (requires admin token). |
-| PUT | `/channels/{channel_pk}` | Update whether the bot should join a channel (admin). |
-| GET | `/channels/{channel_pk}/settings` | Retrieve channel configuration. |
-| PUT | `/channels/{channel_pk}/settings` | Update channel configuration (admin). |
+| PUT | `/channels/{channel}` | Update whether the bot should join a channel (admin). |
+| GET | `/channels/{channel}/settings` | Retrieve channel configuration. |
+| PUT | `/channels/{channel}/settings` | Update channel configuration (admin). |
 
 ## Songs
 | Method | Path | Description |
 |--------|------|-------------|
-| GET | `/channels/{channel_pk}/songs` | Search songs in a channel, optionally filtering by artist or title. |
-| POST | `/channels/{channel_pk}/songs` | Add a song to the catalog (admin). |
-| GET | `/channels/{channel_pk}/songs/{song_id}` | Fetch a specific song. |
-| PUT | `/channels/{channel_pk}/songs/{song_id}` | Update song details (admin). |
-| DELETE | `/channels/{channel_pk}/songs/{song_id}` | Remove a song from the catalog (admin). |
+| GET | `/channels/{channel}/songs` | Search songs in a channel, optionally filtering by artist or title. |
+| POST | `/channels/{channel}/songs` | Add a song to the catalog (admin). |
+| GET | `/channels/{channel}/songs/{song_id}` | Fetch a specific song. |
+| PUT | `/channels/{channel}/songs/{song_id}` | Update song details (admin). |
+| DELETE | `/channels/{channel}/songs/{song_id}` | Remove a song from the catalog (admin). |
 
 ## Users
 | Method | Path | Description |
 |--------|------|-------------|
-| GET | `/channels/{channel_pk}/users` | Search or list users in a channel. Providing an admin token returns the full list. |
-| POST | `/channels/{channel_pk}/users` | Create or update a user record (admin). |
-| GET | `/channels/{channel_pk}/users/{user_id}` | Retrieve user details. |
-| PUT | `/channels/{channel_pk}/users/{user_id}` | Update user statistics such as priority points (admin). |
-| GET | `/channels/{channel_pk}/users/{user_id}/stream_state` | Get per-stream state like free subscriber priority usage. |
-| PUT | `/channels/{channel_pk}/users/{user_id}/points` | Set a user's priority points directly (admin). |
+| GET | `/channels/{channel}/users` | Search or list users in a channel. Providing an admin token returns the full list. |
+| POST | `/channels/{channel}/users` | Create or update a user record (admin). |
+| GET | `/channels/{channel}/users/{user_id}` | Retrieve user details. |
+| PUT | `/channels/{channel}/users/{user_id}` | Update user statistics such as priority points (admin). |
+| GET | `/channels/{channel}/users/{user_id}/stream_state` | Get per-stream state like free subscriber priority usage. |
+| PUT | `/channels/{channel}/users/{user_id}/points` | Set a user's priority points directly (admin). |
 
 ## Queue
 | Method | Path | Description |
 |--------|------|-------------|
-| GET | `/channels/{channel_pk}/queue/stream` | Server-sent events stream emitting queue updates. |
-| GET | `/channels/{channel_pk}/queue` | Current request queue for the active stream. |
-| GET | `/channels/{channel_pk}/streams/{stream_id}/queue` | Request queue for a specific past stream. |
-| POST | `/channels/{channel_pk}/queue` | Add a song request to the queue (admin or bot). |
-| PUT | `/channels/{channel_pk}/queue/{request_id}` | Update request status such as marking played (admin). |
-| DELETE | `/channels/{channel_pk}/queue/{request_id}` | Remove a request (admin). |
-| POST | `/channels/{channel_pk}/queue/clear` | Remove all pending requests for the current stream (admin). |
-| GET | `/channels/{channel_pk}/queue/random_nonpriority` | Fetch a random non-priority request from the queue. |
-| POST | `/channels/{channel_pk}/queue/{request_id}/bump_admin` | Force a request to priority status (admin). |
-| POST | `/channels/{channel_pk}/queue/{request_id}/move` | Move a request up or down in the queue (admin). |
-| POST | `/channels/{channel_pk}/queue/{request_id}/skip` | Send a request to the end of the queue (admin). |
-| POST | `/channels/{channel_pk}/queue/{request_id}/priority` | Enable or disable priority for a request (admin). |
-| POST | `/channels/{channel_pk}/queue/{request_id}/played` | Mark a request as played (admin). |
+| GET | `/channels/{channel}/queue/stream` | Server-sent events stream emitting queue updates. |
+| GET | `/channels/{channel}/queue` | Current request queue for the active stream. |
+| GET | `/channels/{channel}/streams/{stream_id}/queue` | Request queue for a specific past stream. |
+| POST | `/channels/{channel}/queue` | Add a song request to the queue (admin or bot). |
+| PUT | `/channels/{channel}/queue/{request_id}` | Update request status such as marking played (admin). |
+| DELETE | `/channels/{channel}/queue/{request_id}` | Remove a request (admin). |
+| POST | `/channels/{channel}/queue/clear` | Remove all pending requests for the current stream (admin). |
+| GET | `/channels/{channel}/queue/random_nonpriority` | Fetch a random non-priority request from the queue. |
+| POST | `/channels/{channel}/queue/{request_id}/bump_admin` | Force a request to priority status (admin). |
+| POST | `/channels/{channel}/queue/{request_id}/move` | Move a request up or down in the queue (admin). |
+| POST | `/channels/{channel}/queue/{request_id}/skip` | Send a request to the end of the queue (admin). |
+| POST | `/channels/{channel}/queue/{request_id}/priority` | Enable or disable priority for a request (admin). |
+| POST | `/channels/{channel}/queue/{request_id}/played` | Mark a request as played (admin). |
 
 ## Events
 | Method | Path | Description |
 |--------|------|-------------|
-| POST | `/channels/{channel_pk}/events` | Log a channel event such as follows, subscriptions, or bits (admin). |
-| GET | `/channels/{channel_pk}/events` | Retrieve logged events with optional filtering by type and time. |
+| POST | `/channels/{channel}/events` | Log a channel event such as follows, subscriptions, or bits (admin). |
+| GET | `/channels/{channel}/events` | Retrieve logged events with optional filtering by type and time. |
 
 Certain events award priority points:
 
@@ -66,14 +66,14 @@ Certain events award priority points:
 ## Streams
 | Method | Path | Description |
 |--------|------|-------------|
-| GET | `/channels/{channel_pk}/streams` | List stream sessions for a channel. |
-| POST | `/channels/{channel_pk}/streams/start` | Ensure a stream session exists and return its ID (admin). |
-| POST | `/channels/{channel_pk}/streams/archive` | Close the current stream and start a new session (admin). |
+| GET | `/channels/{channel}/streams` | List stream sessions for a channel. |
+| POST | `/channels/{channel}/streams/start` | Ensure a stream session exists and return its ID (admin). |
+| POST | `/channels/{channel}/streams/archive` | Close the current stream and start a new session (admin). |
 
 ## Stats
 | Method | Path | Description |
 |--------|------|-------------|
-| GET | `/channels/{channel_pk}/stats/general` | General statistics for the current stream such as total requests. |
-| GET | `/channels/{channel_pk}/stats/songs` | Top requested songs for the current stream. |
-| GET | `/channels/{channel_pk}/stats/users` | Top requesting users for the current stream. |
+| GET | `/channels/{channel}/stats/general` | General statistics for the current stream such as total requests. |
+| GET | `/channels/{channel}/stats/songs` | Top requested songs for the current stream. |
+| GET | `/channels/{channel}/stats/users` | Top requesting users for the current stream. |
 

--- a/web/public/app.js
+++ b/web/public/app.js
@@ -1,9 +1,9 @@
 // Configuration is primarily driven by environment variables exposed via
 // `config.js`. Query parameters still allow overrides for debugging:
-// ?backend=http://localhost:7070&channel=1
+// ?backend=http://localhost:7070&channel=example_channel
 const qs = new URLSearchParams(location.search);
 const BACKEND = (qs.get('backend') || window.BACKEND_URL || 'http://localhost:7070').replace(/\/$/, '');
-const CHANNEL = qs.get('channel') || '1';
+const CHANNEL = qs.get('channel') || 'example_channel';
 
 const el = (sel) => document.querySelector(sel);
 const queueEl   = el('#queue');


### PR DESCRIPTION
## Summary
- Switch backend endpoints to accept channel names instead of numeric IDs
- Update bot and web UI to send channel names in API requests
- Refresh API documentation to reference channel names

## Testing
- `python -m py_compile backend_app.py bot/bot_app.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c682150d988328bd50ab837000507e