### PR TITLE
Fix channel listing authentication in admin console

### DIFF
--- a/admin/public/admin.js
+++ b/admin/public/admin.js
@@ -104,7 +104,9 @@ async function updateRegButton() {
   const btn = qs('reg-btn');
   if (!userLogin) { btn.style.display = 'none'; return; }
   try {
-    const resp = await fetch(`${API}/channels`);
+    const resp = await fetch(`${API}/channels`, {
+      headers: token ? { Authorization: `Bearer ${token}` } : {}
+    });
     const list = await resp.json();
     const found = list.find(ch => ch.channel_name.toLowerCase() === userLogin.toLowerCase());
     if (found) {


### PR DESCRIPTION
## Summary
- send OAuth token when requesting `/channels` so register/unregister button loads
- refresh stored Twitch token when logging into admin console

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c6c6bab8088328841ef02fd262b1e7