### PR TITLE
Add hoster statistics dashboard and oauth endpoint

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -59,3 +59,17 @@ services:
     restart: unless-stopped
     volumes:
       - ./admin:/admin
+  stats:
+    build:
+      context: .
+      dockerfile: stats/Dockerfile
+    container_name: songqueue-stats
+    environment:
+      BACKEND_URL: ${BACKEND_URL:-http://api:7070}
+    env_file:
+      - stack.env
+    ports:
+      - "${STATS_PORT:-7171}:80"
+    restart: unless-stopped
+    volumes:
+      - ./stats:/stats

--- a/stats/Dockerfile
+++ b/stats/Dockerfile
@@ -1,0 +1,7 @@
+FROM nginx:alpine
+RUN apk add --no-cache gettext
+COPY stats/nginx.conf /etc/nginx/conf.d/default.conf
+COPY stats/public/ /usr/share/nginx/html/
+COPY stats/entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]

--- a/stats/entrypoint.sh
+++ b/stats/entrypoint.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+set -e
+: "${BACKEND_URL:=http://api:7070}"
+# Substitute variables into config.js
+envsubst '${BACKEND_URL}' < /usr/share/nginx/html/config.js.template > /usr/share/nginx/html/config.js
+exec nginx -g 'daemon off;'

--- a/stats/nginx.conf
+++ b/stats/nginx.conf
@@ -1,0 +1,11 @@
+server {
+  listen 80;
+  server_name _;
+  add_header Cache-Control "no-cache, no-store, must-revalidate";
+  add_header Pragma "no-cache";
+  add_header Expires "0";
+  location / {
+    root /usr/share/nginx/html;
+    try_files $uri /index.html;
+  }
+}

--- a/stats/public/config.js.template
+++ b/stats/public/config.js.template
@@ -1,0 +1,1 @@
+window.BACKEND_URL='${BACKEND_URL:-http://localhost:7070}';

--- a/stats/public/index.html
+++ b/stats/public/index.html
@@ -1,0 +1,30 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1"/>
+  <title>ALPEN.BOT SONGQ — Host Stats</title>
+  <link rel="stylesheet" href="style.css"/>
+</head>
+<body>
+  <div class="wrap">
+    <header class="header">
+      <div class="brand">Hoster Statistics</div>
+      <span id="status" class="badge">status: loading…</span>
+    </header>
+
+    <section class="card">
+      <h2>Registered Channels</h2>
+      <div id="channel-list" class="channel-list"></div>
+    </section>
+
+    <section class="card">
+      <h2>Channel Overview</h2>
+      <div id="channel-tree" class="tree"></div>
+    </section>
+  </div>
+
+  <script src="config.js"></script>
+  <script src="stats.js"></script>
+</body>
+</html>

--- a/stats/public/stats.js
+++ b/stats/public/stats.js
@@ -1,0 +1,324 @@
+const API = (window.BACKEND_URL || 'http://localhost:7070').replace(/\/$/, '');
+const statusEl = document.getElementById('status');
+const channelListEl = document.getElementById('channel-list');
+const treeEl = document.getElementById('channel-tree');
+
+const songCache = new Map();
+const userCache = new Map();
+
+function setStatus(text, variant) {
+  if (!statusEl) return;
+  statusEl.textContent = text;
+  statusEl.classList.remove('ok', 'warn', 'error');
+  if (variant) {
+    statusEl.classList.add(variant);
+  }
+}
+
+async function fetchJson(path) {
+  const res = await fetch(`${API}${path}`);
+  if (!res.ok) {
+    throw new Error(`request failed: ${res.status}`);
+  }
+  return res.json();
+}
+
+async function fetchChannelOAuth(name) {
+  try {
+    return await fetchJson(`/channels/${encodeURIComponent(name)}/oauth`);
+  } catch (err) {
+    console.error('failed to load oauth info for', name, err);
+    return null;
+  }
+}
+
+function renderChannelList(channels, oauthMap) {
+  channelListEl.innerHTML = '';
+  if (!channels.length) {
+    const empty = document.createElement('div');
+    empty.className = 'empty';
+    empty.textContent = 'No registered channels.';
+    channelListEl.appendChild(empty);
+    return;
+  }
+  channels.forEach(ch => {
+    const pill = document.createElement('div');
+    pill.className = 'channel-pill';
+    const link = document.createElement('a');
+    link.href = `https://twitch.tv/${ch.channel_name}`;
+    link.target = '_blank';
+    link.rel = 'noopener';
+    link.textContent = ch.channel_name;
+    pill.appendChild(link);
+
+    const oauth = oauthMap.get(ch.channel_name);
+    if (oauth) {
+      const badge = document.createElement('span');
+      badge.className = 'badge ' + (oauth.authorized ? 'ok' : 'warn');
+      if (oauth.authorized) {
+        const scopes = oauth.scopes && oauth.scopes.length ? oauth.scopes.join(', ') : 'connected';
+        badge.textContent = `oauth: ${scopes}`;
+      } else {
+        badge.textContent = 'oauth missing';
+      }
+      pill.appendChild(badge);
+    }
+
+    channelListEl.appendChild(pill);
+  });
+}
+
+async function getSong(channel, id) {
+  const key = `${channel.toLowerCase()}:${id}`;
+  if (!songCache.has(key)) {
+    const promise = fetchJson(`/channels/${encodeURIComponent(channel)}/songs/${id}`)
+      .catch(err => {
+        songCache.delete(key);
+        throw err;
+      });
+    songCache.set(key, promise);
+  }
+  return songCache.get(key);
+}
+
+async function getUser(channel, id) {
+  const key = `${channel.toLowerCase()}:${id}`;
+  if (!userCache.has(key)) {
+    const promise = fetchJson(`/channels/${encodeURIComponent(channel)}/users/${id}`)
+      .catch(err => {
+        userCache.delete(key);
+        throw err;
+      });
+    userCache.set(key, promise);
+  }
+  return userCache.get(key);
+}
+
+function formatSettingKey(key) {
+  return key.replace(/_/g, ' ');
+}
+
+function renderSettings(container, settings) {
+  if (!settings) {
+    const msg = document.createElement('div');
+    msg.className = 'empty';
+    msg.textContent = 'Settings unavailable.';
+    container.appendChild(msg);
+    return;
+  }
+  const grid = document.createElement('div');
+  grid.className = 'settings';
+  Object.entries(settings).forEach(([key, value]) => {
+    if (key === 'channel_id') return;
+    const item = document.createElement('div');
+    item.className = 'setting';
+    const label = document.createElement('span');
+    label.textContent = formatSettingKey(key);
+    const val = document.createElement('div');
+    val.textContent = value === null || value === undefined || value === '' ? '—' : value;
+    item.appendChild(label);
+    item.appendChild(val);
+    grid.appendChild(item);
+  });
+  if (!grid.children.length) {
+    const msg = document.createElement('div');
+    msg.className = 'empty';
+    msg.textContent = 'No custom settings.';
+    container.appendChild(msg);
+    return;
+  }
+  container.appendChild(grid);
+}
+
+function queueItemNode(entry) {
+  const { request, song, user } = entry;
+  const node = document.createElement('li');
+  node.className = 'queue-item';
+  const title = document.createElement('div');
+  title.className = 'title';
+  if (song) {
+    const artist = song.artist || '?';
+    const songTitle = song.title || '?';
+    title.textContent = `${artist} – ${songTitle}`;
+  } else {
+    title.textContent = `Song #${request.song_id}`;
+  }
+  const meta = document.createElement('div');
+  meta.className = 'meta';
+  const requester = user ? user.username : `User #${request.user_id}`;
+  const priority = request.is_priority ? ' • priority' : '';
+  meta.textContent = `requested by ${requester}${priority}`;
+  node.appendChild(title);
+  node.appendChild(meta);
+  return node;
+}
+
+async function enrichQueue(channel, items) {
+  const results = [];
+  for (const request of items) {
+    try {
+      const [song, user] = await Promise.all([
+        getSong(channel, request.song_id),
+        getUser(channel, request.user_id),
+      ]);
+      results.push({ request, song, user });
+    } catch (err) {
+      console.error('failed to expand queue item', channel, request.id, err);
+      results.push({ request, song: null, user: null });
+    }
+  }
+  return results;
+}
+
+async function renderStreams(container, channel, streams) {
+  container.className = 'stream-details';
+  if (!streams || !streams.length) {
+    const msg = document.createElement('div');
+    msg.className = 'empty';
+    msg.textContent = 'No active streams.';
+    container.appendChild(msg);
+    return;
+  }
+  for (const stream of streams) {
+    const block = document.createElement('details');
+    block.open = true;
+    const summary = document.createElement('summary');
+    summary.className = 'stream-summary';
+    const started = new Date(stream.started_at);
+    summary.textContent = `Stream #${stream.id} • started ${started.toLocaleString()}`;
+    block.appendChild(summary);
+
+    let queue = [];
+    try {
+      const raw = await fetchJson(`/channels/${encodeURIComponent(channel)}/streams/${stream.id}/queue`);
+      queue = raw.filter(item => !item.played);
+    } catch (err) {
+      console.error('failed to load queue for stream', channel, stream.id, err);
+      const errorMsg = document.createElement('div');
+      errorMsg.className = 'error';
+      errorMsg.textContent = 'Unable to load queue for this stream.';
+      block.appendChild(errorMsg);
+      container.appendChild(block);
+      continue;
+    }
+
+    if (!queue.length) {
+      const empty = document.createElement('div');
+      empty.className = 'empty';
+      empty.textContent = 'No songs currently queued.';
+      block.appendChild(empty);
+      container.appendChild(block);
+      continue;
+    }
+
+    const expanded = await enrichQueue(channel, queue);
+    const list = document.createElement('ul');
+    list.className = 'queue-list';
+    expanded.forEach(entry => list.appendChild(queueItemNode(entry)));
+    block.appendChild(list);
+    container.appendChild(block);
+  }
+}
+
+async function renderChannelTree(channels, oauthMap) {
+  treeEl.innerHTML = '';
+  if (!channels.length) {
+    const empty = document.createElement('div');
+    empty.className = 'empty';
+    empty.textContent = 'No registered channels.';
+    treeEl.appendChild(empty);
+    return;
+  }
+
+  for (const ch of channels) {
+    const details = document.createElement('details');
+    details.open = true;
+    const summary = document.createElement('summary');
+    const main = document.createElement('div');
+    main.className = 'summary-main';
+    const link = document.createElement('a');
+    link.href = `https://twitch.tv/${ch.channel_name}`;
+    link.target = '_blank';
+    link.rel = 'noopener';
+    link.textContent = ch.channel_name;
+    main.appendChild(link);
+    const oauth = oauthMap.get(ch.channel_name);
+    if (oauth) {
+      const badge = document.createElement('span');
+      badge.className = 'badge ' + (oauth.authorized ? 'ok' : 'warn');
+      if (oauth.authorized) {
+        const scopes = oauth.scopes && oauth.scopes.length ? oauth.scopes.join(', ') : 'connected';
+        badge.textContent = `oauth: ${scopes}`;
+      } else {
+        badge.textContent = 'oauth missing';
+      }
+      main.appendChild(badge);
+    }
+    summary.appendChild(main);
+    const meta = document.createElement('div');
+    meta.className = 'summary-meta';
+    const ownerInfo = oauth && oauth.owner_login ? ` • owner: ${oauth.owner_login}` : '';
+    meta.textContent = `join active: ${ch.join_active ? 'yes' : 'no'} • channel id: ${ch.channel_id}${ownerInfo}`;
+    summary.appendChild(meta);
+    details.appendChild(summary);
+
+    const settingsWrapper = document.createElement('div');
+    const settingsTitle = document.createElement('h3');
+    settingsTitle.textContent = 'Custom Settings';
+    details.appendChild(settingsTitle);
+    details.appendChild(settingsWrapper);
+
+    let settings = null;
+    try {
+      settings = await fetchJson(`/channels/${encodeURIComponent(ch.channel_name)}/settings`);
+    } catch (err) {
+      console.error('failed to load settings for', ch.channel_name, err);
+    }
+    renderSettings(settingsWrapper, settings);
+
+    const streamTitle = document.createElement('h3');
+    streamTitle.textContent = 'Active Streams';
+    details.appendChild(streamTitle);
+    const streamContainer = document.createElement('div');
+    details.appendChild(streamContainer);
+
+    let streams = [];
+    try {
+      const raw = await fetchJson(`/channels/${encodeURIComponent(ch.channel_name)}/streams`);
+      streams = raw.filter(row => !row.ended_at);
+    } catch (err) {
+      console.error('failed to load streams for', ch.channel_name, err);
+    }
+    await renderStreams(streamContainer, ch.channel_name, streams);
+
+    treeEl.appendChild(details);
+  }
+}
+
+async function init() {
+  setStatus('status: loading…');
+  try {
+    const channels = await fetchJson('/channels');
+    channels.sort((a, b) => a.channel_name.localeCompare(b.channel_name));
+    const oauthEntries = await Promise.all(channels.map(ch => fetchChannelOAuth(ch.channel_name)));
+    const oauthMap = new Map();
+    oauthEntries.forEach((info, idx) => {
+      if (info) {
+        oauthMap.set(channels[idx].channel_name, info);
+      }
+    });
+    renderChannelList(channels, oauthMap);
+    await renderChannelTree(channels, oauthMap);
+    setStatus('status: ok', 'ok');
+  } catch (err) {
+    console.error('failed to load channel data', err);
+    setStatus('status: error', 'error');
+    treeEl.innerHTML = '';
+    const error = document.createElement('div');
+    error.className = 'error';
+    error.textContent = 'Unable to load statistics from the backend.';
+    treeEl.appendChild(error);
+  }
+}
+
+window.addEventListener('DOMContentLoaded', init);

--- a/stats/public/style.css
+++ b/stats/public/style.css
@@ -1,0 +1,39 @@
+:root{
+  --bg:#0f1117; --panel:#151821; --muted:#9aa4b2; --text:#f8fafc; --accent:#8b5cf6;
+  --ok:#22c55e; --warn:#f59e0b; --danger:#ef4444;
+  --w: min(1100px, 96vw);
+}
+*{box-sizing:border-box}
+html,body{margin:0;height:100%;background:var(--bg);color:var(--text);font:14px/1.4 system-ui,Segoe UI,Roboto,Arial}
+a{color:var(--accent);text-decoration:none}
+a:hover{text-decoration:underline}
+.wrap{max-width:var(--w);margin:24px auto;padding:0 8px;display:flex;flex-direction:column;gap:16px}
+.header{display:flex;align-items:center;gap:16px}
+.brand{font-weight:700;font-size:20px}
+.badge{display:inline-block;padding:.15rem .5rem;border-radius:999px;background:var(--panel);border:1px solid #24283b;color:var(--muted);font-size:12px;text-transform:lowercase}
+.badge.ok{border-color:var(--ok);color:var(--ok)}
+.badge.warn{border-color:var(--warn);color:var(--warn)}
+.card{background:var(--panel);border:1px solid #24283b;border-radius:12px;padding:16px;display:flex;flex-direction:column;gap:12px}
+.card h2{margin:0;font-size:16px}
+.channel-list{display:flex;flex-wrap:wrap;gap:8px}
+.channel-pill{padding:.35rem .75rem;border-radius:999px;border:1px solid #24283b;background:#121423;color:var(--text);display:flex;align-items:center;gap:8px}
+.channel-pill .badge{margin-left:4px}
+.tree{display:flex;flex-direction:column;gap:10px}
+.tree details{background:#121423;border:1px solid #24283b;border-radius:10px;padding:10px}
+.tree summary{cursor:pointer;font-weight:600;display:flex;align-items:center;gap:10px;list-style:none;justify-content:space-between;flex-wrap:wrap}
+.tree summary::-webkit-details-marker{display:none}
+.tree .summary-main{display:flex;align-items:center;gap:8px}
+.tree .summary-meta{display:flex;align-items:center;gap:8px;font-size:12px;color:var(--muted)}
+.tree h3{margin:12px 0 6px;font-size:13px;font-weight:600;color:var(--muted);text-transform:uppercase;letter-spacing:.04em}
+.tree .settings{background:#0f121a;border-radius:8px;padding:10px;margin-top:8px;font-size:13px;display:grid;grid-template-columns:repeat(auto-fit,minmax(220px,1fr));gap:8px}
+.tree .setting{background:#151821;border:1px solid #24283b;border-radius:8px;padding:8px;display:flex;flex-direction:column;gap:4px}
+.tree .setting span{color:var(--muted);font-size:12px;text-transform:uppercase;letter-spacing:.04em}
+.stream-details{margin-top:10px;display:flex;flex-direction:column;gap:8px}
+.stream-details details{padding:0;border:none;background:transparent}
+.stream-summary{display:flex;align-items:center;gap:8px;font-size:13px;color:var(--muted)}
+.queue-list{list-style:none;padding:0;margin:8px 0 0 0;display:flex;flex-direction:column;gap:6px}
+.queue-item{padding:8px;border-radius:8px;border:1px solid #24283b;background:#151821}
+.queue-item .title{font-weight:600}
+.queue-item .meta{font-size:12px;color:var(--muted);margin-top:4px}
+.empty{color:var(--muted);font-size:13px}
+.error{color:var(--danger)}


### PR DESCRIPTION
## Summary
- add a `/channels/{channel}/oauth` backend endpoint that exposes sanitized Twitch OAuth metadata for each channel
- introduce a new `stats` service with an nginx container that serves a hoster-focused statistics dashboard on port 7171
- implement the dashboard UI to list registered channels, highlight OAuth scope coverage, and show active streams with queued songs and settings using the existing visual theme

## Testing
- python -m compileall backend_app.py

------
https://chatgpt.com/codex/tasks/task_e_68e4157e78b88328bca6c645aca4c478