### PR TITLE
Add support for wildcard CORS origins

### DIFF
--- a/example.env
+++ b/example.env
@@ -9,6 +9,7 @@ ADMIN_TOKEN=change-me
 BACKEND_URL=http://api:7070
 
 # Optional comma separated list of allowed origins for browser clients.
+# Wildcards using `*` are supported (e.g. https://*.example.com).
 # If left empty, any http(s) origin will be allowed.
 # CORS_ALLOW_ORIGINS=
 # Optional regular expression for matching allowed origins when the list is empty.


### PR DESCRIPTION
## Summary
- translate wildcard entries in `CORS_ALLOW_ORIGINS` into regex fragments so subdomains can be whitelisted without resorting to global wildcards
- document wildcard origin support in the sample environment configuration
- add regression tests covering mixed explicit/wildcard origins and the default regex fallback

## Testing
- PYTHONPATH=. pytest tests/test_cors.py

------
https://chatgpt.com/codex/tasks/task_e_68e43da1c9c4832881594a3e3a3741b6