### PR TITLE
Add admin login persistence UI and logout endpoints

### DIFF
--- a/admin/public/index.html
+++ b/admin/public/index.html
@@ -7,6 +7,19 @@
   <link rel="stylesheet" href="style.css"/>
 </head>
 <body>
+<div id="login-status" class="status-bar" style="display:none">
+  <div class="status-user">
+    <div id="login-avatar" class="status-avatar" aria-hidden="true"></div>
+    <div class="status-info">
+      <span id="login-name" class="status-name"></span>
+      <span id="login-channel" class="status-channel"></span>
+    </div>
+  </div>
+  <div class="status-actions">
+    <button id="logout-btn" class="status-action">log out</button>
+    <button id="logout-perm-btn" class="status-action danger">forget &amp; log out</button>
+  </div>
+</div>
 <div id="landing" class="landing">
   <h1>ALPEN.BOT SONGQ</h1>
   <button id="login-btn">log in with Twitch</button>

--- a/admin/public/style.css
+++ b/admin/public/style.css
@@ -7,6 +7,17 @@
 html,body{margin:0;height:100%;background:var(--bg);color:var(--text);font:14px/1.4 system-ui,Segoe UI,Roboto,Arial}
 a{color:var(--accent);text-decoration:none}
 a:hover{text-decoration:underline}
+.status-bar{display:flex;align-items:center;gap:12px;background:var(--panel);border-bottom:1px solid #24283b;padding:10px 16px}
+.status-user{display:flex;align-items:center;gap:10px;min-width:0}
+.status-avatar{width:36px;height:36px;border-radius:50%;border:1px solid #24283b;background:#121423;color:var(--muted);font-weight:600;display:grid;place-items:center;overflow:hidden;background-size:cover;background-position:center}
+.status-info{display:flex;flex-direction:column;line-height:1.2}
+.status-name{font-weight:600;white-space:nowrap}
+.status-channel{font-size:12px;color:var(--muted);white-space:nowrap}
+.status-actions{margin-left:auto;display:flex;gap:8px;flex-wrap:wrap}
+.status-action{padding:.35rem .75rem;border-radius:8px;border:1px solid #24283b;background:#121423;color:var(--text);cursor:pointer}
+.status-action:hover{background:#1b1f2b}
+.status-action.danger{border-color:var(--danger);color:var(--danger)}
+.status-action.danger:hover{background:rgba(239,68,68,0.15)}
 .wrap{max-width:var(--w);margin:24px auto;padding:0 8px}
 .header{display:flex;gap:16px;align-items:center;margin-bottom:16px}
 .brand{font-weight:700;font-size:20px}


### PR DESCRIPTION
## Summary
- expose a top-of-page admin status bar that shows the signed-in Twitch user, avatar, and logout actions
- teach the admin console script to reuse persisted cookies, refresh the status display, and handle logout and account removal flows
- extend the backend session APIs with profile metadata plus logout and account deletion endpoints

## Testing
- python -m compileall backend_app.py

------
https://chatgpt.com/codex/tasks/task_e_68e25cfd691c8328bd5ecadf7c49a0d4