### PR TITLE
Allow lower-severity bot messages at higher channel verbosity and add tests

### DIFF
--- a/bot/bot_app.py
+++ b/bot/bot_app.py
@@ -1013,12 +1013,15 @@ class SongBot(commands.Bot):
         through `push_console_event` for observability. Code customers: all bot
         command and event handlers. Used variables/origin: message content comes
         from `message_or_key` (literal text or `self.messages` key), while
-        `level` is declared at each call site.
+        `level` is declared at each call site. Visibility rule: `MUTE`
+        channels always suppress chat, otherwise messages are allowed when the
+        resolved message level is less than or equal to the configured channel
+        threshold (`resolved_level <= threshold`).
         """
 
         resolved_level = self._coerce_message_level(level)
         threshold = self._resolve_channel_message_threshold(channel_login)
-        allow_chat = threshold != BotMessageLevel.MUTE and resolved_level >= threshold
+        allow_chat = threshold != BotMessageLevel.MUTE and resolved_level <= threshold
         message_text = self.messages.get(message_or_key, '') if message_key else message_or_key
         if not message_text:
             return

--- a/tests/test_bot_service.py
+++ b/tests/test_bot_service.py
@@ -433,6 +433,7 @@ class BotServiceTests(unittest.IsolatedAsyncioTestCase):
         song_bot.handle_random_request.assert_not_awaited()
 
     async def test_send_bot_message_policy_matrix(self) -> None:
+        """Verify per-channel thresholds include lower-severity messages."""
         song_bot = bot_app.SongBot.__new__(bot_app.SongBot)
         song_bot.messages = bot_app.DEFAULT_MESSAGES.copy()
         song_bot.channel_map = {
@@ -445,23 +446,95 @@ class BotServiceTests(unittest.IsolatedAsyncioTestCase):
         song_bot._send_message = AsyncMock()
 
         with patch.object(bot_app, "push_console_event", AsyncMock()) as push_event:
-            await song_bot._send_bot_message("mutech", "hidden", level=bot_app.BotMessageLevel.DEBUG)
-            await song_bot._send_bot_message("normalch", "hidden", level=bot_app.BotMessageLevel.MUTE)
-            await song_bot._send_bot_message("verbosech", "hidden", level=bot_app.BotMessageLevel.NORMAL)
-            await song_bot._send_bot_message("debugch", "hidden", level=bot_app.BotMessageLevel.VERBOSE)
+            # Mute sends none.
+            await song_bot._send_bot_message("mutech", "mute-normal", level=bot_app.BotMessageLevel.NORMAL)
+            await song_bot._send_bot_message("mutech", "mute-verbose", level=bot_app.BotMessageLevel.VERBOSE)
 
-            await song_bot._send_bot_message("normalch", "shown", level=bot_app.BotMessageLevel.NORMAL)
-            await song_bot._send_bot_message("verbosech", "shown", level=bot_app.BotMessageLevel.VERBOSE)
-            await song_bot._send_bot_message("debugch", "shown", level=bot_app.BotMessageLevel.DEBUG)
+            # Normal sends only normal.
+            await song_bot._send_bot_message("normalch", "normal-normal", level=bot_app.BotMessageLevel.NORMAL)
+            await song_bot._send_bot_message("normalch", "normal-verbose", level=bot_app.BotMessageLevel.VERBOSE)
+            await song_bot._send_bot_message("normalch", "normal-debug", level=bot_app.BotMessageLevel.DEBUG)
+
+            # Verbose sends normal + verbose.
+            await song_bot._send_bot_message("verbosech", "verbose-normal", level=bot_app.BotMessageLevel.NORMAL)
+            await song_bot._send_bot_message("verbosech", "verbose-verbose", level=bot_app.BotMessageLevel.VERBOSE)
+            await song_bot._send_bot_message("verbosech", "verbose-debug", level=bot_app.BotMessageLevel.DEBUG)
+
+            # Debug sends normal + verbose + debug.
+            await song_bot._send_bot_message("debugch", "debug-normal", level=bot_app.BotMessageLevel.NORMAL)
+            await song_bot._send_bot_message("debugch", "debug-verbose", level=bot_app.BotMessageLevel.VERBOSE)
+            await song_bot._send_bot_message("debugch", "debug-debug", level=bot_app.BotMessageLevel.DEBUG)
 
         sent_calls = [call.args[1] for call in song_bot._send_message.await_args_list]
-        self.assertEqual(sent_calls, ["shown", "shown", "shown"])
+        self.assertEqual(
+            sent_calls,
+            [
+                "normal-normal",
+                "verbose-normal",
+                "verbose-verbose",
+                "debug-normal",
+                "debug-verbose",
+                "debug-debug",
+            ],
+        )
         suppressed_logs = [
             call
             for call in push_event.await_args_list
             if call.kwargs.get("event") == "message_suppressed"
         ]
-        self.assertEqual(len(suppressed_logs), 4)
+        self.assertEqual(len(suppressed_logs), 5)
+
+    async def test_request_added_message_visible_at_verbose_and_debug(self) -> None:
+        """Regression: command responses remain visible for verbose/debug channels."""
+        song_bot = bot_app.SongBot.__new__(bot_app.SongBot)
+        song_bot.messages = bot_app.DEFAULT_MESSAGES.copy()
+        song_bot.message_catalog = bot_app.DEFAULT_MESSAGE_CATALOG.copy()
+        song_bot.channel_map = {
+            "verbosech": {"channel_name": "VerboseCh", "bot_message_level": "verbose"},
+            "debugch": {"channel_name": "DebugCh", "bot_message_level": "debug"},
+        }
+        song_bot._channel_login = bot_app.SongBot._channel_login.__get__(song_bot, bot_app.SongBot)
+        song_bot._send_message = AsyncMock()
+
+        with patch.object(bot_app, "push_console_event", AsyncMock()):
+            await song_bot._send_catalog_message(
+                "verbosech",
+                "request_added",
+                template_vars={"artist": "Artist", "title": "Title"},
+            )
+            await song_bot._send_catalog_message(
+                "debugch",
+                "request_added",
+                template_vars={"artist": "Artist", "title": "Title"},
+            )
+
+        sent_calls = [call.args[1] for call in song_bot._send_message.await_args_list]
+        self.assertEqual(sent_calls, ["Added: Artist - Title", "Added: Artist - Title"])
+
+    def test_default_message_catalog_levels_match_intended_groups(self) -> None:
+        """Ensure command/background/diagnostic messages retain expected severities."""
+        catalog = bot_app.DEFAULT_MESSAGE_CATALOG
+        command_ids = [
+            "request_added",
+            "random_request_added",
+            "playlist_request_added",
+            "remove_success",
+            "archive_success",
+        ]
+        verbose_background_ids = [
+            "bot_joined",
+            "played_next",
+            "award_follow",
+            "queue_position_changed",
+        ]
+        diagnostic_ids = ["token_refreshed", "action_failed_debug"]
+
+        for message_id in command_ids:
+            self.assertEqual(catalog[message_id].level, bot_app.BotMessageLevel.NORMAL)
+        for message_id in verbose_background_ids:
+            self.assertEqual(catalog[message_id].level, bot_app.BotMessageLevel.VERBOSE)
+        for message_id in diagnostic_ids:
+            self.assertEqual(catalog[message_id].level, bot_app.BotMessageLevel.DEBUG)
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
### Motivation
- Make channel message filtering more intuitive by keeping `MUTE` as full suppression while allowing lower-severity messages to be delivered when the channel is configured for a higher verbosity (so that `VERBOSE` and `DEBUG` channels also receive `NORMAL` messages).
- Keep the existing `BotMessageLevel` ordering (`MUTE=0, NORMAL=1, VERBOSE=2, DEBUG=3`) unchanged while clarifying policy intent in documentation.
- Add unit tests to prevent regressions and to assert that command responses remain visible at `verbose` and `debug` thresholds.

### Description
- Update `SongBot._send_bot_message` policy to compute `allow_chat` using `threshold != BotMessageLevel.MUTE and resolved_level <= threshold` and expand the function docstring to describe the new visibility rule. (`bot/bot_app.py`)
- Modify and expand `tests/test_bot_service.py::BotServiceTests::test_send_bot_message_policy_matrix` to exercise the full matrix of channel thresholds and message severities. (`tests/test_bot_service.py`)
- Add `test_request_added_message_visible_at_verbose_and_debug` to assert `request_added` catalog messages are visible at both `verbose` and `debug` channel settings. (`tests/test_bot_service.py`)
- Add `test_default_message_catalog_levels_match_intended_groups` to verify default catalog entries keep intended `NORMAL`/`VERBOSE`/`DEBUG` assignments. (`tests/test_bot_service.py`)

### Testing
- Ran `pytest -q` for the modified bot service tests: `tests/test_bot_service.py::BotServiceTests::test_send_bot_message_policy_matrix`, `tests/test_bot_service.py::BotServiceTests::test_request_added_message_visible_at_verbose_and_debug`, and `tests/test_bot_service.py::BotServiceTests::test_default_message_catalog_levels_match_intended_groups` and iterated once to correct an expected suppressed-count assertion.  
- Final run of the selected tests passed: all 3 tests succeeded.  
- The change is limited to the message visibility policy and test coverage; no other runtime behavior changes were introduced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c926e2a9a883288ae1a5b2238adcb8)