### PR TITLE
Update Twitch bot token environment configuration

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,6 @@ services:
     environment:
       BACKEND_URL: ${BACKEND_URL:-http://api:7070}
       ADMIN_TOKEN: ${ADMIN_TOKEN}
-      TWITCH_BOT_TOKEN: ${TWITCH_OAUTH_TOKEN}
       BOT_NICK: ${BOT_NICK}
       COMMANDS_FILE: /bot/commands.yml
       BOT_MESSAGES_PATH: /bot/messages.yml

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,7 +15,7 @@ Additional directories include:
 
 ## Running with Docker
 1. Copy `example.env` to `stack.env` and adjust values such as `ADMIN_TOKEN`,
-   `TWITCH_OAUTH_TOKEN`, `BOT_NICK`, `TWITCH_CLIENT_ID`, and
+   `TWITCH_BOT_TOKEN`, `BOT_NICK`, `TWITCH_CLIENT_ID`, and
    `TWITCH_CLIENT_SECRET`. When exposing the stack outside of Docker, set
    `BACKEND_URL` to the public URL of the API so the bot and web UI can reach
    it.

--- a/example.env
+++ b/example.env
@@ -17,7 +17,7 @@ BACKEND_URL=http://api:7070
 # CORS_ALLOW_ORIGIN_REGEX=https?://.*
 
 # Twitch bot credentials
-TWITCH_OAUTH_TOKEN=your_twitch_oauth_token
+TWITCH_BOT_TOKEN=your_twitch_bot_token
 BOT_NICK=your_bot_nick
 
 # Twitch OAuth for channel authorization


### PR DESCRIPTION
## Summary
- rename the example Twitch bot token entry to TWITCH_BOT_TOKEN
- remove the docker override that mapped TWITCH_OAUTH_TOKEN to TWITCH_BOT_TOKEN
- update documentation to reference the TWITCH_BOT_TOKEN variable exclusively

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e26de03bb08328a273a23d85c4c510