### PR TITLE
Fix channel listing authentication in admin console

### DIFF
--- a/admin/public/admin.js
+++ b/admin/public/admin.js
@@ -104,7 +104,9 @@ async function updateRegButton() {
   const btn = qs('reg-btn');
   if (!userLogin) { btn.style.display = 'none'; return; }
   try {
-    const resp = await fetch(`${API}/channels`);
+    const resp = await fetch(`${API}/channels`, {
+      headers: token ? { Authorization: `Bearer ${token}` } : {}
+    });
     const list = await resp.json();
     const found = list.find(ch => ch.channel_name.toLowerCase() === userLogin.toLowerCase());
     if (found) {

--- a/backend_app.py
+++ b/backend_app.py
@@ -400,8 +400,32 @@ def get_current_user(authorization: str = Header(None), db: Session = Depends(ge
         raise HTTPException(status_code=401, detail="missing token")
     token = authorization.split(" ", 1)[1]
     user = db.query(TwitchUser).filter_by(access_token=token).one_or_none()
-    if not user:
+    if user:
+        return user
+    resp = requests.get(
+        "https://id.twitch.tv/oauth2/validate",
+        headers={"Authorization": f"OAuth {token}"},
+    )
+    if resp.status_code != 200:
         raise HTTPException(status_code=401, detail="invalid token")
+    data = resp.json()
+    login = data.get("login")
+    if not login:
+        raise HTTPException(status_code=401, detail="invalid token")
+    user = db.query(TwitchUser).filter(func.lower(TwitchUser.username) == login.lower()).one_or_none()
+    if not user:
+        user = TwitchUser(
+            twitch_id=data.get("user_id", ""),
+            username=login,
+            access_token=token,
+            refresh_token="",
+            scopes=" ".join(data.get("scopes", [])),
+        )
+        db.add(user)
+    else:
+        user.access_token = token
+    db.commit()
+    db.refresh(user)
     return user
 
 def _user_has_access(user: TwitchUser, channel_pk: int, db: Session) -> bool:


### PR DESCRIPTION
## Summary
- send OAuth token when requesting `/channels` so register/unregister button loads
- refresh stored Twitch token when logging into admin console
- create `TwitchUser` records on first login instead of returning 401

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c6c6bab8088328841ef02fd262b1e7