### PR TITLE
Add admin bot message catalog API and consume it in admin UI

### DIFF
--- a/admin/public/admin.js
+++ b/admin/public/admin.js
@@ -106,44 +106,7 @@ const state = {
   channelUiState: {},
 };
 const BOT_MESSAGE_LEVELS = ['mute', 'normal', 'verbose', 'debug'];
-const BOT_MESSAGE_LEVEL_DESCRIPTIONS = {
-  mute: 'Mute — suppress all bot chat messages for this channel.',
-  normal: 'Normal — core command and error responses.',
-  verbose: 'Verbose — Normal plus lifecycle/reward/queue activity updates.',
-  debug: 'Debug — Verbose plus diagnostics intended for troubleshooting.',
-};
-const BOT_MESSAGE_CATALOG_FALLBACK = [
-  { id: 'channel_not_registered', level: 'normal', category: 'commands', description: 'Command target channel is not registered.' },
-  { id: 'request_added', level: 'normal', category: 'commands', description: 'User song request accepted.' },
-  { id: 'random_request_added', level: 'normal', category: 'commands', description: 'Random playlist request accepted.' },
-  { id: 'random_not_found', level: 'normal', category: 'commands', description: 'Random playlist keyword did not match any playlist.' },
-  { id: 'playlist_request_added', level: 'normal', category: 'commands', description: 'Playlist song request accepted.' },
-  { id: 'playlist_not_found', level: 'normal', category: 'commands', description: 'Playlist command referenced a missing playlist.' },
-  { id: 'playlist_song_missing', level: 'normal', category: 'commands', description: 'Playlist command referenced an out-of-range song index.' },
-  { id: 'playlist_usage', level: 'normal', category: 'commands', description: 'Playlist command usage guidance.' },
-  { id: 'prioritize_limit', level: 'normal', category: 'commands', description: 'User reached prioritize limit.' },
-  { id: 'prioritize_no_target', level: 'normal', category: 'commands', description: 'No eligible request to prioritize.' },
-  { id: 'prioritize_success', level: 'normal', category: 'commands', description: 'Request prioritized successfully.' },
-  { id: 'points', level: 'normal', category: 'commands', description: 'Points command response.' },
-  { id: 'remove_no_pending', level: 'normal', category: 'commands', description: 'Remove command found no pending requests.' },
-  { id: 'remove_success', level: 'normal', category: 'commands', description: 'Remove command deleted latest request.' },
-  { id: 'archive_success', level: 'normal', category: 'commands', description: 'Queue archive command succeeded.' },
-  { id: 'archive_denied', level: 'normal', category: 'commands', description: 'Archive command denied due to missing permissions.' },
-  { id: 'failed', level: 'normal', category: 'errors', description: 'Command failed with a user-facing error.' },
-  { id: 'bot_joined', level: 'verbose', category: 'lifecycle', description: 'Bot joined channel chat.' },
-  { id: 'bot_left', level: 'verbose', category: 'lifecycle', description: 'Bot left channel chat.' },
-  { id: 'played_next', level: 'verbose', category: 'queue', description: 'Playback advanced and next prioritized song announced.' },
-  { id: 'played_last', level: 'verbose', category: 'queue', description: 'Playback advanced and no prioritized songs remain.' },
-  { id: 'bump_free', level: 'verbose', category: 'rewards', description: 'Automatic free bump was granted.' },
-  { id: 'award_follow', level: 'verbose', category: 'rewards', description: 'Follow reward points announcement.' },
-  { id: 'award_raid', level: 'verbose', category: 'rewards', description: 'Raid reward points announcement.' },
-  { id: 'award_gift_sub', level: 'verbose', category: 'rewards', description: 'Gifted subscription reward points announcement.' },
-  { id: 'award_bits', level: 'verbose', category: 'rewards', description: 'Bits reward points announcement.' },
-  { id: 'vip_points_awarded', level: 'verbose', category: 'rewards', description: 'VIP reward points announcement.' },
-  { id: 'queue_position_changed', level: 'verbose', category: 'queue', description: 'Queue item moved to a new position.' },
-  { id: 'token_refreshed', level: 'debug', category: 'lifecycle', description: 'Token refresh succeeded.' },
-  { id: 'action_failed_debug', level: 'debug', category: 'errors', description: 'Internal action failure diagnostic.' },
-];
+let botMessageLevelDescriptions = {};
 let botMessageCatalogCache = null;
 const channelListEl = document.getElementById('channel-list');
 const treeEl = document.getElementById('channel-tree');
@@ -592,28 +555,26 @@ function renderSettings(container, settings) {
 
 /**
  * Retrieve bot message catalog metadata for the channel settings panel.
- * Dependencies: backend optional endpoint `/bot/messages/catalog`; fallback
- * uses shared catalog entries mirrored from bot/bot_app.py.
+ * Dependencies: backend endpoint `/bot/messages/catalog` and fetchJson helper.
  * Code customers: renderBotMessagesPanel matrix/list UI.
  * Variables used/origin: `API` for endpoint base and module-level
- * `botMessageCatalogCache` memoization for repeat calls.
+ * `botMessageCatalogCache` + `botMessageLevelDescriptions` memoization.
  */
 async function loadBotMessageCatalog() {
-  if (Array.isArray(botMessageCatalogCache)) {
+  if (botMessageCatalogCache && Array.isArray(botMessageCatalogCache.messages)) {
     return botMessageCatalogCache;
   }
-  try {
-    const payload = await fetchJson('/bot/messages/catalog');
-    if (Array.isArray(payload)) {
-      botMessageCatalogCache = payload;
-    } else if (Array.isArray(payload?.items)) {
-      botMessageCatalogCache = payload.items;
-    } else {
-      botMessageCatalogCache = BOT_MESSAGE_CATALOG_FALLBACK;
+  const payload = await fetchJson('/bot/messages/catalog');
+  const levels = Array.isArray(payload?.levels) ? payload.levels : [];
+  const messages = Array.isArray(payload?.messages) ? payload.messages : [];
+  botMessageLevelDescriptions = levels.reduce((acc, levelEntry) => {
+    const key = typeof levelEntry?.level === 'string' ? levelEntry.level : '';
+    if (key && typeof levelEntry?.description === 'string') {
+      acc[key] = levelEntry.description;
     }
-  } catch (err) {
-    botMessageCatalogCache = BOT_MESSAGE_CATALOG_FALLBACK;
-  }
+    return acc;
+  }, {});
+  botMessageCatalogCache = { levels, messages };
   return botMessageCatalogCache;
 }
 
@@ -694,14 +655,14 @@ async function renderBotMessagesPanel(container, channelName, settings) {
   });
   const selectorHelp = document.createElement('div');
   selectorHelp.className = 'form-hint';
-  selectorHelp.textContent = BOT_MESSAGE_LEVEL_DESCRIPTIONS[panelState.selectedLevel] || '';
+  selectorHelp.textContent = botMessageLevelDescriptions[panelState.selectedLevel] || '';
   selector.addEventListener('change', async () => {
     const nextLevel = selector.value;
     selector.disabled = true;
     try {
       const updated = await saveChannelBotMessageLevel(channelName, nextLevel);
       panelState.selectedLevel = updated?.bot_message_level || nextLevel;
-      selectorHelp.textContent = BOT_MESSAGE_LEVEL_DESCRIPTIONS[panelState.selectedLevel] || '';
+      selectorHelp.textContent = botMessageLevelDescriptions[panelState.selectedLevel] || '';
       await renderBotMessagesPanel(container, channelName, updated);
     } catch (err) {
       console.error('failed to update bot message level', channelName, err);
@@ -716,8 +677,17 @@ async function renderBotMessagesPanel(container, channelName, settings) {
   controlWrap.appendChild(selectorHelp);
   container.appendChild(controlWrap);
 
-  const catalog = await loadBotMessageCatalog();
-  const rows = Array.isArray(catalog) ? catalog.slice() : [];
+  let catalog = null;
+  try {
+    catalog = await loadBotMessageCatalog();
+  } catch (err) {
+    const empty = document.createElement('div');
+    empty.className = 'empty';
+    empty.textContent = err instanceof Error ? err.message : 'Bot message catalog metadata unavailable.';
+    container.appendChild(empty);
+    return;
+  }
+  const rows = Array.isArray(catalog?.messages) ? catalog.messages.slice() : [];
   rows.sort((a, b) => String(a.id || '').localeCompare(String(b.id || '')));
   if (!rows.length) {
     const empty = document.createElement('div');
@@ -743,9 +713,10 @@ async function renderBotMessagesPanel(container, channelName, settings) {
 
     const meta = document.createElement('div');
     meta.className = 'bot-message-meta';
-    const category = entry.category ? `Category: ${entry.category}` : 'Category: uncategorized';
+    const category = entry.group ? `Category: ${entry.group}` : 'Category: uncategorized';
     const included = messageIncludedInLevel(level, panelState.selectedLevel);
-    meta.textContent = `${category} • ${included ? 'Included' : 'Excluded'} at current level`;
+    const customizableText = entry.customizable === false ? 'Fixed template' : 'Customizable template';
+    meta.textContent = `${category} • ${included ? 'Included' : 'Excluded'} at current level • ${customizableText}`;
     card.appendChild(meta);
 
     if (entry.description) {
@@ -753,6 +724,12 @@ async function renderBotMessagesPanel(container, channelName, settings) {
       desc.className = 'bot-message-desc';
       desc.textContent = entry.description;
       card.appendChild(desc);
+    }
+    if (entry.template_key && entry.template_key !== entry.id) {
+      const template = document.createElement('div');
+      template.className = 'bot-message-desc';
+      template.textContent = `Template key: ${entry.template_key}`;
+      card.appendChild(template);
     }
     grid.appendChild(card);
   });

--- a/backend_app.py
+++ b/backend_app.py
@@ -109,6 +109,58 @@ EVENTSUB_EVENT_MAP: dict[str, str] = {
     "channel.subscription.gift": "gift_sub",
 }
 
+BOT_MESSAGE_LEVEL_DETAILS: list[dict[str, str]] = [
+    {
+        "level": "mute",
+        "description": "Mute — suppress all bot chat messages for this channel.",
+    },
+    {
+        "level": "normal",
+        "description": "Normal — core command and error responses.",
+    },
+    {
+        "level": "verbose",
+        "description": "Verbose — Normal plus lifecycle/reward/queue activity updates.",
+    },
+    {
+        "level": "debug",
+        "description": "Debug — Verbose plus diagnostics intended for troubleshooting.",
+    },
+]
+
+BOT_MESSAGE_CATALOG: list[dict[str, Any]] = [
+    {"id": "channel_not_registered", "level": "normal", "group": "commands", "template_key": "channel_not_registered", "description": "Command target channel is not registered.", "customizable": True},
+    {"id": "request_added", "level": "normal", "group": "commands", "template_key": "request_added", "description": "User song request accepted.", "customizable": True},
+    {"id": "random_request_added", "level": "normal", "group": "commands", "template_key": "random_request_added", "description": "Random playlist request accepted.", "customizable": True},
+    {"id": "random_not_found", "level": "normal", "group": "commands", "template_key": "random_not_found", "description": "Random playlist keyword did not match any playlist.", "customizable": True},
+    {"id": "playlist_request_added", "level": "normal", "group": "commands", "template_key": "playlist_request_added", "description": "Playlist song request accepted.", "customizable": True},
+    {"id": "playlist_not_found", "level": "normal", "group": "commands", "template_key": "playlist_not_found", "description": "Playlist command referenced a missing playlist.", "customizable": True},
+    {"id": "playlist_song_missing", "level": "normal", "group": "commands", "template_key": "playlist_song_missing", "description": "Playlist command referenced an out-of-range song index.", "customizable": True},
+    {"id": "playlist_usage", "level": "normal", "group": "commands", "template_key": "playlist_usage", "description": "Playlist command usage guidance.", "customizable": True},
+    {"id": "prioritize_limit", "level": "normal", "group": "commands", "template_key": "prioritize_limit", "description": "User reached prioritize limit.", "customizable": True},
+    {"id": "prioritize_no_target", "level": "normal", "group": "commands", "template_key": "prioritize_no_target", "description": "No eligible request to prioritize.", "customizable": True},
+    {"id": "prioritize_success", "level": "normal", "group": "commands", "template_key": "prioritize_success", "description": "Request prioritized successfully.", "customizable": True},
+    {"id": "points", "level": "normal", "group": "commands", "template_key": "points", "description": "Points command response.", "customizable": True},
+    {"id": "remove_no_pending", "level": "normal", "group": "commands", "template_key": "remove_no_pending", "description": "Remove command found no pending requests.", "customizable": True},
+    {"id": "remove_success", "level": "normal", "group": "commands", "template_key": "remove_success", "description": "Remove command deleted latest request.", "customizable": True},
+    {"id": "archive_success", "level": "normal", "group": "commands", "template_key": "archive_success", "description": "Queue archive command succeeded.", "customizable": True},
+    {"id": "archive_denied", "level": "normal", "group": "commands", "template_key": "archive_denied", "description": "Archive command denied due to missing permissions.", "customizable": True},
+    {"id": "failed", "level": "normal", "group": "errors", "template_key": "failed", "description": "Command failed with a user-facing error.", "customizable": True},
+    {"id": "bot_joined", "level": "verbose", "group": "lifecycle", "template_key": "bot_joined", "description": "Bot joined channel chat.", "customizable": True},
+    {"id": "bot_left", "level": "verbose", "group": "lifecycle", "template_key": "bot_left", "description": "Bot left channel chat.", "customizable": True},
+    {"id": "played_next", "level": "verbose", "group": "queue", "template_key": "played_next", "description": "Playback advanced and next prioritized song announced.", "customizable": True},
+    {"id": "played_last", "level": "verbose", "group": "queue", "template_key": "played_last", "description": "Playback advanced and no prioritized songs remain.", "customizable": True},
+    {"id": "bump_free", "level": "verbose", "group": "rewards", "template_key": "bump_free", "description": "Automatic free bump was granted.", "customizable": True},
+    {"id": "award_follow", "level": "verbose", "group": "rewards", "template_key": "award_follow", "description": "Follow reward points announcement.", "customizable": True},
+    {"id": "award_raid", "level": "verbose", "group": "rewards", "template_key": "award_raid", "description": "Raid reward points announcement.", "customizable": True},
+    {"id": "award_gift_sub", "level": "verbose", "group": "rewards", "template_key": "award_gift_sub", "description": "Gifted subscription reward points announcement.", "customizable": True},
+    {"id": "award_bits", "level": "verbose", "group": "rewards", "template_key": "award_bits", "description": "Bits reward points announcement.", "customizable": True},
+    {"id": "vip_points_awarded", "level": "verbose", "group": "rewards", "template_key": "vip_points_awarded", "description": "VIP reward points announcement.", "customizable": True},
+    {"id": "queue_position_changed", "level": "verbose", "group": "queue", "template_key": "queue_position_changed", "description": "Queue item moved to a new position.", "customizable": True},
+    {"id": "token_refreshed", "level": "debug", "group": "lifecycle", "template_key": "token_refreshed", "description": "Token refresh succeeded.", "customizable": True},
+    {"id": "action_failed_debug", "level": "debug", "group": "errors", "template_key": "action_failed_debug", "description": "Internal action failure diagnostic.", "customizable": True},
+]
+
 _bot_log_listeners: set[asyncio.Queue[str]] = set()
 _bot_oauth_states: dict[str, Dict[str, Any]] = {}
 
@@ -1321,6 +1373,25 @@ class BotConfigUpdate(BaseModel):
     scopes: Optional[List[str]] = None
     display_name: Optional[str] = None
     login: Optional[str] = None
+
+
+class BotMessageLevelDetailOut(BaseModel):
+    level: Literal["mute", "normal", "verbose", "debug"]
+    description: str
+
+
+class BotMessageCatalogEntryOut(BaseModel):
+    id: str
+    level: Literal["mute", "normal", "verbose", "debug"]
+    group: Optional[str] = None
+    template_key: str
+    description: str
+    customizable: bool = True
+
+
+class BotMessageCatalogOut(BaseModel):
+    levels: List[BotMessageLevelDetailOut]
+    messages: List[BotMessageCatalogEntryOut]
 
 
 class BotTokenUpdateIn(BaseModel):
@@ -2814,6 +2885,27 @@ def bot_config(
     cfg = _get_bot_config(db)
     include_tokens = x_admin_token == ADMIN_TOKEN
     return _serialize_bot_config(cfg, include_tokens=include_tokens)
+
+
+@app.get(
+    "/bot/messages/catalog",
+    response_model=BotMessageCatalogOut,
+    dependencies=[Depends(require_token)],
+)
+def bot_message_catalog() -> BotMessageCatalogOut:
+    """Return stable bot message metadata used by admin channel settings UI.
+
+    Dependencies: Secured by `require_token`; data source is module-level
+    constants maintained alongside backend API contracts.
+    Code customers: `admin/public/admin.js` bot message panel rendering.
+    Used variables/origin: `BOT_MESSAGE_LEVEL_DETAILS` and
+    `BOT_MESSAGE_CATALOG` are transformed into typed response models.
+    """
+
+    return BotMessageCatalogOut(
+        levels=[BotMessageLevelDetailOut(**level_row) for level_row in BOT_MESSAGE_LEVEL_DETAILS],
+        messages=[BotMessageCatalogEntryOut(**message_row) for message_row in BOT_MESSAGE_CATALOG],
+    )
 
 
 @app.put(

--- a/docs/backend_api.md
+++ b/docs/backend_api.md
@@ -62,9 +62,19 @@ This document summarizes the REST endpoints exposed by `backend_app.py`.
 | Method | Path | Description |
 |--------|------|-------------|
 | GET | `/bot/config` | Retrieve the stored bot OAuth configuration (admin). |
+| GET | `/bot/messages/catalog` | Return stable bot message levels/catalog metadata for admin UI rendering (admin). |
 | PUT | `/bot/config` | Update bot settings such as scopes or enable flag (admin). |
 | POST | `/bot/config/oauth` | Start the OAuth authorization flow for the bot account (admin). |
 | GET | `/bot/config/oauth/callback` | Callback used by Twitch to finish the bot OAuth flow. |
+
+### `/bot/messages/catalog`
+- **Authentication**: Requires admin authorization (`X-Admin-Token`, bearer token, or admin session cookie) via `require_token`.
+- **Behavior**
+  - Returns a stable contract with two top-level arrays: `levels` and `messages`.
+  - `levels` is ordered by verbosity (`mute`, `normal`, `verbose`, `debug`) and includes short descriptions for each selector option.
+  - `messages` includes metadata rows with `{ "id", "level", "group", "template_key", "description", "customizable" }`.
+  - `customizable` is currently `true` for all default entries and is included so UI clients can evolve to per-message override controls without a breaking API change.
+- **Response**: `{ "levels": [BotMessageLevelDetailOut], "messages": [BotMessageCatalogEntryOut] }`.
 
 ### `/bot/config/oauth/callback`
 - **Behavior**


### PR DESCRIPTION
### Motivation
- Expose a stable, admin-authenticated catalog of bot message levels and message metadata so the admin UI can render and evolve per-message overrides instead of relying on hardcoded lists.
- Provide a simple, forward-compatible contract that includes ordered `levels` with descriptions and `messages` rows including `customizable` so the UI can evolve without a breaking change.

### Description
- Added module-level constants `BOT_MESSAGE_LEVEL_DETAILS` and `BOT_MESSAGE_CATALOG` as the canonical data source for bot message levels and metadata (`id`, `level`, `group`, `template_key`, `description`, `customizable`).
- Added response schemas `BotMessageLevelDetailOut`, `BotMessageCatalogEntryOut`, and `BotMessageCatalogOut` to `backend_app.py` for an explicit typed API contract.
- Implemented a new admin-protected route `GET /bot/messages/catalog` (uses `require_token`) that returns the typed payload built from the module constants and includes a docstring describing dependencies, code consumers, and used variables.
- Updated `admin/public/admin.js` to fetch and cache the new endpoint data (levels + messages), remove the previous hardcoded fallback, render `group` and `customizable` metadata, and gracefully handle endpoint errors.
- Documented the new endpoint and response shape in `docs/backend_api.md`.
- No unused code was introduced; the new route and models are consumed by the admin UI and docs.

### Testing
- Ran `python -m py_compile backend_app.py` to validate backend syntax, which succeeded.
- Ran `node --check admin/public/admin.js` to validate frontend JS syntax, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c91899c7cc83288dca206a3c81e493)