### PR TITLE
Add bot OAuth config API and log streaming support

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -15,10 +15,10 @@ Additional directories include:
 
 ## Running with Docker
 1. Copy `example.env` to `stack.env` and adjust values such as `ADMIN_TOKEN`,
-   `TWITCH_BOT_TOKEN`, `BOT_NICK`, `TWITCH_CLIENT_ID`, and
-   `TWITCH_CLIENT_SECRET`. When exposing the stack outside of Docker, set
-   `BACKEND_URL` to the public URL of the API so the bot and web UI can reach
-   it.
+   `TWITCH_CLIENT_ID`, and `TWITCH_CLIENT_SECRET`. When exposing the stack
+   outside of Docker, set `BACKEND_URL` to the public URL of the API so the bot
+   and web UI can reach it. Bot credentials are now managed through the backend
+   at `/bot/config` instead of `.env` entries.
 2. Start the stack:
    ```bash
    docker-compose --env-file stack.env up --build
@@ -28,7 +28,10 @@ Additional directories include:
 
 ## Backend Highlights
 - Uses a SQLite database stored at `/data/db.sqlite` and defines models for channels, songs, users, stream sessions, and requests.
-- Exposes REST endpoints for managing songs and queue entries, plus an SSE stream for real‑time events.
+- Stores bot OAuth credentials via the `/bot/config` API and exposes an OAuth
+  helper flow for authorizing the bot account.
+- Exposes REST endpoints for managing songs and queue entries, plus SSE streams
+  for queue updates and bot log streaming.
 - `run.sh` initializes the database and starts the server with Uvicorn.
 
 ## Bot Highlights

--- a/docs/backend_api.md
+++ b/docs/backend_api.md
@@ -7,6 +7,20 @@ This document summarizes the REST endpoints exposed by `backend_app.py`.
 |--------|------|-------------|
 | GET | `/system/health` | Health check that verifies database connectivity. |
 
+## Bot
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/bot/config` | Retrieve the stored bot OAuth configuration (admin). |
+| PUT | `/bot/config` | Update bot settings such as scopes or enable flag (admin). |
+| POST | `/bot/config/oauth` | Start the OAuth authorization flow for the bot account (admin). |
+| GET | `/bot/config/oauth/callback` | Callback used by Twitch to finish the bot OAuth flow. |
+
+## Bot Logs
+| Method | Path | Description |
+|--------|------|-------------|
+| POST | `/bot/logs` | Push a bot worker log event which is relayed to connected consoles (admin). |
+| GET | `/bot/logs/stream` | Server-sent events stream of bot worker log messages (admin). |
+
 ## Channels
 | Method | Path | Description |
 |--------|------|-------------|

--- a/example.env
+++ b/example.env
@@ -17,9 +17,10 @@ BACKEND_URL=http://api:7070
 # while remaining compatible with bot requests that do not rely on cookies.
 # CORS_ALLOW_ORIGIN_REGEX=https?://.*
 
-# Twitch bot credentials
-TWITCH_BOT_TOKEN=your_twitch_bot_token
-BOT_NICK=your_bot_nick
+# Twitch bot credentials are now stored through the backend `/bot/config`
+# endpoints. Uncomment these overrides only for legacy deployments.
+# TWITCH_BOT_TOKEN=your_twitch_bot_token
+# BOT_NICK=your_bot_nick
 
 # Twitch OAuth for channel authorization
 TWITCH_CLIENT_ID=your_client_id

--- a/tests/test_bot_config.py
+++ b/tests/test_bot_config.py
@@ -1,0 +1,127 @@
+import os
+import sys
+import unittest
+from pathlib import Path
+from urllib.parse import urlparse, parse_qs
+from unittest.mock import patch
+
+from fastapi.testclient import TestClient
+
+os.makedirs("/data", exist_ok=True)
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import backend_app
+
+
+class BotConfigApiTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self._client_id = backend_app.TWITCH_CLIENT_ID
+        self._client_secret = backend_app.TWITCH_CLIENT_SECRET
+        self._redirect_uri = backend_app.TWITCH_REDIRECT_URI
+        self._bot_nick = backend_app.BOT_NICK
+        self._bot_user_id = backend_app.BOT_USER_ID
+        backend_app._bot_oauth_states.clear()
+        db = backend_app.SessionLocal()
+        try:
+            db.query(backend_app.BotConfig).delete()
+            db.commit()
+        finally:
+            db.close()
+        backend_app.BOT_NICK = None
+        backend_app.BOT_USER_ID = None
+        self.client = TestClient(backend_app.app)
+
+    def tearDown(self) -> None:
+        self.client.close()
+        backend_app.TWITCH_CLIENT_ID = self._client_id
+        backend_app.TWITCH_CLIENT_SECRET = self._client_secret
+        backend_app.TWITCH_REDIRECT_URI = self._redirect_uri
+        backend_app.BOT_NICK = self._bot_nick
+        backend_app.BOT_USER_ID = self._bot_user_id
+
+    def test_fetch_default_config(self) -> None:
+        response = self.client.get("/bot/config", headers={"X-Admin-Token": backend_app.ADMIN_TOKEN})
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertIsNone(data["login"])
+        self.assertFalse(data["enabled"])
+        self.assertEqual(data["scopes"], backend_app.TWITCH_SCOPES)
+
+    def test_update_config_scope_and_enabled(self) -> None:
+        payload = {"enabled": True, "scopes": ["chat:read", "channel:bot"]}
+        response = self.client.put(
+            "/bot/config",
+            headers={"X-Admin-Token": backend_app.ADMIN_TOKEN},
+            json=payload,
+        )
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertTrue(data["enabled"])
+        self.assertEqual(data["scopes"], payload["scopes"])
+
+    def test_oauth_flow_persists_tokens(self) -> None:
+        backend_app.TWITCH_CLIENT_ID = "client"
+        backend_app.TWITCH_CLIENT_SECRET = "secret"
+        backend_app.TWITCH_REDIRECT_URI = None
+
+        auth_start = self.client.post(
+            "/bot/config/oauth",
+            headers={"X-Admin-Token": backend_app.ADMIN_TOKEN},
+        )
+        self.assertEqual(auth_start.status_code, 200)
+        auth_url = auth_start.json()["auth_url"]
+        parsed = urlparse(auth_url)
+        params = parse_qs(parsed.query)
+        state = params["state"][0]
+
+        class FakeTokenResponse:
+            status_code = 200
+
+            def raise_for_status(self) -> None:
+                return None
+
+            def json(self) -> dict[str, object]:
+                return {
+                    "access_token": "access",
+                    "refresh_token": "refresh",
+                    "scope": ["chat:read", "chat:edit"],
+                    "expires_in": 3600,
+                }
+
+        class FakeUserResponse:
+            status_code = 200
+
+            def raise_for_status(self) -> None:
+                return None
+
+            def json(self) -> dict[str, object]:
+                return {
+                    "data": [
+                        {
+                            "id": "1234",
+                            "login": "botuser",
+                            "display_name": "BotUser",
+                        }
+                    ]
+                }
+
+        with patch.object(backend_app.requests, "post", return_value=FakeTokenResponse()), \
+            patch.object(backend_app.requests, "get", return_value=FakeUserResponse()):
+            callback = self.client.get(
+                "/bot/config/oauth/callback",
+                params={"code": "abc", "state": state},
+            )
+
+        self.assertEqual(callback.status_code, 200)
+        data = self.client.get(
+            "/bot/config",
+            headers={"X-Admin-Token": backend_app.ADMIN_TOKEN},
+        ).json()
+        self.assertEqual(data["login"], "botuser")
+        self.assertTrue(data["enabled"])
+        self.assertIn("chat:read", data["scopes"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_cors.py
+++ b/tests/test_cors.py
@@ -1,13 +1,17 @@
 import os
 import re
+import sys
 import unittest
 import uuid
+from pathlib import Path
 from unittest.mock import patch
 
 import requests
 from fastapi.testclient import TestClient
 
 os.makedirs("/data", exist_ok=True)
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 import backend_app
 


### PR DESCRIPTION
## Summary
- add a BotConfig model and helpers so the backend persists bot OAuth credentials
- expose admin endpoints to manage bot configuration, run the Twitch OAuth flow, and stream bot logs over SSE
- document the backend-managed bot credentials and cover the new API with tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e55a8c3ef88328a35589e4d343476c