### PR TITLE
Fix FastAPI Request name clash in EventSub callback

### DIFF
--- a/backend_app.py
+++ b/backend_app.py
@@ -11,7 +11,16 @@ import requests
 from sse_starlette.sse import EventSourceResponse
 from fastapi.middleware.cors import CORSMiddleware
 
-from fastapi import FastAPI, HTTPException, Depends, Header, Query, APIRouter, Request, Response
+from fastapi import (
+    FastAPI,
+    HTTPException,
+    Depends,
+    Header,
+    Query,
+    APIRouter,
+    Request as FastAPIRequest,
+    Response,
+)
 from pydantic import BaseModel, Field
 from sqlalchemy import (
     create_engine, Column, Integer, String, Text, DateTime, Boolean,
@@ -504,7 +513,7 @@ def auth_callback(code: str, state: str, db: Session = Depends(get_db)):
 
 @app.post("/eventsub/callback")
 async def eventsub_callback(
-    request: Request,
+    request: FastAPIRequest,
     twitch_eventsub_message_type: str = Header(None),
     twitch_eventsub_message_id: str = Header(None),
     twitch_eventsub_message_timestamp: str = Header(None),


### PR DESCRIPTION
## Summary
- Alias FastAPI's `Request` to avoid collision with the local `Request` model
- Update EventSub callback to use the aliased request type

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile backend_app.py`
- `python - <<'PY'
import backend_app
print('loaded ok', backend_app.eventsub_callback.__annotations__['request'])
PY`


------
https://chatgpt.com/codex/tasks/task_e_68c6b29d489c83289d81441ecba53526