### PR TITLE
Fix channel registration flow in admin console

### DIFF
--- a/admin/public/admin.js
+++ b/admin/public/admin.js
@@ -104,7 +104,9 @@ async function updateRegButton() {
   const btn = qs('reg-btn');
   if (!userLogin) { btn.style.display = 'none'; return; }
   try {
-    const resp = await fetch(`${API}/channels`);
+    const resp = await fetch(`${API}/channels`, {
+      headers: token ? { Authorization: `Bearer ${token}` } : {}
+    });
     const list = await resp.json();
     const found = list.find(ch => ch.channel_name.toLowerCase() === userLogin.toLowerCase());
     if (found) {
@@ -115,8 +117,12 @@ async function updateRegButton() {
       };
     } else {
       btn.textContent = 'register your channel';
-      btn.onclick = () => {
-        location.href = `${API}/auth/login?channel=${encodeURIComponent(userLogin)}`;
+      btn.onclick = async () => {
+        const resp = await fetch(
+          `${API}/auth/login?channel=${encodeURIComponent(userLogin)}`
+        );
+        const data = await resp.json();
+        location.href = data.auth_url;
       };
     }
     btn.style.display = '';
@@ -140,9 +146,9 @@ function initToken() {
     const params = new URLSearchParams(location.hash.slice(1));
     token = params.get('access_token');
     history.replaceState({}, document.title, location.pathname);
-    fetch('https://id.twitch.tv/oauth2/validate', {headers:{Authorization:`OAuth ${token}`}})
-      .then(r=>r.json())
-      .then(info=>{ userLogin = info.login || ''; updateRegButton(); })
+    fetch(`${API}/me`, {headers:{Authorization:`Bearer ${token}`}})
+      .then(r => r.json())
+      .then(info => { userLogin = info.login || ''; updateRegButton(); })
       .catch(()=>{});
     fetch(`${API}/me/channels`, {headers:{Authorization:`Bearer ${token}`}})
       .then(r => r.json())
@@ -158,6 +164,9 @@ function initToken() {
             b.onclick = () => selectChannel(c.channel_name);
             container.appendChild(b);
           });
+        } else {
+          qs('landing').style.display = 'none';
+          qs('app').style.display = '';
         }
       })
       .catch(()=>{});


### PR DESCRIPTION
## Summary
- fetch OAuth URL from backend before redirecting to Twitch when registering a channel
- derive OAuth redirect URI from the current request when none is configured
- send OAuth token when requesting `/channels` so register/unregister button loads
- refresh stored Twitch token when logging into admin console
- create `TwitchUser` records on first login instead of returning 401
- expose `/me` endpoint and use it to fetch login for register button
- reveal admin header when no channels are linked so register button is visible after login

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c6c6bab8088328841ef02fd262b1e7