### PR TITLE
Adjust bot OAuth popup close behavior and add failure coverage

### DIFF
--- a/admin/public/admin.js
+++ b/admin/public/admin.js
@@ -1205,6 +1205,11 @@ async function startBotOAuthFlow() {
   }
 }
 
+/**
+ * Process OAuth completion messages from the bot authorization popup.
+ * Dependencies: window.postMessage payload from backend callback HTML and showBotAlert/loadBotConfig UI helpers.
+ * Variables used: API_ORIGIN (trusted origin), botOAuthWindow + botOAuthPending (popup lifecycle), botAuthorizeBtn/currentUser (button state).
+ */
 function handleBotOAuthMessage(event) {
   if (!event || !event.data || event.data.type !== 'bot-oauth-complete') {
     return;
@@ -1212,20 +1217,23 @@ function handleBotOAuthMessage(event) {
   if (API_ORIGIN && event.origin !== API_ORIGIN) {
     return;
   }
+  const payload = event.data || {};
+  const successful = payload.success === true;
   botOAuthPending = false;
-  if (botOAuthWindow && !botOAuthWindow.closed) {
+  if (successful && botOAuthWindow && !botOAuthWindow.closed) {
     try {
       botOAuthWindow.close();
     } catch (_) {
       // ignore errors closing popup
     }
   }
-  botOAuthWindow = null;
+  if (successful) {
+    botOAuthWindow = null;
+  }
   if (botAuthorizeBtn) {
     botAuthorizeBtn.disabled = !currentUser;
   }
-  const payload = event.data || {};
-  if (payload.success) {
+  if (successful) {
     showBotAlert('Bot authorization completed successfully.', 'info');
     loadBotConfig();
   } else {

--- a/backend_app.py
+++ b/backend_app.py
@@ -2241,12 +2241,22 @@ def _cleanup_bot_oauth_states() -> None:
 
 
 def _bot_oauth_html_response(success: bool, message: str, *, redirect_url: Optional[str] = None, status_code: int = 200) -> HTMLResponse:
+    """Build popup HTML for bot OAuth completion and notify the admin window via postMessage."""
     payload = {"type": "bot-oauth-complete", "success": success}
     if not success:
         payload["error"] = message
     script_payload = json.dumps(payload)
     message_text = html.escape(message or "")
     redirect_script = ""
+    close_script = ""
+    cta_text = "You can close this window."
+    if not success:
+        cta_text = "You may close this window."
+    else:
+        close_script = """
+        setTimeout(function() {
+          try { window.close(); } catch (err) { /* ignore */ }
+        }, 1500);"""
     if redirect_url:
         redirect_script = f"\n          setTimeout(function() {{ window.location.replace('{html.escape(redirect_url)}'); }}, 1200);"
     body = f"""<!DOCTYPE html>
@@ -2260,7 +2270,8 @@ def _bot_oauth_html_response(success: bool, message: str, *, redirect_url: Optio
   </head>
   <body>
     <h1>{'Success' if success else 'Authorization Failed'}</h1>
-    <p>{message_text or ('Authorization completed successfully. You can close this window.' if success else 'Unable to complete bot authorization.')}</p>
+    <p>{message_text or ('Authorization completed successfully.' if success else 'Unable to complete bot authorization.')}</p>
+    <p>{cta_text}</p>
     <script>
       (function() {{
         var payload = {script_payload};
@@ -2271,9 +2282,7 @@ def _bot_oauth_html_response(success: bool, message: str, *, redirect_url: Optio
             window.parent.postMessage(payload, '*');
           }}
         }} catch (err) {{ /* ignore */ }}
-        setTimeout(function() {{
-          try {{ window.close(); }} catch (err) {{ /* ignore */ }}
-        }}, 1500);{redirect_script}
+        {close_script}{redirect_script}
       }})();
     </script>
   </body>

--- a/docs/backend_api.md
+++ b/docs/backend_api.md
@@ -66,6 +66,13 @@ This document summarizes the REST endpoints exposed by `backend_app.py`.
 | POST | `/bot/config/oauth` | Start the OAuth authorization flow for the bot account (admin). |
 | GET | `/bot/config/oauth/callback` | Callback used by Twitch to finish the bot OAuth flow. |
 
+### `/bot/config/oauth/callback`
+- **Behavior**
+  - Returns a compact HTML page for popup-based OAuth flows.
+  - Posts `{"type":"bot-oauth-complete","success":<bool>,"error"?:<string>}` to the opener/parent window so the admin panel can render a success or error banner.
+  - Auto-closes the popup only on success; failure responses stay open so the error message remains visible for debugging.
+  - Includes a short CTA in the popup (`"You may close this window."` on failures).
+
 ## Bot Logs
 | Method | Path | Description |
 |--------|------|-------------|
@@ -354,4 +361,3 @@ All payloads only expose queue-facing data:
 - **Authentication**: Requires `X-Admin-Token` or a valid bearer token/session cookie. No additional role check is enforced beyond token validity.
 - **Payload**: `{ "active": <bool>, "error": "<optional last error>" }`.
 - **Behavior**: Ensures a `ChannelBotState` row exists, updates `active` and `last_error`, persists changes, and emits a queue change notification.
-

--- a/tests/test_bot_config.py
+++ b/tests/test_bot_config.py
@@ -363,6 +363,24 @@ class BotConfigApiTests(unittest.TestCase):
             "https://secure.example.com/bot/config/oauth/callback",
         )
 
+    def test_bot_oauth_html_response_success_auto_closes_popup(self) -> None:
+        response = backend_app._bot_oauth_html_response(True, "Success message")
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("Success message", response.body.decode())
+        self.assertIn("setTimeout(function() {", response.body.decode())
+        self.assertIn("window.close()", response.body.decode())
+        self.assertIn("You can close this window.", response.body.decode())
+
+    def test_bot_oauth_html_response_failure_keeps_popup_open(self) -> None:
+        response = backend_app._bot_oauth_html_response(False, "OAuth denied by broadcaster")
+        self.assertEqual(response.status_code, 200)
+        html_body = response.body.decode()
+        self.assertIn("OAuth denied by broadcaster", html_body)
+        self.assertIn('"success": false', html_body)
+        self.assertIn('"error": "OAuth denied by broadcaster"', html_body)
+        self.assertIn("You may close this window.", html_body)
+        self.assertNotIn("window.close()", html_body)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
### Motivation
- Prevent the admin panel from auto-closing the bot OAuth popup when the flow failed so error details remain visible for debugging.
- Make the popup HTML and callback behavior explicit and document it so callers know when the window will auto-close.

### Description
- Change `handleBotOAuthMessage` in `admin/public/admin.js` to treat success strictly as `payload.success === true`, only close `botOAuthWindow` on success, and added a short header describing dependencies and used variables.
- Update `_bot_oauth_html_response` in `backend_app.py` to only schedule `window.close()` when the OAuth result is successful, include a short CTA line in the popup (uses "You may close this window." for failures), and add a docstring describing the helper.
- Add backend tests in `tests/test_bot_config.py` that assert the popup HTML auto-closes on success and remains open (with visible error payload/CTA) on failure.
- Update `docs/backend_api.md` to document the `/bot/config/oauth/callback` popup behavior and posted message payload format.

### Testing
- Ran `pytest -q tests/test_bot_config.py` and the test suite passed (12 tests, all green).
- Verified the new HTML-response unit tests confirm success includes `window.close()` and the failure response omits `window.close()` while exposing the error payload and CTA text.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c85c4c39688328a4a4cb2802322e9d)