### PR TITLE
Improve admin Bot Messages matrix fallback, warning card, and troubleshooting docs

### DIFF
--- a/admin/public/admin.js
+++ b/admin/public/admin.js
@@ -106,6 +106,21 @@ const state = {
   channelUiState: {},
 };
 const BOT_MESSAGE_LEVELS = ['mute', 'normal', 'verbose', 'debug'];
+const BOT_MESSAGE_FALLBACK_CATALOG = {
+  levels: [
+    { level: 'mute', description: 'No bot chat responses are sent.' },
+    { level: 'normal', description: 'Core user-visible command responses.' },
+    { level: 'verbose', description: 'Normal + informational lifecycle notices.' },
+    { level: 'debug', description: 'Verbose + diagnostic and troubleshooting output.' },
+  ],
+  messages: [
+    { id: 'queue.request.accepted', level: 'normal', description: 'Queue/request confirmation responses.', group: 'queue', customizable: true },
+    { id: 'commands.user.feedback', level: 'normal', description: 'Command feedback sent to users.', group: 'commands', customizable: true },
+    { id: 'lifecycle.join.leave', level: 'verbose', description: 'Join/leave/lifecycle activity notices.', group: 'lifecycle', customizable: false },
+    { id: 'rewards.pricing.events', level: 'verbose', description: 'Rewards and pricing event notifications.', group: 'rewards', customizable: false },
+    { id: 'errors.recoverable', level: 'debug', description: 'Debug/error diagnostics and recovery context.', group: 'errors', customizable: false },
+  ],
+};
 let botMessageLevelDescriptions = {};
 let botMessageCatalogCache = null;
 const channelListEl = document.getElementById('channel-list');
@@ -634,6 +649,52 @@ function buildBotLevelBadge(level) {
 }
 
 /**
+ * Build a prominent warning card when live bot-message catalog loading fails.
+ * Dependencies: DOM APIs and admin auth state from `state.adminToken`.
+ * Code customers: renderBotMessagesPanel fallback/error path.
+ * Variables used/origin: fetch error `err.status` from fetchAdminJson helpers.
+ */
+function renderBotCatalogWarningCard(err) {
+  const warning = document.createElement('div');
+  warning.className = 'bot-message-warning-card';
+  const heading = document.createElement('strong');
+  heading.textContent = 'Live bot-message catalog unavailable';
+  warning.appendChild(heading);
+
+  const reason = document.createElement('div');
+  if (err && typeof err.status === 'number' && err.status === 401) {
+    reason.textContent = 'Reason: 401 unauthorized.';
+  } else {
+    reason.textContent = `Reason: ${err instanceof Error ? err.message : 'request failed while loading /bot/messages/catalog.'}`;
+  }
+  warning.appendChild(reason);
+
+  const remediation = document.createElement('div');
+  remediation.textContent = 'Remediation: set admin token or sign in, then refresh to load the live matrix.';
+  warning.appendChild(remediation);
+  return warning;
+}
+
+/**
+ * Return a lightweight local fallback matrix when the catalog endpoint fails.
+ * Dependencies: local constant BOT_MESSAGE_FALLBACK_CATALOG.
+ * Code customers: renderBotMessagesPanel degraded catalog mode.
+ * Variables used/origin: module-level fallback definitions and level descriptions.
+ */
+function getFallbackBotMessageCatalog() {
+  const levels = BOT_MESSAGE_FALLBACK_CATALOG.levels.slice();
+  const messages = BOT_MESSAGE_FALLBACK_CATALOG.messages.slice();
+  botMessageLevelDescriptions = levels.reduce((acc, levelEntry) => {
+    const key = typeof levelEntry?.level === 'string' ? levelEntry.level : '';
+    if (key && typeof levelEntry?.description === 'string') {
+      acc[key] = levelEntry.description;
+    }
+    return acc;
+  }, {});
+  return { levels, messages };
+}
+
+/**
  * Render the per-channel Bot Messages tab controls and inclusion matrix.
  * Dependencies: channel settings endpoints and loadBotMessageCatalog metadata.
  * Code customers: renderChannelTree channel detail tabs.
@@ -647,6 +708,7 @@ async function renderBotMessagesPanel(container, channelName, settings) {
     state.channelUiState[channelKey] = {
       botMessages: {
         selectedLevel: 'normal',
+        // TODO(future-cleanup): currently unused until per-message editing UI lands.
         perMessageOverrides: {},
       },
     };
@@ -702,18 +764,8 @@ async function renderBotMessagesPanel(container, channelName, settings) {
   try {
     catalog = await loadBotMessageCatalog();
   } catch (err) {
-    const empty = document.createElement('div');
-    empty.className = 'empty';
-    if (err && typeof err.status === 'number' && err.status === 401) {
-      const hasAdminToken = Boolean(state.adminToken && state.adminToken.trim());
-      empty.textContent = hasAdminToken
-        ? 'Bot message catalog unavailable: admin authentication failed. Verify the X-Admin-Token value or sign in again to refresh your admin session cookie.'
-        : 'Bot message catalog unavailable: no admin authentication found. Enter an admin token or sign in to establish an admin session cookie.';
-    } else {
-      empty.textContent = err instanceof Error ? err.message : 'Bot message catalog metadata unavailable.';
-    }
-    container.appendChild(empty);
-    return;
+    container.appendChild(renderBotCatalogWarningCard(err));
+    catalog = getFallbackBotMessageCatalog();
   }
   const rows = Array.isArray(catalog?.messages) ? catalog.messages.slice() : [];
   rows.sort((a, b) => String(a.id || '').localeCompare(String(b.id || '')));
@@ -918,10 +970,15 @@ async function renderChannelTree(channels, oauthMap) {
     details.appendChild(summary);
 
     const channelTabs = document.createElement('div');
+    const channelDetailSummary = document.createElement('div');
+    channelDetailSummary.className = 'channel-detail-summary';
+    channelDetailSummary.textContent = 'Bot Messages tab shows included responses by level and contains the message matrix.';
+    details.appendChild(channelDetailSummary);
+
     channelTabs.className = 'channel-detail-tabs';
     const tabButtons = [
       { id: 'custom-settings', label: 'Custom Settings' },
-      { id: 'bot-messages', label: 'Bot Messages' },
+      { id: 'bot-messages', label: 'Bot Messages (Matrix)' },
       { id: 'active-streams', label: 'Active Streams' },
     ];
     const panelMap = new Map();

--- a/admin/public/style.css
+++ b/admin/public/style.css
@@ -316,6 +316,12 @@ a:hover {
   margin-top: 12px;
 }
 
+.channel-detail-summary {
+  margin-top: 10px;
+  color: var(--muted);
+  font-size: 12px;
+}
+
 .channel-detail-tab {
   background: #1a1d2a;
   border: 1px solid #2a2f45;
@@ -364,6 +370,19 @@ a:hover {
   display: flex;
   flex-direction: column;
   gap: 6px;
+}
+
+.bot-message-warning-card {
+  margin-top: 10px;
+  padding: 12px;
+  border-radius: 8px;
+  border: 1px solid #8b1f2f;
+  background: rgba(139, 31, 47, 0.16);
+  color: #fecaca;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  font-size: 13px;
 }
 
 .bot-message-select {

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,15 +16,22 @@ Additional directories include:
 ## Admin panel bot message controls
 - Channel detail cards in the Admin panel now include a dedicated **Bot Messages**
   tab beside **Custom Settings** and **Active Streams**.
+- Each channel card shows a short summary above the tabs clarifying that the
+  message matrix lives in **Bot Messages** (labelled **Bot Messages (Matrix)**).
 - The tab reads `/channels/{channel}/settings`, shows the current
   `bot_message_level`, and persists level changes with
   `PUT /channels/{channel}/settings`.
 - The UI includes a read-only message catalog matrix grouped by message ID with
   default level badges (`normal`, `verbose`, `debug`) and inherited inclusion
   behavior: **Normal ⊂ Verbose ⊂ Debug**, while **Mute overrides all**.
+- If `/bot/messages/catalog` fails, the panel shows a prominent warning card
+  with reason/remediation and renders a lightweight local fallback matrix so
+  operators can still validate expected categories (`queue`, `commands`,
+  `lifecycle`, `rewards`, `errors`) while fixing auth.
 - Front-end state reserves a `perMessageOverrides` object map keyed by message
   ID for future customization workflows (editing controls intentionally hidden
-  for now).
+  for now; currently unused and marked for future cleanup if this direction is
+  dropped).
 
 ### Bot message catalog auth checklist (manual UI verification)
 - [ ] **Admin token only works**: clear browser cookies, enter a valid admin
@@ -38,6 +45,20 @@ Additional directories include:
   session cookie, then open **Bot Messages**. Confirm the panel shows a
   user-facing authentication guidance message that explains admin token/session
   is missing and how to recover.
+
+### Troubleshooting missing matrix / auth failures
+- **Warning card says `401 unauthorized`**:
+  1. In Admin panel **Setup**, set a valid admin token (`X-Admin-Token`) and save.
+  2. Or sign in through the Admin Twitch auth flow to restore an admin session cookie.
+  3. Refresh the channel card and re-open **Bot Messages (Matrix)**.
+- **Matrix missing after sign-in**:
+  1. Open browser devtools network tab and confirm `/bot/messages/catalog` returns 200.
+  2. Confirm the backend origin in Admin footer points at the expected API host.
+  3. Re-check reverse proxy auth/header forwarding for `X-Admin-Token` and cookies.
+- **Temporary fallback matrix shown**:
+  - This is expected degraded mode when live catalog metadata cannot be fetched.
+  - Use fallback categories for quick validation, then restore auth to return to
+    the full live catalog.
 
 ## Deployment setup flow
 When the stack starts for the first time, the backend remains locked until an


### PR DESCRIPTION
### Motivation
- Make the Admin UI clearer about where the Bot Messages matrix lives and keep the existing default tab behavior while surfacing the matrix for faster validation. 
- Provide a clear, actionable UI when `/bot/messages/catalog` cannot be fetched (especially `401` auth failures) instead of subtle empty text. 
- Allow a lightweight local fallback so operators can still validate expected categories when live catalog metadata is unavailable. 
- Document troubleshooting steps and mark currently unused front-end state for future cleanup.

### Description
- Added a local fallback catalog constant `BOT_MESSAGE_FALLBACK_CATALOG` and helper `getFallbackBotMessageCatalog()` to provide a lightweight matrix when `/bot/messages/catalog` fails. 
- Implemented `renderBotCatalogWarningCard(err)` to render a prominent warning card that includes a `401 unauthorized` reason when applicable and remediation text instructing operators to set an admin token or sign in. 
- Updated `renderBotMessagesPanel()` to append the warning card on catalog load failure and then render the fallback matrix instead of returning a subtle empty message. 
- Made channel cards show a short summary above tabs (`channel-detail-summary`) and relabeled the tab to `Bot Messages (Matrix)` to make the matrix location explicit, and added a `TODO` comment noting `perMessageOverrides` is currently unused. 
- Added CSS styles for `.channel-detail-summary` and `.bot-message-warning-card` and updated `docs/README.md` with troubleshooting steps for missing matrix / auth failures.

### Testing
- Ran `node --check admin/public/admin.js` which completed successfully. 
- Verified file changes were staged and committed (`admin/public/admin.js`, `admin/public/style.css`, `docs/README.md`) with a commit message; the commit step succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c9281b2c1c8328b093b3cb983be7b4)