### PR TITLE
Add bot_message_level support to channel settings API and schema

### DIFF
--- a/backend_app.py
+++ b/backend_app.py
@@ -163,8 +163,8 @@ def ensure_channel_settings_schema() -> None:
     Code customers: Startup bootstrap that needs the latest settings columns
     before serving traffic.
     Used variables/origin: Operates on the ``channel_settings`` table and adds
-    the ``full_auto_priority_mode`` flag plus priority pricing columns with
-    defaults when absent.
+    the ``full_auto_priority_mode`` flag, priority pricing columns, and
+    ``bot_message_level`` with defaults when absent.
     """
 
     inspector = inspect(engine)
@@ -187,13 +187,19 @@ def ensure_channel_settings_schema() -> None:
         "prio_reset_points_vip": "ALTER TABLE channel_settings ADD COLUMN prio_reset_points_vip INTEGER NOT NULL DEFAULT 0",
         "prio_reset_points_mod": "ALTER TABLE channel_settings ADD COLUMN prio_reset_points_mod INTEGER NOT NULL DEFAULT 0",
         "free_mod_priority_requests": "ALTER TABLE channel_settings ADD COLUMN free_mod_priority_requests INTEGER NOT NULL DEFAULT 0",
+        "bot_message_level": "ALTER TABLE channel_settings ADD COLUMN bot_message_level VARCHAR NOT NULL DEFAULT 'normal'",
     }
-    missing = {name: ddl for name, ddl in required_columns.items() if name not in columns}
-    if not missing:
-        return
     with engine.begin() as conn:
+        missing = {name: ddl for name, ddl in required_columns.items() if name not in columns}
         for ddl in missing.values():
             conn.execute(text(ddl))
+        if "bot_message_level" in columns:
+            conn.execute(
+                text(
+                    "UPDATE channel_settings SET bot_message_level = 'normal' "
+                    "WHERE bot_message_level IS NULL OR bot_message_level = ''"
+                )
+            )
 
 
 def backfill_missing_channel_keys() -> None:
@@ -810,6 +816,7 @@ class ChannelSettings(Base):
     prio_reset_points_vip = Column(Integer, default=0)
     prio_reset_points_mod = Column(Integer, default=0)
     free_mod_priority_requests = Column(Integer, default=0)
+    bot_message_level = Column(String, default="normal", nullable=False)
 
     channel = relationship("ActiveChannel", back_populates="settings")
 
@@ -1002,7 +1009,8 @@ def _ensure_channel_settings_schema() -> None:
     emitters, and tests that assume queue capacity fields exist.
     Used variables/origin: Reads the discovered column names from the inspector
     and applies a default of ``100`` for both ``overall_queue_cap`` and
-    ``nonpriority_queue_cap`` when adding or backfilling those fields.
+    ``nonpriority_queue_cap`` plus ``"normal"`` for ``bot_message_level`` when
+    adding or backfilling those fields.
     """
 
     with engine.begin() as connection:
@@ -1060,6 +1068,21 @@ def _ensure_channel_settings_schema() -> None:
         for name, ddl in pricing_columns.items():
             if name not in columns:
                 connection.execute(text(ddl))
+
+        if "bot_message_level" not in columns:
+            connection.execute(
+                text(
+                    "ALTER TABLE channel_settings "
+                    "ADD COLUMN bot_message_level VARCHAR NOT NULL DEFAULT 'normal'"
+                )
+            )
+        else:
+            connection.execute(
+                text(
+                    "UPDATE channel_settings SET bot_message_level = 'normal' "
+                    "WHERE bot_message_level IS NULL OR bot_message_level = ''"
+                )
+            )
 
 
 def _ensure_playlist_schema() -> None:
@@ -1215,6 +1238,7 @@ class ChannelSettingsBase(BaseModel):
     prio_reset_points_vip: int = Field(0, ge=0)
     prio_reset_points_mod: int = Field(0, ge=0)
     free_mod_priority_requests: int = 0
+    bot_message_level: Literal["mute", "normal", "verbose", "debug"] = "normal"
 
 
 class ChannelSettingsUpdate(BaseModel):
@@ -1240,6 +1264,7 @@ class ChannelSettingsUpdate(BaseModel):
     prio_reset_points_vip: Optional[int] = Field(None, ge=0)
     prio_reset_points_mod: Optional[int] = Field(None, ge=0)
     free_mod_priority_requests: Optional[int] = None
+    bot_message_level: Optional[Literal["mute", "normal", "verbose", "debug"]] = None
 
 
 class ChannelSettingsOut(ChannelSettingsBase):
@@ -2068,6 +2093,16 @@ def _next_priority_request(
 
 
 def _serialize_settings_event(settings: ChannelSettings) -> Dict[str, Any]:
+    """Serialize persisted settings into a stable event payload dictionary.
+
+    Dependencies: Reads fields from the provided ``ChannelSettings`` ORM
+    instance.
+    Code customers: Settings update routes and websocket publishers emitting the
+    ``settings.updated`` event.
+    Used variables/origin: Pulls each settings attribute, including
+    ``bot_message_level``, from ``settings``.
+    """
+
     return {
         "max_requests_per_user": settings.max_requests_per_user,
         "prio_only": settings.prio_only,
@@ -2091,6 +2126,7 @@ def _serialize_settings_event(settings: ChannelSettings) -> Dict[str, Any]:
         "prio_reset_points_vip": settings.prio_reset_points_vip,
         "prio_reset_points_mod": settings.prio_reset_points_mod,
         "free_mod_priority_requests": settings.free_mod_priority_requests,
+        "bot_message_level": settings.bot_message_level,
     }
 
 
@@ -3205,7 +3241,8 @@ def get_or_create_settings(db: Session, channel_pk: int) -> ChannelSettings:
     queue enforcement, playlist helpers, and channel metadata endpoints.
     Used variables/origin: Receives ``channel_pk`` from upstream path parameters
     or ownership checks, and writes default values onto the settings row when
-    ``overall_queue_cap`` or ``nonpriority_queue_cap`` are unset.
+    ``overall_queue_cap``, ``nonpriority_queue_cap``, or
+    ``bot_message_level`` are unset.
     """
 
     st = db.query(ChannelSettings).filter(ChannelSettings.channel_id == channel_pk).one_or_none()
@@ -3241,6 +3278,9 @@ def get_or_create_settings(db: Session, channel_pk: int) -> ChannelSettings:
         if getattr(st, field, None) is None:
             setattr(st, field, default_value)
             backfilled = True
+    if not st.bot_message_level:
+        st.bot_message_level = "normal"
+        backfilled = True
 
     if created or backfilled:
         db.commit()
@@ -4379,6 +4419,7 @@ def get_channel_settings(channel: str, db: Session = Depends(get_db)):
         prio_reset_points_vip=st.prio_reset_points_vip,
         prio_reset_points_mod=st.prio_reset_points_mod,
         free_mod_priority_requests=st.free_mod_priority_requests,
+        bot_message_level=st.bot_message_level,
     )
 
 

--- a/docs/backend_api.md
+++ b/docs/backend_api.md
@@ -99,6 +99,7 @@ Channel settings include queue intake controls:
 - `overall_queue_cap` (0–100, default 100) auto-closes intake once pending requests reach the cap and emits a `queue.status` event.
 - `nonpriority_queue_cap` (0–100, default 100) rejects new non-priority submissions when full while still allowing priority requests.
 - `prio_only`, `max_requests_per_user`, `allow_bumps`, `other_flags`, and `max_prio_points` behave as before and are reflected in `settings.updated` events.
+- `bot_message_level` controls how chatty the bot is in channel responses; allowed values are exactly `mute`, `normal`, `verbose`, and `debug` (default `normal`).
 - Priority point pricing is configurable: `prio_follow_enabled`, `prio_raid_enabled`, `prio_bits_per_point`, `prio_gifts_per_point`, and per-tier fields (`prio_sub_tier1_points`, `prio_sub_tier2_points`, `prio_sub_tier3_points`) control how many points events grant. Reset bonuses (`prio_reset_points_tier1`, `prio_reset_points_tier2`, `prio_reset_points_tier3`, `prio_reset_points_vip`, `prio_reset_points_mod`) are awarded when the queue resets for a new stream. Use `free_mod_priority_requests` to allow moderators to request priority without spending points.
 - Existing deployments should apply `migrations/20240624_queue_caps.sql` to add the new capacity columns and backfill defaults for legacy channels; the application also attempts to patch missing columns on startup for SQLite/legacy installs before enforcing queue caps.
 
@@ -314,7 +315,7 @@ All payloads only expose queue-facing data:
 - `request.played` — payload `{ "request": <request summary>, "up_next": <request summary>|null }`, where `up_next` is the next pending request after the played entry.
 - `queue.status` — payload `{ "closed": bool, "status": "open"|"closed"|"limited", "reason"?: str }` indicating whether the queue accepts new requests or has restricted non-priority slots. Hitting the overall queue cap flips the queue to `closed` until it is reopened.
 - `queue.archived` — payload `{ "archived_stream_id": int|null, "new_stream_id": int }` describing the stream transition when archiving.
-- `settings.updated` — payload mirroring the settings fields (`max_requests_per_user`, `prio_only`, `queue_closed`, `allow_bumps`, `other_flags`, `max_prio_points`, `overall_queue_cap`, `nonpriority_queue_cap`) after merges.
+- `settings.updated` — payload mirroring the settings fields (`max_requests_per_user`, `prio_only`, `queue_closed`, `allow_bumps`, `other_flags`, `max_prio_points`, `overall_queue_cap`, `nonpriority_queue_cap`, `bot_message_level`) after merges.
 - `user.bump_awarded` — payload `{ "user": { "id", "username" }, "delta": int, "prio_points": int }` when a user earns additional priority points.
 
 ## Streams

--- a/tests/test_channel_events.py
+++ b/tests/test_channel_events.py
@@ -420,7 +420,33 @@ class ChannelEventTests(unittest.TestCase):
         self.assertEqual(updated["max_prio_points"], 42)
         self.assertEqual(updated["overall_queue_cap"], 77)
 
+    def test_bot_message_level_defaults_updates_and_rejects_invalid_values(self) -> None:
+        details = _setup_channel()
+        channel = details["channel_name"]
+        headers = {"X-Admin-Token": backend_app.ADMIN_TOKEN}
+
+        initial = self.client.get(f"/channels/{channel}/settings", headers=headers)
+        self.assertEqual(initial.status_code, 200, initial.text)
+        self.assertEqual(initial.json()["bot_message_level"], "normal")
+
+        update = self.client.put(
+            f"/channels/{channel}/settings",
+            json={"bot_message_level": "debug"},
+            headers=headers,
+        )
+        self.assertEqual(update.status_code, 200, update.text)
+
+        after_update = self.client.get(f"/channels/{channel}/settings", headers=headers)
+        self.assertEqual(after_update.status_code, 200, after_update.text)
+        self.assertEqual(after_update.json()["bot_message_level"], "debug")
+
+        invalid = self.client.put(
+            f"/channels/{channel}/settings",
+            json={"bot_message_level": "loud"},
+            headers=headers,
+        )
+        self.assertEqual(invalid.status_code, 422, invalid.text)
+
 
 if __name__ == "__main__":
     unittest.main()
-


### PR DESCRIPTION
### Motivation
- Expose a configurable bot verbosity setting so channels can control how chatty the bot is in responses.
- Ensure this new setting is persisted and available via existing GET/PUT `/channels/{channel}/settings` routes and settings event payloads.
- Keep behavior backward-compatible so legacy rows and deployments default to `normal` without manual migration steps.

### Description
- Added a persisted `bot_message_level` column (`String`, `NOT NULL`, default `"normal"`) to `ChannelSettings` and updated both schema migration helpers (`ensure_channel_settings_schema` and `_ensure_channel_settings_schema`) to add and backfill the column for legacy DBs.
- Extended API schemas: `ChannelSettingsBase`, `ChannelSettingsUpdate`, and `ChannelSettingsOut` now include `bot_message_level` constrained by `Literal["mute","normal","verbose","debug"]` so invalid values produce FastAPI/Pydantic 422 validation errors.
- Pulled the field through the codepath by adding it to `_serialize_settings_event`, `get_channel_settings`, and `get_or_create_settings` (which backfills missing values to `"normal"`), and ensured `_apply_settings_patch` allows updates to persist.
- Updated documentation (`docs/backend_api.md`) to document the new option and added tests (`tests/test_channel_events.py`) that assert defaulting, persistence on update, and rejection of invalid values.

### Testing
- Ran targeted tests after preparing the SQLite path: `mkdir -p /data && python -m pytest tests/test_channel_events.py -k "partial_settings_updates_preserve_existing_values or bot_message_level_defaults_updates_and_rejects_invalid_values" -q` which passed the selected cases.
- Ran the full channel events test file with `python -m pytest tests/test_channel_events.py -q` and observed `6 passed` (with unrelated warnings), confirming default, update, and invalid-value behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c910a206448328b2155f401313bd04)