### PR TITLE
Streamline admin login flow

### DIFF
--- a/admin/public/index.html
+++ b/admin/public/index.html
@@ -9,8 +9,7 @@
 <body>
 <div id="landing" class="landing">
   <h1>ALPEN.BOT SONGQ</h1>
-  <button id="owner-login-btn">log in as channel owner</button>
-  <button id="mod-login-btn">log in as moderator to an existing channel</button>
+  <button id="login-btn">log in with Twitch</button>
   <div id="channel-list" class="channel-list"></div>
 </div>
 
@@ -19,6 +18,7 @@
     <div class="header">
       <div class="brand">Admin Console</div>
       <span id="ch-badge" class="badge">channel: ?</span>
+      <button id="reg-btn" style="display:none"></button>
     </div>
 
     <div class="grid">


### PR DESCRIPTION
## Summary
- Replace separate owner/mod login buttons with a single Twitch login
- Add top-level register/unregister channel button
- Allow owners to unregister channels via new backend endpoint

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c6bf5bcd5c8328820b4a91c19768f2