### PR TITLE
Use channel names in API paths

### DIFF
--- a/backend_app.py
+++ b/backend_app.py
@@ -272,6 +272,17 @@ def require_token(x_admin_token: str = Header(None)):
     if x_admin_token != ADMIN_TOKEN:
         raise HTTPException(status_code=401, detail="invalid admin token")
 
+def get_channel_pk(channel: str, db: Session) -> int:
+    """Return the primary key for a channel, matching name case-insensitively."""
+    ch = (
+        db.query(ActiveChannel)
+        .filter(func.lower(ActiveChannel.channel_name) == channel.lower())
+        .one_or_none()
+    )
+    if not ch:
+        raise HTTPException(status_code=404, detail="channel not found")
+    return ch.id
+
 # =====================================
 # Helpers / Services
 # =====================================
@@ -380,17 +391,21 @@ def list_channels(db: Session = Depends(get_db)):
 
 @app.post("/channels", response_model=ChannelOut, dependencies=[Depends(require_token)])
 def add_channel(payload: ChannelIn, db: Session = Depends(get_db)):
-    ch = ActiveChannel(channel_id=payload.channel_id, channel_name=payload.channel_name, join_active=payload.join_active)
+    name = payload.channel_name.lower()
+    ch = ActiveChannel(channel_id=payload.channel_id, channel_name=name, join_active=payload.join_active)
     db.add(ch)
     db.commit()
     db.refresh(ch)
     get_or_create_settings(db, ch.id)
-    try: _broker(channel_pk).put_nowait("changed")
-    except: pass
+    try:
+        _broker(ch.id).put_nowait("changed")
+    except:  # pragma: no cover - broker queue is best effort
+        pass
     return ch
 
-@app.put("/channels/{channel_pk}", dependencies=[Depends(require_token)])
-def update_channel_status(channel_pk: int, join_active: int, db: Session = Depends(get_db)):
+@app.put("/channels/{channel}", dependencies=[Depends(require_token)])
+def update_channel_status(channel: str, join_active: int, db: Session = Depends(get_db)):
+    channel_pk = get_channel_pk(channel, db)
     ch = db.get(ActiveChannel, channel_pk)
     if not ch:
         raise HTTPException(404, "channel not found")
@@ -400,8 +415,9 @@ def update_channel_status(channel_pk: int, join_active: int, db: Session = Depen
     except: pass
     return {"success": True}
 
-@app.get("/channels/{channel_pk}/settings", response_model=ChannelSettingsOut)
-def get_channel_settings(channel_pk: int, db: Session = Depends(get_db)):
+@app.get("/channels/{channel}/settings", response_model=ChannelSettingsOut)
+def get_channel_settings(channel: str, db: Session = Depends(get_db)):
+    channel_pk = get_channel_pk(channel, db)
     st = get_or_create_settings(db, channel_pk)
     return ChannelSettingsOut(
         channel_id=st.channel_id,
@@ -413,8 +429,9 @@ def get_channel_settings(channel_pk: int, db: Session = Depends(get_db)):
         max_prio_points=st.max_prio_points,
     )
 
-@app.put("/channels/{channel_pk}/settings", dependencies=[Depends(require_token)])
-def set_channel_settings(channel_pk: int, payload: ChannelSettingsIn, db: Session = Depends(get_db)):
+@app.put("/channels/{channel}/settings", dependencies=[Depends(require_token)])
+def set_channel_settings(channel: str, payload: ChannelSettingsIn, db: Session = Depends(get_db)):
+    channel_pk = get_channel_pk(channel, db)
     st = get_or_create_settings(db, channel_pk)
     st.max_requests_per_user = payload.max_requests_per_user
     st.prio_only = payload.prio_only
@@ -430,16 +447,18 @@ def set_channel_settings(channel_pk: int, payload: ChannelSettingsIn, db: Sessio
 # =====================================
 # Routes: Songs
 # =====================================
-@app.get("/channels/{channel_pk}/songs", response_model=List[SongOut])
-def search_songs(channel_pk: int, search: Optional[str] = Query(None), db: Session = Depends(get_db)):
+@app.get("/channels/{channel}/songs", response_model=List[SongOut])
+def search_songs(channel: str, search: Optional[str] = Query(None), db: Session = Depends(get_db)):
+    channel_pk = get_channel_pk(channel, db)
     q = db.query(Song).filter(Song.channel_id == channel_pk)
     if search:
         like = f"%{search}%"
         q = q.filter((Song.artist.ilike(like)) | (Song.title.ilike(like)))
     return q.order_by(Song.artist.asc(), Song.title.asc()).all()
 
-@app.post("/channels/{channel_pk}/songs", response_model=dict, dependencies=[Depends(require_token)])
-def add_song(channel_pk: int, payload: SongIn, db: Session = Depends(get_db)):
+@app.post("/channels/{channel}/songs", response_model=dict, dependencies=[Depends(require_token)])
+def add_song(channel: str, payload: SongIn, db: Session = Depends(get_db)):
+    channel_pk = get_channel_pk(channel, db)
     song = Song(channel_id=channel_pk, **payload.model_dump())
     db.add(song)
     db.commit()
@@ -447,15 +466,17 @@ def add_song(channel_pk: int, payload: SongIn, db: Session = Depends(get_db)):
     except: pass
     return {"id": song.id}
 
-@app.get("/channels/{channel_pk}/songs/{song_id}", response_model=SongOut)
-def get_song(channel_pk: int, song_id: int, db: Session = Depends(get_db)):
+@app.get("/channels/{channel}/songs/{song_id}", response_model=SongOut)
+def get_song(channel: str, song_id: int, db: Session = Depends(get_db)):
+    channel_pk = get_channel_pk(channel, db)
     song = db.query(Song).filter(Song.id == song_id, Song.channel_id == channel_pk).one_or_none()
     if not song:
         raise HTTPException(404, "song not found")
     return song
 
-@app.put("/channels/{channel_pk}/songs/{song_id}", dependencies=[Depends(require_token)])
-def update_song(channel_pk: int, song_id: int, payload: SongIn, db: Session = Depends(get_db)):
+@app.put("/channels/{channel}/songs/{song_id}", dependencies=[Depends(require_token)])
+def update_song(channel: str, song_id: int, payload: SongIn, db: Session = Depends(get_db)):
+    channel_pk = get_channel_pk(channel, db)
     song = db.query(Song).filter(Song.id == song_id, Song.channel_id == channel_pk).one_or_none()
     if not song:
         raise HTTPException(404, "song not found")
@@ -466,8 +487,9 @@ def update_song(channel_pk: int, song_id: int, payload: SongIn, db: Session = De
     except: pass
     return {"success": True}
 
-@app.delete("/channels/{channel_pk}/songs/{song_id}", dependencies=[Depends(require_token)])
-def delete_song(channel_pk: int, song_id: int, db: Session = Depends(get_db)):
+@app.delete("/channels/{channel}/songs/{song_id}", dependencies=[Depends(require_token)])
+def delete_song(channel: str, song_id: int, db: Session = Depends(get_db)):
+    channel_pk = get_channel_pk(channel, db)
     song = db.query(Song).filter(Song.id == song_id, Song.channel_id == channel_pk).one_or_none()
     if not song:
         raise HTTPException(404, "song not found")
@@ -480,16 +502,18 @@ def delete_song(channel_pk: int, song_id: int, db: Session = Depends(get_db)):
 # =====================================
 # Routes: Users
 # =====================================
-@app.get("/channels/{channel_pk}/users", response_model=List[UserOut])
-def search_users(channel_pk: int, search: Optional[str] = Query(None), db: Session = Depends(get_db)):
+@app.get("/channels/{channel}/users", response_model=List[UserOut])
+def search_users(channel: str, search: Optional[str] = Query(None), db: Session = Depends(get_db)):
+    channel_pk = get_channel_pk(channel, db)
     q = db.query(User).filter(User.channel_id == channel_pk)
     if search:
         like = f"%{search}%"
         q = q.filter(User.username.ilike(like))
     return q.order_by(User.username.asc()).all()
 
-@app.post("/channels/{channel_pk}/users", response_model=dict, dependencies=[Depends(require_token)])
-def get_or_create_user(channel_pk: int, payload: UserIn, db: Session = Depends(get_db)):
+@app.post("/channels/{channel}/users", response_model=dict, dependencies=[Depends(require_token)])
+def get_or_create_user(channel: str, payload: UserIn, db: Session = Depends(get_db)):
+    channel_pk = get_channel_pk(channel, db)
     u = (
         db.query(User)
         .filter(User.channel_id == channel_pk, User.twitch_id == payload.twitch_id)
@@ -508,15 +532,17 @@ def get_or_create_user(channel_pk: int, payload: UserIn, db: Session = Depends(g
     except: pass
     return {"id": u.id}
 
-@app.get("/channels/{channel_pk}/users/{user_id}", response_model=UserOut)
-def get_user(channel_pk: int, user_id: int, db: Session = Depends(get_db)):
+@app.get("/channels/{channel}/users/{user_id}", response_model=UserOut)
+def get_user(channel: str, user_id: int, db: Session = Depends(get_db)):
+    channel_pk = get_channel_pk(channel, db)
     u = db.query(User).filter(User.id == user_id, User.channel_id == channel_pk).one_or_none()
     if not u:
         raise HTTPException(404, "user not found")
     return u
 
-@app.put("/channels/{channel_pk}/users/{user_id}", dependencies=[Depends(require_token)])
-def update_user(channel_pk: int, user_id: int, prio_points: Optional[int] = None, amount_requested: Optional[int] = None, db: Session = Depends(get_db)):
+@app.put("/channels/{channel}/users/{user_id}", dependencies=[Depends(require_token)])
+def update_user(channel: str, user_id: int, prio_points: Optional[int] = None, amount_requested: Optional[int] = None, db: Session = Depends(get_db)):
+    channel_pk = get_channel_pk(channel, db)
     u = db.query(User).filter(User.id == user_id, User.channel_id == channel_pk).one_or_none()
     if not u:
         raise HTTPException(404, "user not found")
@@ -530,8 +556,9 @@ def update_user(channel_pk: int, user_id: int, prio_points: Optional[int] = None
     except: pass
     return {"success": True}
 
-@app.get("/channels/{channel_pk}/users/{user_id}/stream_state")
-def get_user_stream_state(channel_pk: int, user_id: int, db: Session = Depends(get_db)):
+@app.get("/channels/{channel}/users/{user_id}/stream_state")
+def get_user_stream_state(channel: str, user_id: int, db: Session = Depends(get_db)):
+    channel_pk = get_channel_pk(channel, db)
     sid = current_stream(db, channel_pk)
     ensure_user_stream_state(db, user_id, sid)
     st = (
@@ -541,12 +568,14 @@ def get_user_stream_state(channel_pk: int, user_id: int, db: Session = Depends(g
     )
     return {"stream_id": sid, "sub_free_used": int(st.sub_free_used)}
 
-@app.get("/channels/{channel_pk}/users", dependencies=[Depends(require_token)])
-def list_users(channel_pk: int, db: Session = Depends(get_db)):
+@app.get("/channels/{channel}/users", dependencies=[Depends(require_token)])
+def list_users(channel: str, db: Session = Depends(get_db)):
+    channel_pk = get_channel_pk(channel, db)
     return db.query(User).filter(User.channel_id==channel_pk).all()
 
-@app.put("/channels/{channel_pk}/users/{user_id}/points", dependencies=[Depends(require_token)])
-def set_points(channel_pk: int, user_id: int, payload: dict, db: Session = Depends(get_db)):
+@app.put("/channels/{channel}/users/{user_id}/points", dependencies=[Depends(require_token)])
+def set_points(channel: str, user_id: int, payload: dict, db: Session = Depends(get_db)):
+    channel_pk = get_channel_pk(channel, db)
     u = db.get(User, user_id)
     if not u or u.channel_id != channel_pk: raise HTTPException(404)
     u.prio_points = int(payload.get("prio_points", 0))
@@ -558,8 +587,9 @@ def set_points(channel_pk: int, user_id: int, payload: dict, db: Session = Depen
 # =====================================
 # Routes: Queue
 # =====================================
-@app.get("/channels/{channel_pk}/queue/stream")
-async def stream_queue(channel_pk: int):
+@app.get("/channels/{channel}/queue/stream")
+async def stream_queue(channel: str, db: Session = Depends(get_db)):
+    channel_pk = get_channel_pk(channel, db)
     q = _broker(channel_pk)
     async def gen():
         # initial tick so clients render immediately
@@ -575,8 +605,9 @@ async def stream_queue(channel_pk: int):
     }
 )
 
-@app.get("/channels/{channel_pk}/queue", response_model=List[RequestOut])
-def get_queue(channel_pk: int, db: Session = Depends(get_db)):
+@app.get("/channels/{channel}/queue", response_model=List[RequestOut])
+def get_queue(channel: str, db: Session = Depends(get_db)):
+    channel_pk = get_channel_pk(channel, db)
     sid = current_stream(db, channel_pk)
     return (
         db.query(Request)
@@ -594,8 +625,9 @@ def get_queue(channel_pk: int, db: Session = Depends(get_db)):
         .all()
     )
 
-@app.get("/channels/{channel_pk}/streams/{stream_id}/queue", response_model=List[RequestOut])
-def get_stream_queue(channel_pk: int, stream_id: int, db: Session = Depends(get_db)):
+@app.get("/channels/{channel}/streams/{stream_id}/queue", response_model=List[RequestOut])
+def get_stream_queue(channel: str, stream_id: int, db: Session = Depends(get_db)):
+    channel_pk = get_channel_pk(channel, db)
     return (
         db.query(Request)
         .filter(Request.channel_id == channel_pk, Request.stream_id == stream_id)
@@ -609,8 +641,9 @@ def get_stream_queue(channel_pk: int, stream_id: int, db: Session = Depends(get_
         .all()
     )
 
-@app.post("/channels/{channel_pk}/queue", response_model=dict, dependencies=[Depends(require_token)])
-def add_request(channel_pk: int, payload: RequestCreate, db: Session = Depends(get_db)):
+@app.post("/channels/{channel}/queue", response_model=dict, dependencies=[Depends(require_token)])
+def add_request(channel: str, payload: RequestCreate, db: Session = Depends(get_db)):
+    channel_pk = get_channel_pk(channel, db)
     # Checks
     enforce_queue_limits(db, channel_pk, payload.user_id, payload.want_priority)
     sid = current_stream(db, channel_pk)
@@ -681,8 +714,9 @@ def add_request(channel_pk: int, payload: RequestCreate, db: Session = Depends(g
         pass
     return {"request_id": req.id}
 
-@app.put("/channels/{channel_pk}/queue/{request_id}", dependencies=[Depends(require_token)])
-def update_request(channel_pk: int, request_id: int, payload: RequestUpdate, db: Session = Depends(get_db)):
+@app.put("/channels/{channel}/queue/{request_id}", dependencies=[Depends(require_token)])
+def update_request(channel: str, request_id: int, payload: RequestUpdate, db: Session = Depends(get_db)):
+    channel_pk = get_channel_pk(channel, db)
     r = db.query(Request).filter(Request.id == request_id, Request.channel_id == channel_pk).one_or_none()
     if not r:
         raise HTTPException(404, "request not found")
@@ -710,8 +744,9 @@ def update_request(channel_pk: int, request_id: int, payload: RequestUpdate, db:
         pass
     return {"success": True}
 
-@app.delete("/channels/{channel_pk}/queue/{request_id}", dependencies=[Depends(require_token)])
-def remove_request(channel_pk: int, request_id: int, db: Session = Depends(get_db)):
+@app.delete("/channels/{channel}/queue/{request_id}", dependencies=[Depends(require_token)])
+def remove_request(channel: str, request_id: int, db: Session = Depends(get_db)):
+    channel_pk = get_channel_pk(channel, db)
     r = db.query(Request).filter(Request.id == request_id, Request.channel_id == channel_pk).one_or_none()
     if not r:
         raise HTTPException(404, "request not found")
@@ -723,8 +758,9 @@ def remove_request(channel_pk: int, request_id: int, db: Session = Depends(get_d
         pass
     return {"success": True}
 
-@app.post("/channels/{channel_pk}/queue/clear", dependencies=[Depends(require_token)])
-def clear_queue(channel_pk: int, db: Session = Depends(get_db)):
+@app.post("/channels/{channel}/queue/clear", dependencies=[Depends(require_token)])
+def clear_queue(channel: str, db: Session = Depends(get_db)):
+    channel_pk = get_channel_pk(channel, db)
     sid = current_stream(db, channel_pk)
     db.query(Request).filter(Request.channel_id == channel_pk, Request.stream_id == sid, Request.played == 0).delete()
     db.commit()
@@ -734,8 +770,9 @@ def clear_queue(channel_pk: int, db: Session = Depends(get_db)):
         pass
     return {"success": True}
 
-@app.get("/channels/{channel_pk}/queue/random_nonpriority")
-def random_nonpriority(channel_pk: int, db: Session = Depends(get_db)):
+@app.get("/channels/{channel}/queue/random_nonpriority")
+def random_nonpriority(channel: str, db: Session = Depends(get_db)):
+    channel_pk = get_channel_pk(channel, db)
     sid = current_stream(db, channel_pk)
     row = (
         db.query(Request, Song, User)
@@ -757,8 +794,9 @@ def random_nonpriority(channel_pk: int, db: Session = Depends(get_db)):
         "user": {"id": u.id, "username": u.username}
     }
 
-@app.post("/channels/{channel_pk}/queue/{request_id}/bump_admin", dependencies=[Depends(require_token)])
-def bump_admin(channel_pk: int, request_id: int, db: Session = Depends(get_db)):
+@app.post("/channels/{channel}/queue/{request_id}/bump_admin", dependencies=[Depends(require_token)])
+def bump_admin(channel: str, request_id: int, db: Session = Depends(get_db)):
+    channel_pk = get_channel_pk(channel, db)
     r = db.query(Request).filter(Request.id == request_id, Request.channel_id == channel_pk).one_or_none()
     if not r:
         raise HTTPException(404, "request not found")
@@ -780,8 +818,9 @@ def _get_req(db, channel_pk: int, request_id: int):
         raise HTTPException(status_code=404, detail="request not found")
     return req
 
-@app.post("/channels/{channel_pk}/queue/{request_id}/move", dependencies=[Depends(require_token)])
-def move_request(channel_pk: int, request_id: int, direction: str, db: Session = Depends(get_db)):
+@app.post("/channels/{channel}/queue/{request_id}/move", dependencies=[Depends(require_token)])
+def move_request(channel: str, request_id: int, direction: str, db: Session = Depends(get_db)):
+    channel_pk = get_channel_pk(channel, db)
     if direction not in ("up", "down"):
         raise HTTPException(400, "direction must be 'up' or 'down'")
     req = _get_req(db, channel_pk, request_id)
@@ -812,8 +851,9 @@ def move_request(channel_pk: int, request_id: int, direction: str, db: Session =
     except: pass
     return {"success": True}
 
-@app.post("/channels/{channel_pk}/queue/{request_id}/skip", dependencies=[Depends(require_token)])
-def skip_request(channel_pk: int, request_id: int, db: Session = Depends(get_db)):
+@app.post("/channels/{channel}/queue/{request_id}/skip", dependencies=[Depends(require_token)])
+def skip_request(channel: str, request_id: int, db: Session = Depends(get_db)):
+    channel_pk = get_channel_pk(channel, db)
     req = _get_req(db, channel_pk, request_id)
     # move to bottom of pending
     max_pos = db.execute(
@@ -826,8 +866,9 @@ def skip_request(channel_pk: int, request_id: int, db: Session = Depends(get_db)
     except: pass
     return {"success": True}
 
-@app.post("/channels/{channel_pk}/queue/{request_id}/priority", dependencies=[Depends(require_token)])
-def set_priority(channel_pk: int, request_id: int, enabled: bool, db: Session = Depends(get_db)):
+@app.post("/channels/{channel}/queue/{request_id}/priority", dependencies=[Depends(require_token)])
+def set_priority(channel: str, request_id: int, enabled: bool, db: Session = Depends(get_db)):
+    channel_pk = get_channel_pk(channel, db)
     req = _get_req(db, channel_pk, request_id)
     # optional: refund or spend points can be inserted here
     req.is_priority = 1 if enabled else 0
@@ -836,8 +877,9 @@ def set_priority(channel_pk: int, request_id: int, enabled: bool, db: Session = 
     except: pass
     return {"success": True}
 
-@app.post("/channels/{channel_pk}/queue/{request_id}/played", dependencies=[Depends(require_token)])
-def mark_played(channel_pk: int, request_id: int, db: Session = Depends(get_db)):
+@app.post("/channels/{channel}/queue/{request_id}/played", dependencies=[Depends(require_token)])
+def mark_played(channel: str, request_id: int, db: Session = Depends(get_db)):
+    channel_pk = get_channel_pk(channel, db)
     req = _get_req(db, channel_pk, request_id)
     req.played = 1
     # optionally push it out of visible order by setting a sentinel position
@@ -849,8 +891,9 @@ def mark_played(channel_pk: int, request_id: int, db: Session = Depends(get_db))
 # =====================================
 # Routes: Events
 # =====================================
-@app.post("/channels/{channel_pk}/events", response_model=dict, dependencies=[Depends(require_token)])
-def log_event(channel_pk: int, payload: EventIn, db: Session = Depends(get_db)):
+@app.post("/channels/{channel}/events", response_model=dict, dependencies=[Depends(require_token)])
+def log_event(channel: str, payload: EventIn, db: Session = Depends(get_db)):
+    channel_pk = get_channel_pk(channel, db)
     meta = payload.meta or {}
     meta_str = json.dumps(meta)
     ev = Event(channel_id=channel_pk, event_type=payload.type, user_id=payload.user_id, meta=meta_str)
@@ -878,8 +921,9 @@ def log_event(channel_pk: int, payload: EventIn, db: Session = Depends(get_db)):
     except: pass    
     return {"event_id": ev.id}
 
-@app.get("/channels/{channel_pk}/events", response_model=List[EventOut])
-def list_events(channel_pk: int, type: Optional[str] = None, since: Optional[str] = None, db: Session = Depends(get_db)):
+@app.get("/channels/{channel}/events", response_model=List[EventOut])
+def list_events(channel: str, type: Optional[str] = None, since: Optional[str] = None, db: Session = Depends(get_db)):
+    channel_pk = get_channel_pk(channel, db)
     q = db.query(Event).filter(Event.channel_id == channel_pk)
     if type:
         q = q.filter(Event.event_type == type)
@@ -894,8 +938,9 @@ def list_events(channel_pk: int, type: Optional[str] = None, since: Optional[str
 # =====================================
 # Routes: Streams
 # =====================================
-@app.get("/channels/{channel_pk}/streams", response_model=List[StreamOut])
-def list_streams(channel_pk: int, db: Session = Depends(get_db)):
+@app.get("/channels/{channel}/streams", response_model=List[StreamOut])
+def list_streams(channel: str, db: Session = Depends(get_db)):
+    channel_pk = get_channel_pk(channel, db)
     return (
         db.query(StreamSession)
         .filter(StreamSession.channel_id == channel_pk)
@@ -903,13 +948,15 @@ def list_streams(channel_pk: int, db: Session = Depends(get_db)):
         .all()
     )
 
-@app.post("/channels/{channel_pk}/streams/start", response_model=dict, dependencies=[Depends(require_token)])
-def start_stream(channel_pk: int, db: Session = Depends(get_db)):
+@app.post("/channels/{channel}/streams/start", response_model=dict, dependencies=[Depends(require_token)])
+def start_stream(channel: str, db: Session = Depends(get_db)):
+    channel_pk = get_channel_pk(channel, db)
     sid = current_stream(db, channel_pk)
     return {"stream_id": sid}
 
-@app.post("/channels/{channel_pk}/streams/archive", response_model=dict, dependencies=[Depends(require_token)])
-def archive_stream(channel_pk: int, db: Session = Depends(get_db)):
+@app.post("/channels/{channel}/streams/archive", response_model=dict, dependencies=[Depends(require_token)])
+def archive_stream(channel: str, db: Session = Depends(get_db)):
+    channel_pk = get_channel_pk(channel, db)
     # close current
     cur = (
         db.query(StreamSession)
@@ -931,8 +978,9 @@ def archive_stream(channel_pk: int, db: Session = Depends(get_db)):
 # =====================================
 # Routes: Stats
 # =====================================
-@app.get("/channels/{channel_pk}/stats/general")
-def stats_general(channel_pk: int, since: Optional[str] = None, db: Session = Depends(get_db)):
+@app.get("/channels/{channel}/stats/general")
+def stats_general(channel: str, since: Optional[str] = None, db: Session = Depends(get_db)):
+    channel_pk = get_channel_pk(channel, db)
     sid = current_stream(db, channel_pk)
     rq = db.query(Request).filter(Request.channel_id == channel_pk, Request.stream_id == sid)
     if since:
@@ -946,8 +994,9 @@ def stats_general(channel_pk: int, since: Optional[str] = None, db: Session = De
     unique_users = rq.with_entities(Request.user_id).distinct().count()
     return {"total_requests": total_requests, "unique_songs": unique_songs, "unique_users": unique_users}
 
-@app.get("/channels/{channel_pk}/stats/songs")
-def stats_top_songs(channel_pk: int, top: int = 10, since: Optional[str] = None, db: Session = Depends(get_db)):
+@app.get("/channels/{channel}/stats/songs")
+def stats_top_songs(channel: str, top: int = 10, since: Optional[str] = None, db: Session = Depends(get_db)):
+    channel_pk = get_channel_pk(channel, db)
     sid = current_stream(db, channel_pk)
     rq = db.query(Request.song_id, func.count(Request.id).label("cnt")).\
         filter(Request.channel_id == channel_pk, Request.stream_id == sid).group_by(Request.song_id)
@@ -960,8 +1009,9 @@ def stats_top_songs(channel_pk: int, top: int = 10, since: Optional[str] = None,
     rows = rq.order_by(func.count(Request.id).desc()).limit(top).all()
     return [{"song_id": r[0], "count": r[1]} for r in rows]
 
-@app.get("/channels/{channel_pk}/stats/users")
-def stats_top_users(channel_pk: int, top: int = 10, since: Optional[str] = None, db: Session = Depends(get_db)):
+@app.get("/channels/{channel}/stats/users")
+def stats_top_users(channel: str, top: int = 10, since: Optional[str] = None, db: Session = Depends(get_db)):
+    channel_pk = get_channel_pk(channel, db)
     sid = current_stream(db, channel_pk)
     rq = db.query(Request.user_id, func.count(Request.id).label("cnt")).\
         filter(Request.channel_id == channel_pk, Request.stream_id == sid).group_by(Request.user_id)

--- a/docs/backend_api.md
+++ b/docs/backend_api.md
@@ -8,55 +8,57 @@ This document summarizes the REST endpoints exposed by `backend_app.py`.
 | GET | `/system/health` | Health check that verifies database connectivity. |
 
 ## Channels
+Channel names in path parameters are matched case-insensitively.
+
 | Method | Path | Description |
 |--------|------|-------------|
 | GET | `/channels` | List all configured channels. |
 | POST | `/channels` | Add a new channel (requires admin token). |
-| PUT | `/channels/{channel_pk}` | Update whether the bot should join a channel (admin). |
-| GET | `/channels/{channel_pk}/settings` | Retrieve channel configuration. |
-| PUT | `/channels/{channel_pk}/settings` | Update channel configuration (admin). |
+| PUT | `/channels/{channel}` | Update whether the bot should join a channel (admin). |
+| GET | `/channels/{channel}/settings` | Retrieve channel configuration. |
+| PUT | `/channels/{channel}/settings` | Update channel configuration (admin). |
 
 ## Songs
 | Method | Path | Description |
 |--------|------|-------------|
-| GET | `/channels/{channel_pk}/songs` | Search songs in a channel, optionally filtering by artist or title. |
-| POST | `/channels/{channel_pk}/songs` | Add a song to the catalog (admin). |
-| GET | `/channels/{channel_pk}/songs/{song_id}` | Fetch a specific song. |
-| PUT | `/channels/{channel_pk}/songs/{song_id}` | Update song details (admin). |
-| DELETE | `/channels/{channel_pk}/songs/{song_id}` | Remove a song from the catalog (admin). |
+| GET | `/channels/{channel}/songs` | Search songs in a channel, optionally filtering by artist or title. |
+| POST | `/channels/{channel}/songs` | Add a song to the catalog (admin). |
+| GET | `/channels/{channel}/songs/{song_id}` | Fetch a specific song. |
+| PUT | `/channels/{channel}/songs/{song_id}` | Update song details (admin). |
+| DELETE | `/channels/{channel}/songs/{song_id}` | Remove a song from the catalog (admin). |
 
 ## Users
 | Method | Path | Description |
 |--------|------|-------------|
-| GET | `/channels/{channel_pk}/users` | Search or list users in a channel. Providing an admin token returns the full list. |
-| POST | `/channels/{channel_pk}/users` | Create or update a user record (admin). |
-| GET | `/channels/{channel_pk}/users/{user_id}` | Retrieve user details. |
-| PUT | `/channels/{channel_pk}/users/{user_id}` | Update user statistics such as priority points (admin). |
-| GET | `/channels/{channel_pk}/users/{user_id}/stream_state` | Get per-stream state like free subscriber priority usage. |
-| PUT | `/channels/{channel_pk}/users/{user_id}/points` | Set a user's priority points directly (admin). |
+| GET | `/channels/{channel}/users` | Search or list users in a channel. Providing an admin token returns the full list. |
+| POST | `/channels/{channel}/users` | Create or update a user record (admin). |
+| GET | `/channels/{channel}/users/{user_id}` | Retrieve user details. |
+| PUT | `/channels/{channel}/users/{user_id}` | Update user statistics such as priority points (admin). |
+| GET | `/channels/{channel}/users/{user_id}/stream_state` | Get per-stream state like free subscriber priority usage. |
+| PUT | `/channels/{channel}/users/{user_id}/points` | Set a user's priority points directly (admin). |
 
 ## Queue
 | Method | Path | Description |
 |--------|------|-------------|
-| GET | `/channels/{channel_pk}/queue/stream` | Server-sent events stream emitting queue updates. |
-| GET | `/channels/{channel_pk}/queue` | Current request queue for the active stream. |
-| GET | `/channels/{channel_pk}/streams/{stream_id}/queue` | Request queue for a specific past stream. |
-| POST | `/channels/{channel_pk}/queue` | Add a song request to the queue (admin or bot). |
-| PUT | `/channels/{channel_pk}/queue/{request_id}` | Update request status such as marking played (admin). |
-| DELETE | `/channels/{channel_pk}/queue/{request_id}` | Remove a request (admin). |
-| POST | `/channels/{channel_pk}/queue/clear` | Remove all pending requests for the current stream (admin). |
-| GET | `/channels/{channel_pk}/queue/random_nonpriority` | Fetch a random non-priority request from the queue. |
-| POST | `/channels/{channel_pk}/queue/{request_id}/bump_admin` | Force a request to priority status (admin). |
-| POST | `/channels/{channel_pk}/queue/{request_id}/move` | Move a request up or down in the queue (admin). |
-| POST | `/channels/{channel_pk}/queue/{request_id}/skip` | Send a request to the end of the queue (admin). |
-| POST | `/channels/{channel_pk}/queue/{request_id}/priority` | Enable or disable priority for a request (admin). |
-| POST | `/channels/{channel_pk}/queue/{request_id}/played` | Mark a request as played (admin). |
+| GET | `/channels/{channel}/queue/stream` | Server-sent events stream emitting queue updates. |
+| GET | `/channels/{channel}/queue` | Current request queue for the active stream. |
+| GET | `/channels/{channel}/streams/{stream_id}/queue` | Request queue for a specific past stream. |
+| POST | `/channels/{channel}/queue` | Add a song request to the queue (admin or bot). |
+| PUT | `/channels/{channel}/queue/{request_id}` | Update request status such as marking played (admin). |
+| DELETE | `/channels/{channel}/queue/{request_id}` | Remove a request (admin). |
+| POST | `/channels/{channel}/queue/clear` | Remove all pending requests for the current stream (admin). |
+| GET | `/channels/{channel}/queue/random_nonpriority` | Fetch a random non-priority request from the queue. |
+| POST | `/channels/{channel}/queue/{request_id}/bump_admin` | Force a request to priority status (admin). |
+| POST | `/channels/{channel}/queue/{request_id}/move` | Move a request up or down in the queue (admin). |
+| POST | `/channels/{channel}/queue/{request_id}/skip` | Send a request to the end of the queue (admin). |
+| POST | `/channels/{channel}/queue/{request_id}/priority` | Enable or disable priority for a request (admin). |
+| POST | `/channels/{channel}/queue/{request_id}/played` | Mark a request as played (admin). |
 
 ## Events
 | Method | Path | Description |
 |--------|------|-------------|
-| POST | `/channels/{channel_pk}/events` | Log a channel event such as follows, subscriptions, or bits (admin). |
-| GET | `/channels/{channel_pk}/events` | Retrieve logged events with optional filtering by type and time. |
+| POST | `/channels/{channel}/events` | Log a channel event such as follows, subscriptions, or bits (admin). |
+| GET | `/channels/{channel}/events` | Retrieve logged events with optional filtering by type and time. |
 
 Certain events award priority points:
 
@@ -66,14 +68,14 @@ Certain events award priority points:
 ## Streams
 | Method | Path | Description |
 |--------|------|-------------|
-| GET | `/channels/{channel_pk}/streams` | List stream sessions for a channel. |
-| POST | `/channels/{channel_pk}/streams/start` | Ensure a stream session exists and return its ID (admin). |
-| POST | `/channels/{channel_pk}/streams/archive` | Close the current stream and start a new session (admin). |
+| GET | `/channels/{channel}/streams` | List stream sessions for a channel. |
+| POST | `/channels/{channel}/streams/start` | Ensure a stream session exists and return its ID (admin). |
+| POST | `/channels/{channel}/streams/archive` | Close the current stream and start a new session (admin). |
 
 ## Stats
 | Method | Path | Description |
 |--------|------|-------------|
-| GET | `/channels/{channel_pk}/stats/general` | General statistics for the current stream such as total requests. |
-| GET | `/channels/{channel_pk}/stats/songs` | Top requested songs for the current stream. |
-| GET | `/channels/{channel_pk}/stats/users` | Top requesting users for the current stream. |
+| GET | `/channels/{channel}/stats/general` | General statistics for the current stream such as total requests. |
+| GET | `/channels/{channel}/stats/songs` | Top requested songs for the current stream. |
+| GET | `/channels/{channel}/stats/users` | Top requesting users for the current stream. |
 

--- a/web/public/app.js
+++ b/web/public/app.js
@@ -1,9 +1,9 @@
 // Configuration is primarily driven by environment variables exposed via
 // `config.js`. Query parameters still allow overrides for debugging:
-// ?backend=http://localhost:7070&channel=1
+// ?backend=http://localhost:7070&channel=example_channel
 const qs = new URLSearchParams(location.search);
 const BACKEND = (qs.get('backend') || window.BACKEND_URL || 'http://localhost:7070').replace(/\/$/, '');
-const CHANNEL = qs.get('channel') || '1';
+const CHANNEL = (qs.get('channel') || 'example_channel').toLowerCase();
 
 const el = (sel) => document.querySelector(sel);
 const queueEl   = el('#queue');


### PR DESCRIPTION
## Summary
- Make channel lookups case-insensitive by lowercasing comparisons and stored names
- Clarify in docs that channel names are matched case-insensitively
- Normalize channel name query parameter in web client

## Testing
- `python -m py_compile backend_app.py bot/bot_app.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c682150d988328bd50ab837000507e