### PR TITLE
Add backend-driven bot coordination and tests

### DIFF
--- a/bot/bot_app.py
+++ b/bot/bot_app.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 import os, re, asyncio, json, yaml
-from typing import Optional, Dict, List, Tuple
+from typing import Optional, Dict, List, Tuple, Callable, Awaitable
+from dataclasses import dataclass
 from pathlib import Path
 from datetime import datetime
 
@@ -12,8 +13,8 @@ from twitchio.ext import commands
 BACKEND_URL = os.getenv('BACKEND_URL', 'http://api:7070')
 # Token used for privileged requests to the backend.
 ADMIN_TOKEN = os.getenv('ADMIN_TOKEN', 'change-me')
-BOT_TOKEN = os.getenv('TWITCH_BOT_TOKEN')  # token without 'oauth:'
-BOT_NICK = os.getenv('BOT_NICK')
+ENV_BOT_TOKEN = os.getenv('TWITCH_BOT_TOKEN')  # token without 'oauth:'
+ENV_BOT_NICK = os.getenv('BOT_NICK')
 MESSAGES_PATH = Path(os.getenv("BOT_MESSAGES_PATH", "/bot/messages.yml"))
 
 COMMANDS_FILE = os.getenv('COMMANDS_FILE', '/bot/commands.yml')
@@ -150,7 +151,55 @@ class Backend:
             path += f"?since={since}"
         return await self._req('GET', path)
 
+    async def get_bot_config(self) -> Dict[str, object]:
+        return await self._req('GET', "/bot/config")
+
+    async def push_bot_log(
+        self,
+        *,
+        level: str = 'info',
+        message: str,
+        metadata: Optional[Dict[str, object]] = None,
+    ) -> Dict[str, object]:
+        payload = {
+            'level': level,
+            'message': message,
+            'metadata': metadata or {},
+            'source': 'bot',
+        }
+        return await self._req('POST', "/bot/logs", payload)
+
 backend = Backend(BACKEND_URL, ADMIN_TOKEN)
+
+
+@dataclass
+class BotSettings:
+    token: Optional[str]
+    refresh_token: Optional[str]
+    login: Optional[str]
+    enabled: bool
+
+
+def _format_token(token: str) -> str:
+    return token if token.startswith('oauth:') else f"oauth:{token}"
+
+
+async def push_console_event(
+    level: str,
+    message: str,
+    *,
+    event: Optional[str] = None,
+    metadata: Optional[Dict[str, object]] = None,
+):
+    meta = dict(metadata or {})
+    if event:
+        meta.setdefault('event', event)
+    try:
+        await backend.push_bot_log(level=level, message=message, metadata=meta)
+    except Exception:
+        # Console streaming is best-effort; avoid crashing the bot when the
+        # backend is temporarily unavailable.
+        pass
 
 # ---- helpers ----
 async def fetch_youtube_oembed_title(session: aiohttp.ClientSession, url: str) -> Optional[str]:
@@ -201,33 +250,40 @@ def load_messages(path: Path) -> Dict[str, str]:
 
 # ---- bot ----
 class SongBot(commands.Bot):
-    def __init__(self):
-        if not BOT_TOKEN or not BOT_NICK:
-            raise RuntimeError('TWITCH_BOT_TOKEN and BOT_NICK required')
+    def __init__(self, *, token: str, nick: str, enabled: bool = True):
+        if not token or not nick:
+            raise RuntimeError('token and nick required')
         self.commands_map = load_commands(COMMANDS_FILE)
         self.messages = load_messages(MESSAGES_PATH)
         self.currency_singular = self.messages.get('currency_singular', 'point')
         self.currency_plural = self.messages.get('currency_plural', 'points')
         prefix = self.commands_map['prefix'][0]
-        super().__init__(token=f"oauth:{BOT_TOKEN}", prefix=prefix, initial_channels=[])
+        super().__init__(token=token, prefix=prefix, initial_channels=[])
         self.channel_map: Dict[str, Dict] = {}
         self.ready_event = asyncio.Event()
         self.state: Dict[str, Dict] = {}
         self.listeners: Dict[str, asyncio.Task] = {}
         self.joined: set[str] = set()
         self._sync_lock = asyncio.Lock()
+        self.enabled = enabled
+        self.nick = nick
 
     async def event_ready(self):
-        await self.sync_channels()
+        if self.enabled:
+            await self.sync_channels()
         asyncio.create_task(self.channel_refresher())
         self.ready_event.set()
 
     async def channel_refresher(self):
         while True:
             await asyncio.sleep(60)
-            await self.sync_channels()
+            if self.enabled:
+                await self.sync_channels()
 
     async def sync_channels(self):
+        if not self.enabled:
+            await self._disable_all_channels()
+            return
         async with self._sync_lock:
             rows = await backend.get_channels()
             allowed = {
@@ -240,19 +296,25 @@ class SongBot(commands.Bot):
             allowed_keys = set(allowed.keys())
 
             removed = current_keys - allowed_keys
-            for key in removed:
-                info = self.channel_map.pop(key)
-                name = info['channel_name']
-                task = self.listeners.pop(name, None)
-                if task:
-                    task.cancel()
-                if name in self.joined:
-                    try:
-                        await self.part_channels([name])
-                    except Exception:
-                        pass
-                    self.joined.discard(name)
-                self.state.pop(name, None)
+        for key in removed:
+            info = self.channel_map.pop(key)
+            name = info['channel_name']
+            task = self.listeners.pop(name, None)
+            if task:
+                task.cancel()
+            if name in self.joined:
+                try:
+                    await self.part_channels([name])
+                except Exception:
+                    pass
+                self.joined.discard(name)
+                await push_console_event(
+                    'info',
+                    f'Parted channel {name}',
+                    event='part',
+                    metadata={'channel': name},
+                )
+            self.state.pop(name, None)
 
             for key, row in allowed.items():
                 self.channel_map[key] = row
@@ -266,6 +328,12 @@ class SongBot(commands.Bot):
                 except Exception:
                     continue
                 self.joined.add(name)
+                await push_console_event(
+                    'info',
+                    f'Joined channel {name}',
+                    event='join',
+                    metadata={'channel': name},
+                )
                 initial_queue = await backend.get_queue(name, include_played=True)
                 self.state[name] = {
                     'queue': initial_queue,
@@ -285,7 +353,196 @@ class SongBot(commands.Bot):
                         'last_event': datetime.utcnow().isoformat(),
                     }
 
+    async def _disable_all_channels(self):
+        for task in self.listeners.values():
+            task.cancel()
+        self.listeners.clear()
+        for name in list(self.joined):
+            try:
+                await self.part_channels([name])
+            except Exception:
+                pass
+            await push_console_event(
+                'info',
+                f'Parted channel {name}',
+                event='part',
+                metadata={'channel': name},
+            )
+        self.joined.clear()
+        self.state.clear()
+        self.channel_map.clear()
+
+    async def _send_message(self, channel, message: str, *, metadata: Optional[Dict[str, object]] = None):
+        await channel.send(message)
+        await push_console_event(
+            'info',
+            f'Sent message to {channel.name}',
+            event='message',
+            metadata={**(metadata or {}), 'sent_text': message, 'channel': channel.name},
+        )
+
+    async def update_enabled(self, enabled: bool):
+        if self.enabled == enabled:
+            return
+        self.enabled = enabled
+        await self.ready_event.wait()
+        if not enabled:
+            await push_console_event('info', 'Disabling bot', event='lifecycle')
+            await self._disable_all_channels()
+        else:
+            await push_console_event('info', 'Enabling bot', event='lifecycle')
+            await self.sync_channels()
+
+
+class BotService:
+    def __init__(
+        self,
+        backend_client: Backend,
+        *,
+        poll_interval: int = 15,
+        bot_factory: Optional[Callable[..., SongBot]] = None,
+        task_factory: Optional[Callable[[Awaitable], asyncio.Task]] = None,
+    ):
+        self.backend = backend_client
+        self.poll_interval = poll_interval
+        self.bot_factory = bot_factory or (lambda **kwargs: SongBot(**kwargs))
+        self._create_task = task_factory or asyncio.create_task
+        self._bot: Optional[SongBot] = None
+        self._bot_task: Optional[asyncio.Task] = None
+        self._current_token: Optional[str] = None
+        self._current_login: Optional[str] = None
+        self._credentials_available: Optional[bool] = None
+        self._last_enabled: Optional[bool] = None
+
+    async def run(self):
+        while True:
+            try:
+                raw_config = await self.backend.get_bot_config()
+            except Exception as exc:
+                await push_console_event(
+                    'error',
+                    f'Failed to fetch bot configuration: {exc}',
+                    event='config',
+                )
+                raw_config = {}
+            settings = self._settings_from_config(raw_config)
+            try:
+                await self.apply_settings(settings)
+            except Exception as exc:
+                await push_console_event(
+                    'error',
+                    f'Failed to apply bot configuration: {exc}',
+                    event='config',
+                )
+            await asyncio.sleep(self.poll_interval)
+
+    async def apply_settings(self, settings: BotSettings):
+        if not settings.token or not settings.login:
+            if self._credentials_available is not False:
+                await push_console_event(
+                    'error',
+                    'Bot credentials are unavailable; idling worker',
+                    event='startup',
+                )
+            self._credentials_available = False
+            self._last_enabled = None
+            await self._stop_bot(reason='missing_credentials')
+            return
+        if self._credentials_available is not True:
+            await push_console_event(
+                'info',
+                'Bot credentials resolved',
+                event='startup',
+            )
+        self._credentials_available = True
+
+        if not settings.enabled:
+            if self._last_enabled is not False:
+                await push_console_event(
+                    'info',
+                    'Bot disabled in backend; idling',
+                    event='lifecycle',
+                )
+            self._last_enabled = False
+            await self._stop_bot(reason='disabled')
+            return
+        if self._last_enabled is not True:
+            await push_console_event('info', 'Bot enabled in backend', event='lifecycle')
+        self._last_enabled = True
+
+        token = _format_token(settings.token)
+        requires_restart = (
+            self._bot is None
+            or token != self._current_token
+            or settings.login != self._current_login
+        )
+        if requires_restart:
+            await self._restart_bot(token=token, login=settings.login, enabled=settings.enabled)
+        elif self._bot:
+            await self._bot.update_enabled(settings.enabled)
+
+    async def _restart_bot(self, *, token: str, login: str, enabled: bool):
+        await self._stop_bot(reason='restarting')
+        await push_console_event(
+            'info',
+            f'Connecting bot as {login}',
+            event='lifecycle',
+        )
+        bot = self.bot_factory(token=token, nick=login, enabled=enabled)
+        self._bot = bot
+        self._current_token = token
+        self._current_login = login
+        self._bot_task = self._create_task(bot.start())
+
+    async def _stop_bot(self, *, reason: Optional[str] = None):
+        if not self._bot:
+            return
+        try:
+            await self._bot.close()
+        except Exception as exc:
+            await push_console_event(
+                'error',
+                f'Error while stopping bot: {exc}',
+                event='lifecycle',
+            )
+        if self._bot_task:
+            try:
+                await self._bot_task
+            except Exception:
+                pass
+        self._bot = None
+        self._bot_task = None
+        self._current_token = None
+        self._current_login = None
+        if reason:
+            await push_console_event(
+                'info',
+                f'Bot stopped ({reason})',
+                event='lifecycle',
+            )
+
+    def _settings_from_config(self, data: Dict[str, object]) -> BotSettings:
+        config = data or {}
+        if isinstance(config, dict):
+            token = config.get('access_token') or config.get('token')
+            refresh = config.get('refresh_token')
+            login = config.get('login') or config.get('bot_login')
+        else:
+            token = None
+            refresh = None
+            login = None
+        has_stored_login = bool(login)
+        enabled = bool(config.get('enabled')) if has_stored_login else False
+        if not token or not login:
+            token = ENV_BOT_TOKEN
+            login = ENV_BOT_NICK
+            if token and login:
+                enabled = True
+        return BotSettings(token=token, refresh_token=refresh, login=login, enabled=enabled)
+
     async def event_message(self, message):
+        if not self.enabled:
+            return
         if message.echo:
             return
         content = message.content.strip()
@@ -310,7 +567,11 @@ class SongBot(commands.Bot):
         ch_name = msg.channel.name.lower()
         ch_row = self.channel_map.get(ch_name)
         if not ch_row:
-            await msg.channel.send(self.messages['channel_not_registered'])
+            await self._send_message(
+                msg.channel,
+                self.messages['channel_not_registered'],
+                metadata={'channel': msg.channel.name, 'command': 'request'},
+            )
             return
         channel = ch_row['channel_name']
         user_id = await backend.find_or_create_user(channel, str(msg.author.id), msg.author.name)
@@ -346,21 +607,36 @@ class SongBot(commands.Bot):
                 prefer_sub_free=True,
                 is_subscriber=msg.author.is_subscriber,
             )
-            await msg.channel.send(
+            await self._send_message(
+                msg.channel,
                 self.messages['request_added'].format(
                     artist=song.get('artist', ''),
                     title=song.get('title', ''),
-                )
+                ),
+                metadata={'channel': msg.channel.name, 'command': 'request'},
             )
         except Exception as e:
-            await msg.channel.send(self.messages['failed'].format(error=e))
+            await push_console_event(
+                'error',
+                f'Failed to add request for {msg.author.name}: {e}',
+                metadata={'channel': msg.channel.name, 'command': 'request'},
+            )
+            await self._send_message(
+                msg.channel,
+                self.messages['failed'].format(error=e),
+                metadata={'channel': msg.channel.name, 'command': 'request'},
+            )
 
     async def handle_prioritize(self, msg, arg: str):
         # user can prioritize up to 3 songs per stream
         ch_name = msg.channel.name.lower()
         ch_row = self.channel_map.get(ch_name)
         if not ch_row:
-            await msg.channel.send(self.messages['channel_not_registered'])
+            await self._send_message(
+                msg.channel,
+                self.messages['channel_not_registered'],
+                metadata={'channel': msg.channel.name, 'command': 'prioritize'},
+            )
             return
         channel = ch_row['channel_name']
         user_id = await backend.find_or_create_user(channel, str(msg.author.id), msg.author.name)
@@ -368,7 +644,11 @@ class SongBot(commands.Bot):
         queue = await backend.get_queue(channel)
         my_prio = [q for q in queue if q['user_id'] == user_id and q['is_priority'] == 1]
         if len(my_prio) >= 3:
-            await msg.channel.send(self.messages['prioritize_limit'])
+            await self._send_message(
+                msg.channel,
+                self.messages['prioritize_limit'],
+                metadata={'channel': msg.channel.name, 'command': 'prioritize'},
+            )
             return
 
         # choose target: numeric id if given, else latest non-priority pending
@@ -380,7 +660,11 @@ class SongBot(commands.Bot):
             mine = [q for q in queue if q['user_id'] == user_id and q['played'] == 0 and q['is_priority'] == 0]
             target = mine[-1] if mine else None
         if not target:
-            await msg.channel.send(self.messages['prioritize_no_target'])
+            await self._send_message(
+                msg.channel,
+                self.messages['prioritize_no_target'],
+                metadata={'channel': msg.channel.name, 'command': 'prioritize'},
+            )
             return
 
         try:
@@ -394,67 +678,124 @@ class SongBot(commands.Bot):
                 is_subscriber=msg.author.is_subscriber,
             )
             await backend.delete_request(channel, target['id'])
-            await msg.channel.send(
-                self.messages['prioritize_success'].format(request_id=target['id'])
+            await self._send_message(
+                msg.channel,
+                self.messages['prioritize_success'].format(request_id=target['id']),
+                metadata={'channel': msg.channel.name, 'command': 'prioritize'},
             )
         except Exception as e:
-            await msg.channel.send(self.messages['failed'].format(error=e))
+            await push_console_event(
+                'error',
+                f'Failed to prioritize for {msg.author.name}: {e}',
+                metadata={'channel': msg.channel.name, 'command': 'prioritize'},
+            )
+            await self._send_message(
+                msg.channel,
+                self.messages['failed'].format(error=e),
+                metadata={'channel': msg.channel.name, 'command': 'prioritize'},
+            )
 
     async def handle_points(self, msg):
         ch_name = msg.channel.name.lower()
         ch_row = self.channel_map.get(ch_name)
         if not ch_row:
-            await msg.channel.send(self.messages['channel_not_registered'])
+            await self._send_message(
+                msg.channel,
+                self.messages['channel_not_registered'],
+                metadata={'channel': msg.channel.name, 'command': 'points'},
+            )
             return
         channel = ch_row['channel_name']
         user_id = await backend.find_or_create_user(channel, str(msg.author.id), msg.author.name)
         u = await backend.get_user(channel, user_id)
-        await msg.channel.send(
+        await self._send_message(
+            msg.channel,
             self.messages['points'].format(
                 username=msg.author.name,
                 points=u.get('prio_points', 0),
                 currency_plural=self.currency_plural,
-            )
+            ),
+            metadata={'channel': msg.channel.name, 'command': 'points'},
         )
 
     async def handle_remove(self, msg):
         ch_name = msg.channel.name.lower()
         ch_row = self.channel_map.get(ch_name)
         if not ch_row:
-            await msg.channel.send(self.messages['channel_not_registered'])
+            await self._send_message(
+                msg.channel,
+                self.messages['channel_not_registered'],
+                metadata={'channel': msg.channel.name, 'command': 'remove'},
+            )
             return
         channel = ch_row['channel_name']
         user_id = await backend.find_or_create_user(channel, str(msg.author.id), msg.author.name)
         queue = await backend.get_queue(channel)
         mine = [q for q in queue if q['user_id'] == user_id and q['played'] == 0]
         if not mine:
-            await msg.channel.send(self.messages['remove_no_pending'])
+            await self._send_message(
+                msg.channel,
+                self.messages['remove_no_pending'],
+                metadata={'channel': msg.channel.name, 'command': 'remove'},
+            )
             return
         latest = mine[-1]
         try:
             await backend.delete_request(channel, latest['id'])
-            await msg.channel.send(
-                self.messages['remove_success'].format(request_id=latest['id'])
+            await self._send_message(
+                msg.channel,
+                self.messages['remove_success'].format(request_id=latest['id']),
+                metadata={'channel': msg.channel.name, 'command': 'remove'},
             )
         except Exception as e:
-            await msg.channel.send(self.messages['failed'].format(error=e))
+            await push_console_event(
+                'error',
+                f'Failed to remove request for {msg.author.name}: {e}',
+                metadata={'channel': msg.channel.name, 'command': 'remove'},
+            )
+            await self._send_message(
+                msg.channel,
+                self.messages['failed'].format(error=e),
+                metadata={'channel': msg.channel.name, 'command': 'remove'},
+            )
 
     async def handle_archive(self, msg):
         if not (msg.author.is_mod or msg.author.is_broadcaster):
-            await msg.channel.send(self.messages['archive_denied'])
+            await self._send_message(
+                msg.channel,
+                self.messages['archive_denied'],
+                metadata={'channel': msg.channel.name, 'command': 'archive'},
+            )
             return
         ch_name = msg.channel.name.lower()
         ch_row = self.channel_map.get(ch_name)
         if not ch_row:
-            await msg.channel.send(self.messages['channel_not_registered'])
+            await self._send_message(
+                msg.channel,
+                self.messages['channel_not_registered'],
+                metadata={'channel': msg.channel.name, 'command': 'archive'},
+            )
             return
         channel = ch_row['channel_name']
         try:
             await backend.archive_stream(channel)
             await self.process_backend_update(channel)
-            await msg.channel.send(self.messages['archive_success'])
+            await self._send_message(
+                msg.channel,
+                self.messages['archive_success'],
+                metadata={'channel': msg.channel.name, 'command': 'archive'},
+            )
         except Exception as e:
-            await msg.channel.send(self.messages['failed'].format(error=e))
+            await push_console_event(
+                'error',
+                f'Failed to archive queue for {msg.author.name}: {e}',
+                metadata={'channel': msg.channel.name, 'command': 'archive'},
+            )
+            await self._send_message(
+                msg.channel,
+                self.messages['failed'].format(error=e),
+                metadata={'channel': msg.channel.name, 'command': 'archive'},
+            )
 
     async def listen_backend(self, ch_name: str):
         url = f"{backend.base}/channels/{ch_name}/queue/stream"
@@ -469,7 +810,13 @@ class SongBot(commands.Bot):
                             await self.process_backend_update(ch_name)
             except asyncio.CancelledError:
                 break
-            except Exception:
+            except Exception as exc:
+                await push_console_event(
+                    'error',
+                    f'Queue stream error for {ch_name}: {exc}',
+                    event='backend',
+                    metadata={'channel': ch_name},
+                )
                 await asyncio.sleep(5)
 
     async def process_backend_update(self, ch_name: str):
@@ -521,7 +868,11 @@ class SongBot(commands.Bot):
                         user=user.get('username', '?'),
                         channel=ch_name,
                     )
-                await chan.send(msg)
+                await self._send_message(
+                    chan,
+                    msg,
+                    metadata={'channel': ch_name, 'event': 'played'},
+                )
 
     async def check_bumps(self, ch_name: str, prev_queue: List[dict], new_queue: List[dict]):
         prev_map = {q['id']: q for q in prev_queue}
@@ -535,12 +886,14 @@ class SongBot(commands.Bot):
             if new_prio and not was_prio:
                 song = await backend.get_song(ch_name, req['song_id'])
                 user = await backend.get_user(ch_name, req['user_id'])
-                await chan.send(
+                await self._send_message(
+                    chan,
                     self.messages['bump_free'].format(
                         artist=song.get('artist', '?'),
                         title=song.get('title', '?'),
                         user=user.get('username', '?'),
-                    )
+                    ),
+                    metadata={'channel': ch_name, 'event': 'bump'},
                 )
 
     async def announce_event(self, ch_name: str, ev: dict):
@@ -572,21 +925,23 @@ class SongBot(commands.Bot):
         )
         template = self.messages.get(f"award_{etype}")
         if template:
-            await chan.send(
+            await self._send_message(
+                chan,
                 template.format(
                     username=user.get('username', ''),
                     word=word,
                     points=user.get('prio_points', 0),
                     currency_plural=self.currency_plural,
                     **extra,
-                )
+                ),
+                metadata={'channel': ch_name, 'event': etype},
             )
 
 # ---- entry ----
 async def main():
     await backend.start()
-    bot = SongBot()
-    await asyncio.gather(bot.start())
+    service = BotService(backend)
+    await service.run()
 
 if __name__ == '__main__':
     asyncio.run(main())

--- a/tests/test_bot_service.py
+++ b/tests/test_bot_service.py
@@ -1,0 +1,103 @@
+import asyncio
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import bot.bot_app as bot_app
+
+
+class BotServiceTests(unittest.IsolatedAsyncioTestCase):
+    async def asyncSetUp(self) -> None:
+        self._original_backend = bot_app.backend
+        self.backend = AsyncMock()
+        self.backend.push_bot_log = AsyncMock()
+        self.backend.get_bot_config = AsyncMock()
+        bot_app.backend = self.backend
+        self.created_bots: list[tuple[MagicMock, dict]] = []
+
+        def _bot_factory(**kwargs):
+            bot = MagicMock()
+            bot.start = AsyncMock()
+            bot.close = AsyncMock()
+            bot.update_enabled = AsyncMock()
+            ready_event = asyncio.Event()
+            ready_event.set()
+            bot.ready_event = ready_event
+            self.created_bots.append((bot, kwargs))
+            return bot
+
+        self.bot_factory = _bot_factory
+
+    async def asyncTearDown(self) -> None:
+        bot_app.backend = self._original_backend
+
+    async def test_apply_settings_uses_backend_credentials(self) -> None:
+        service = bot_app.BotService(
+            self.backend,
+            bot_factory=self.bot_factory,
+            task_factory=asyncio.create_task,
+        )
+        settings = bot_app.BotSettings(
+            token="backend-token",
+            refresh_token="refresh",
+            login="botnick",
+            enabled=True,
+        )
+
+        await service.apply_settings(settings)
+
+        self.assertEqual(len(self.created_bots), 1)
+        bot, kwargs = self.created_bots[0]
+        self.assertEqual(kwargs["token"], "oauth:backend-token")
+        self.assertEqual(kwargs["nick"], "botnick")
+        self.assertTrue(kwargs["enabled"])
+        bot.start.assert_called()
+
+    async def test_settings_fall_back_to_environment(self) -> None:
+        with patch.object(bot_app, "ENV_BOT_TOKEN", "env-token"), \
+             patch.object(bot_app, "ENV_BOT_NICK", "envnick"):
+            service = bot_app.BotService(
+                self.backend,
+                bot_factory=self.bot_factory,
+                task_factory=asyncio.create_task,
+            )
+            settings = service._settings_from_config({})
+        self.assertEqual(settings.token, "env-token")
+        self.assertEqual(settings.login, "envnick")
+        self.assertTrue(settings.enabled)
+
+    async def test_missing_credentials_idle_bot(self) -> None:
+        service = bot_app.BotService(
+            self.backend,
+            bot_factory=self.bot_factory,
+            task_factory=asyncio.create_task,
+        )
+        await service.apply_settings(
+            bot_app.BotSettings(token=None, refresh_token=None, login=None, enabled=False)
+        )
+        self.assertEqual(self.created_bots, [])
+        self.backend.push_bot_log.assert_awaited()
+
+    async def test_disable_stops_running_bot(self) -> None:
+        service = bot_app.BotService(
+            self.backend,
+            bot_factory=self.bot_factory,
+            task_factory=asyncio.create_task,
+        )
+        await service.apply_settings(
+            bot_app.BotSettings(token="abc", refresh_token=None, login="nick", enabled=True)
+        )
+        bot = self.created_bots[0][0]
+        bot.start.assert_called()
+
+        await service.apply_settings(
+            bot_app.BotSettings(token="abc", refresh_token=None, login="nick", enabled=False)
+        )
+        bot.close.assert_awaited()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- fetch bot credentials and enable state from the backend, falling back to environment variables only when nothing is stored
- replace the static Twitch token usage with a bot service controller that idles when disabled, restarts on credential changes, and streams join/message/error telemetry to the console log endpoint
- add isolated asyncio tests that mock the backend to ensure the controller obeys backend configuration and missing-credential scenarios

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68e55d321eb88328953efeb5150b3575