### PR TITLE
Authenticate bot message catalog fetch in admin UI

### DIFF
--- a/admin/public/admin.js
+++ b/admin/public/admin.js
@@ -425,6 +425,27 @@ async function fetchJson(path) {
   return res.json();
 }
 
+/**
+ * Fetch JSON from an admin-protected endpoint with both token and cookie auth.
+ * Dependencies: adminHeaders helper and browser Fetch API credentials support.
+ * Code customers: admin-only panel calls that should accept either explicit
+ * `X-Admin-Token` or existing admin session cookie fallback.
+ * Variables used/origin: `API` URL prefix and `state.adminToken` via
+ * `adminHeaders(...)`.
+ */
+async function fetchAdminJson(path) {
+  const response = await fetch(`${API}${path}`, {
+    headers: adminHeaders(),
+    credentials: 'include',
+  });
+  if (!response.ok) {
+    const error = new Error(`request failed: ${response.status}`);
+    error.status = response.status;
+    throw error;
+  }
+  return response.json();
+}
+
 async function fetchChannelOAuth(name) {
   try {
     return await fetchJson(`/channels/${encodeURIComponent(name)}/oauth`);
@@ -555,7 +576,7 @@ function renderSettings(container, settings) {
 
 /**
  * Retrieve bot message catalog metadata for the channel settings panel.
- * Dependencies: backend endpoint `/bot/messages/catalog` and fetchJson helper.
+ * Dependencies: backend endpoint `/bot/messages/catalog` and fetchAdminJson helper.
  * Code customers: renderBotMessagesPanel matrix/list UI.
  * Variables used/origin: `API` for endpoint base and module-level
  * `botMessageCatalogCache` + `botMessageLevelDescriptions` memoization.
@@ -564,7 +585,7 @@ async function loadBotMessageCatalog() {
   if (botMessageCatalogCache && Array.isArray(botMessageCatalogCache.messages)) {
     return botMessageCatalogCache;
   }
-  const payload = await fetchJson('/bot/messages/catalog');
+  const payload = await fetchAdminJson('/bot/messages/catalog');
   const levels = Array.isArray(payload?.levels) ? payload.levels : [];
   const messages = Array.isArray(payload?.messages) ? payload.messages : [];
   botMessageLevelDescriptions = levels.reduce((acc, levelEntry) => {
@@ -683,7 +704,14 @@ async function renderBotMessagesPanel(container, channelName, settings) {
   } catch (err) {
     const empty = document.createElement('div');
     empty.className = 'empty';
-    empty.textContent = err instanceof Error ? err.message : 'Bot message catalog metadata unavailable.';
+    if (err && typeof err.status === 'number' && err.status === 401) {
+      const hasAdminToken = Boolean(state.adminToken && state.adminToken.trim());
+      empty.textContent = hasAdminToken
+        ? 'Bot message catalog unavailable: admin authentication failed. Verify the X-Admin-Token value or sign in again to refresh your admin session cookie.'
+        : 'Bot message catalog unavailable: no admin authentication found. Enter an admin token or sign in to establish an admin session cookie.';
+    } else {
+      empty.textContent = err instanceof Error ? err.message : 'Bot message catalog metadata unavailable.';
+    }
     container.appendChild(empty);
     return;
   }

--- a/docs/README.md
+++ b/docs/README.md
@@ -26,6 +26,19 @@ Additional directories include:
   ID for future customization workflows (editing controls intentionally hidden
   for now).
 
+### Bot message catalog auth checklist (manual UI verification)
+- [ ] **Admin token only works**: clear browser cookies, enter a valid admin
+  token in the setup panel, and open a channel’s **Bot Messages** tab. Confirm
+  the catalog matrix loads from `/bot/messages/catalog`.
+- [ ] **Session-cookie only works**: remove any stored admin token from the
+  setup panel, sign in via the Admin Twitch login flow so an admin session
+  cookie exists, and re-open **Bot Messages**. Confirm the catalog matrix still
+  loads.
+- [ ] **Missing auth shows explicit guidance**: clear both admin token and
+  session cookie, then open **Bot Messages**. Confirm the panel shows a
+  user-facing authentication guidance message that explains admin token/session
+  is missing and how to recover.
+
 ## Deployment setup flow
 When the stack starts for the first time, the backend remains locked until an
 administrator opens the Admin panel and saves the Twitch application


### PR DESCRIPTION
### Motivation
- The bot message catalog endpoint `/bot/messages/catalog` is admin-protected and must accept either an explicit admin token or an admin session cookie, but the UI previously fetched it without sending admin auth information.
- The Admin panel UX should show actionable guidance when catalog access is denied (401) so administrators know whether a token or session cookie is missing or invalid.

### Description
- Added a dedicated helper `fetchAdminJson(path)` in `admin/public/admin.js` that always includes `headers: adminHeaders(...)` and `credentials: 'include'` so admin endpoints accept `X-Admin-Token` or the admin session cookie.
- Updated `loadBotMessageCatalog()` to call `fetchAdminJson('/bot/messages/catalog')` instead of the unauthenticated `fetchJson(...)` and added JSDoc-style metadata describing dependencies, code customers, and used variables for the new helper.
- Extended the Bot Messages panel error handling to detect 401 responses and show a user-facing message that distinguishes between a missing admin token/session and a present-but-failing admin authentication.
- Added a manual UI verification checklist to `docs/README.md` that documents how to verify: admin-token-only access, session-cookie-only access, and the missing-auth guidance.

### Testing
- Ran `python -m pytest tests/test_cors.py -k "auth_session_cookie_available_for_other_endpoints"`, which passed (1 test selected and passed).
- Ran `python -m pytest tests/test_bot_config.py -k "catalog"`, which returned no matching tests in the current test selection (all items deselected).
- Verified the changes via static inspection of `admin/public/admin.js` and `docs/README.md` to confirm the helper, callsite replacement, and user-facing messages were added as intended.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c92329fe808328bae9bd83be6b66ae)