### PR TITLE
Repair numeric Twitch usernames and add user delete controls

### DIFF
--- a/backend_app.py
+++ b/backend_app.py
@@ -5270,6 +5270,7 @@ def search_users(
         .limit(limit)
         .all()
     )
+    _refresh_users_with_helix_names(db, channel_row, users)
 
     vip_ids: set[str] = set()
     subs: dict[str, Optional[str]] = {}
@@ -5320,10 +5321,26 @@ def get_or_create_user(channel: str, payload: UserIn, db: Session = Depends(get_
 
 @app.get("/channels/{channel}/users/{user_id}", response_model=UserOut)
 def get_user(channel: str, user_id: int, db: Session = Depends(get_db)):
+    """Return one user row, repairing numeric fallback names when possible.
+
+    Dependencies: channel lookup helpers plus optional Twitch Helix profile
+    lookup through `_refresh_users_with_helix_names`.
+    Code customers: Queue Manager queue/user cards and Admin queue expansion.
+    Used variables/origin: route params `channel`/`user_id` and persisted `User`
+    records scoped by channel primary key.
+    """
+
     channel_pk = get_channel_pk(channel, db)
     u = db.query(User).filter(User.id == user_id, User.channel_id == channel_pk).one_or_none()
     if not u:
         raise HTTPException(404, "user not found")
+    channel_row = (
+        db.query(ActiveChannel)
+        .options(joinedload(ActiveChannel.owner))
+        .filter(ActiveChannel.id == channel_pk)
+        .one_or_none()
+    )
+    _refresh_users_with_helix_names(db, channel_row, [u])
     return u
 
 @app.put("/channels/{channel}/users/{user_id}", dependencies=[Depends(require_token)])
@@ -5360,6 +5377,28 @@ def set_points(channel: str, user_id: int, payload: dict, db: Session = Depends(
     if not u or u.channel_id != channel_pk:
         raise HTTPException(404)
     u.prio_points = int(payload.get("prio_points", 0))
+    db.commit()
+    publish_queue_changed(channel_pk)
+    return {"success": True}
+
+
+@app.delete("/channels/{channel}/users/{user_id}", dependencies=[Depends(require_token)])
+def delete_user(channel: str, user_id: int, db: Session = Depends(get_db)):
+    """Delete a user and cascade related queue state for the active channel.
+
+    Dependencies: channel resolver (`get_channel_pk`), SQLAlchemy session
+    deletion semantics, and foreign keys configured with ON DELETE CASCADE.
+    Code customers: Queue Manager Users tab delete action and admin/API scripts
+    that need to purge malformed user records.
+    Used variables/origin: route params `channel` and `user_id` identify the
+    scoped row; queue subscribers are notified via `publish_queue_changed`.
+    """
+
+    channel_pk = get_channel_pk(channel, db)
+    u = db.query(User).filter(User.id == user_id, User.channel_id == channel_pk).one_or_none()
+    if not u:
+        raise HTTPException(404, "user not found")
+    db.delete(u)
     db.commit()
     publish_queue_changed(channel_pk)
     return {"success": True}
@@ -5461,6 +5500,105 @@ def _collect_channel_roles(channel_obj: ActiveChannel) -> tuple[set[str], dict[s
         if isinstance(user_id, str):
             subs[user_id] = tier if isinstance(tier, str) else None
     return vip_ids, subs
+
+
+def _is_probable_twitch_numeric_id(value: Optional[str]) -> bool:
+    """Return True when a value looks like a Twitch numeric user identifier.
+
+    Dependencies: pure string checks only.
+    Code customers: username repair helpers in user list/detail endpoints.
+    Used variables/origin: values come from persisted `users.twitch_id` and
+    `users.username` fields.
+    """
+
+    if not isinstance(value, str):
+        return False
+    stripped = value.strip()
+    return bool(stripped) and stripped.isdigit()
+
+
+def _username_needs_refresh(user: User) -> bool:
+    """Detect user rows that likely stored an ID instead of a Twitch login name.
+
+    Dependencies: uses `_is_probable_twitch_numeric_id` plus the User ORM model.
+    Code customers: `_refresh_users_with_helix_names`.
+    Used variables/origin: compares stored `user.username` with `user.twitch_id`.
+    """
+
+    twitch_id = getattr(user, "twitch_id", None)
+    username = getattr(user, "username", None)
+    if not _is_probable_twitch_numeric_id(twitch_id):
+        return False
+    if not isinstance(username, str) or not username.strip():
+        return True
+    return username.strip() == twitch_id.strip()
+
+
+def _refresh_users_with_helix_names(db: Session, channel_obj: Optional[ActiveChannel], users: Sequence[User]) -> int:
+    """Repair numeric username placeholders by resolving Twitch logins via Helix.
+
+    Dependencies: requires a channel owner OAuth token, app client ID from
+    `get_twitch_client_id`, and `requests.get` calls to Twitch Helix `/users`.
+    Code customers: user list/detail APIs to opportunistically heal legacy rows.
+    Used variables/origin: candidate Twitch IDs originate from `users` rows and
+    updates are persisted to the same SQLAlchemy session.
+    """
+
+    if not users or not channel_obj or not channel_obj.owner:
+        return 0
+    owner = channel_obj.owner
+    client_id = get_twitch_client_id()
+    if not client_id or not owner.access_token:
+        return 0
+
+    candidates: list[User] = [user for user in users if _username_needs_refresh(user)]
+    if not candidates:
+        return 0
+
+    resolved_logins: dict[str, str] = {}
+    headers = {"Authorization": f"Bearer {owner.access_token}", "Client-Id": client_id}
+    chunk_size = 100
+    for index in range(0, len(candidates), chunk_size):
+        chunk = candidates[index:index + chunk_size]
+        params: list[tuple[str, str]] = [("id", user.twitch_id) for user in chunk if user.twitch_id]
+        if not params:
+            continue
+        try:
+            resp = requests.get("https://api.twitch.tv/helix/users", headers=headers, params=params, timeout=10)
+        except requests.RequestException:
+            logger.warning("username repair lookup failed for channel %s", channel_obj.channel_name, exc_info=True)
+            continue
+        if not resp.ok:
+            logger.warning(
+                "username repair lookup returned %s for channel %s",
+                resp.status_code,
+                channel_obj.channel_name,
+            )
+            continue
+        payload = resp.json() if resp.content else {}
+        data = payload.get("data") if isinstance(payload, dict) else None
+        if not isinstance(data, list):
+            continue
+        for row in data:
+            if not isinstance(row, dict):
+                continue
+            twitch_id = row.get("id")
+            login = row.get("login")
+            if isinstance(twitch_id, str) and isinstance(login, str) and login.strip():
+                resolved_logins[twitch_id] = login.strip()
+
+    if not resolved_logins:
+        return 0
+
+    updated = 0
+    for user in candidates:
+        new_login = resolved_logins.get(user.twitch_id)
+        if new_login and user.username != new_login:
+            user.username = new_login
+            updated += 1
+    if updated:
+        db.commit()
+    return updated
 
 
 def _coerce_int(value: Any, *, default: int = 0) -> int:

--- a/docs/README.md
+++ b/docs/README.md
@@ -163,6 +163,9 @@ them via `/me/channels`.
   a neutral grey marker.
 - Metadata is presented in bracketed chips (for example `[behind: 3]` and
   `[prio: 2]`) to keep “amount behind” context aligned across rows.
+- Each row includes a **Delete** action so managers can remove malformed or
+  stale user records directly from the console; related queue/request rows
+  cascade according to backend foreign-key rules.
 - Channel owners and the playlist automation helper are filtered out of the
   listing, and badges update automatically as pages load or refresh.
 

--- a/docs/backend_api.md
+++ b/docs/backend_api.md
@@ -152,6 +152,7 @@ Channel settings include queue intake controls:
 | POST | `/channels/{channel}/users` | Create or update a user record (admin). |
 | GET | `/channels/{channel}/users/{user_id}` | Retrieve user details. |
 | PUT | `/channels/{channel}/users/{user_id}` | Update user statistics such as priority points (admin). |
+| DELETE | `/channels/{channel}/users/{user_id}` | Delete a user and cascade queue state tied to that user (admin). |
 | GET | `/channels/{channel}/users/{user_id}/stream_state` | Get per-stream state like free subscriber priority usage. |
 | PUT | `/channels/{channel}/users/{user_id}/points` | Set a user's priority points directly (admin). |
 
@@ -159,6 +160,7 @@ Channel settings include queue intake controls:
 - **Query parameters**: `search` (optional substring match on usernames), `limit` (default 25, max 100), and `offset` (default 0).
 - **Response**: `{ "total": <int>, "limit": <int>, "offset": <int>, "owner_login": "<channel owner login?>", "items": [UserOut] }`.
 - **Behavior**: The endpoint excludes the channel owner and the playlist automation user (`twitch_id == "__playlist__"`) from both totals and items. Results order alphabetically by username and are safe for Queue Manager pagination controls.
+- **Name repair**: When a stored username matches a numeric Twitch ID placeholder, the API attempts a best-effort Twitch Helix `/users?id=...` lookup (using the owner's OAuth token) and updates the persisted username to the resolved login.
 
 ## Queue
 | Method | Path | Description |

--- a/queue_manager/public/queue_manager.js
+++ b/queue_manager/public/queue_manager.js
@@ -2553,8 +2553,15 @@ function renderUsers(users) {
     minusBtn.textContent = '-1';
     minusBtn.setAttribute('aria-label', `Remove priority point from ${user.username}`);
     minusBtn.onclick = () => modPoints(user.id, -1);
+    const deleteBtn = document.createElement('button');
+    deleteBtn.type = 'button';
+    deleteBtn.className = 'danger';
+    deleteBtn.textContent = 'Delete';
+    deleteBtn.setAttribute('aria-label', `Delete user ${user.username}`);
+    deleteBtn.onclick = () => deleteUser(user.id, user.username, deleteBtn);
     actions.appendChild(plusBtn);
     actions.appendChild(minusBtn);
+    actions.appendChild(deleteBtn);
 
     row.appendChild(identity);
     row.appendChild(actions);
@@ -2635,6 +2642,45 @@ async function modPoints(uid, delta) {
     credentials: 'include'
   });
   fetchUsers();
+}
+
+/**
+ * Remove a user from the channel and refresh the visible users page.
+ * Dependencies: queue manager API base URL, active `channelName`, and
+ * `showToast`/`fetchUsers` for user feedback and list refresh.
+ * Code customers: delete buttons created in renderUsers().
+ * Used variables/origin: consumes user ID/name from rendered row callbacks and
+ * issues DELETE `/channels/{channel}/users/{user_id}`.
+ */
+async function deleteUser(uid, username, triggerBtn = null) {
+  if (!channelName) { return; }
+  const safeName = typeof username === 'string' && username.trim() ? username.trim() : `#${uid}`;
+  if (!confirm(`Delete user "${safeName}" from this channel?`)) {
+    return;
+  }
+  if (triggerBtn) {
+    triggerBtn.disabled = true;
+  }
+  try {
+    const encodedChannel = encodeURIComponent(channelName);
+    const resp = await fetch(`${API}/channels/${encodedChannel}/users/${uid}`, {
+      method: 'DELETE',
+      credentials: 'include',
+    });
+    if (!resp.ok) {
+      const detail = await readErrorDetail(resp, 'Failed to delete user.');
+      throw new Error(detail);
+    }
+    showToast(`Deleted user ${safeName}.`, 'success');
+    await fetchUsers();
+  } catch (e) {
+    console.error('Failed to delete user', e);
+    showToast(e.message || 'Failed to delete user.', 'error');
+  } finally {
+    if (triggerBtn) {
+      triggerBtn.disabled = false;
+    }
+  }
 }
 
 /**

--- a/queue_manager/public/style.css
+++ b/queue_manager/public/style.css
@@ -52,6 +52,8 @@ a:hover{text-decoration:underline}
 .user-actions{display:flex;gap:6px;align-items:center;justify-content:flex-end}
 .user-actions button{padding:.35rem .55rem;border-radius:8px;border:1px solid #24283b;background:#1a1d29;color:var(--text);cursor:pointer;font-size:12px;font-weight:700}
 .user-actions button:hover{background:#24283b}
+.user-actions button.danger{border-color:var(--danger);color:var(--danger)}
+.user-actions button.danger:hover{background:rgba(239,68,68,0.18)}
 .user-role-badge{width:18px;height:18px;border-radius:5px;display:grid;place-items:center;font-size:11px;font-weight:800;color:#0b0d13;border:1px solid #0b0d13}
 .user-role-mod{background:var(--role-mod)}
 .user-role-vip{background:var(--role-vip)}
@@ -332,4 +334,3 @@ a:hover{text-decoration:underline}
 .channel-key-status{min-height:14px}
 .channel-key-card.loading{opacity:.7}
 .channel-key-hint{margin:0}
-

--- a/tests/test_users_api.py
+++ b/tests/test_users_api.py
@@ -206,6 +206,90 @@ class UsersApiTests(unittest.TestCase):
         self.assertTrue(flags[roster["sub"]]["is_subscriber"])
         self.assertEqual(flags[roster["sub"]]["subscriber_tier"], "3000")
 
+    def test_delete_user_removes_record(self) -> None:
+        """DELETE endpoint should remove an existing user from the channel."""
+
+        db = backend_app.SessionLocal()
+        try:
+            channel = _seed_channel_with_users(db, total=1)
+            target = (
+                db.query(backend_app.User)
+                .filter(
+                    backend_app.User.channel_id == channel.id,
+                    backend_app.User.twitch_id == "user-0",
+                )
+                .one()
+            )
+            channel_name = channel.channel_name
+            user_id = target.id
+        finally:
+            db.close()
+
+        resp = self.client.delete(
+            f"/channels/{channel_name}/users/{user_id}",
+            headers={"X-Admin-Token": backend_app.ADMIN_TOKEN},
+        )
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.json().get("success"), True)
+
+        db = backend_app.SessionLocal()
+        try:
+            remaining = (
+                db.query(backend_app.User)
+                .filter(backend_app.User.channel_id == channel.id, backend_app.User.id == user_id)
+                .count()
+            )
+            self.assertEqual(remaining, 0)
+        finally:
+            db.close()
+
+    def test_user_listing_repairs_numeric_username(self) -> None:
+        """Listing should refresh numeric placeholder usernames from Twitch data."""
+
+        class _StubResponse:
+            def __init__(self, payload):
+                self.ok = True
+                self.status_code = 200
+                self.content = b"1"
+                self._payload = payload
+
+            def json(self):
+                return self._payload
+
+        db = backend_app.SessionLocal()
+        original_get = backend_app.requests.get
+        original_client_id_getter = backend_app.get_twitch_client_id
+        try:
+            channel = _seed_channel_with_users(db, total=1)
+            owner = channel.owner
+            owner.access_token = "owner-token"
+            candidate = (
+                db.query(backend_app.User)
+                .filter(
+                    backend_app.User.channel_id == channel.id,
+                    backend_app.User.twitch_id == "user-0",
+                )
+                .one()
+            )
+            candidate.twitch_id = "12345"
+            candidate.username = "12345"
+            db.commit()
+
+            backend_app.get_twitch_client_id = lambda: "client-id"  # type: ignore[assignment]
+            backend_app.requests.get = lambda *args, **kwargs: _StubResponse({  # type: ignore[assignment]
+                "data": [{"id": "12345", "login": "fixed_login"}]
+            })
+            payload = self.client.get(
+                f"/channels/{channel.channel_name}/users", params={"limit": 25, "offset": 0}
+            ).json()
+        finally:
+            backend_app.requests.get = original_get
+            backend_app.get_twitch_client_id = original_client_id_getter
+            db.close()
+
+        usernames = [row["username"] for row in payload["items"]]
+        self.assertIn("fixed_login", usernames)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- added backend username-repair helpers that detect rows where `users.username` is a numeric Twitch ID placeholder and resolve logins through Twitch Helix `/users` using the channel owner token
- wired the repair flow into `GET /channels/{channel}/users` and `GET /channels/{channel}/users/{user_id}` so legacy rows heal opportunistically
- added `DELETE /channels/{channel}/users/{user_id}` to remove a user (and cascaded queue state) from a channel
- added a **Delete** button in the Queue Manager Users tab with confirmation, API call, and toast feedback
- documented the new users delete endpoint and name-repair behavior in `docs/backend_api.md`, and updated the Queue Manager users-tab docs in `docs/README.md`
- added users API tests for delete behavior and numeric-username repair logic

## Notes
- I did not run the test suite in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c9543812908328830b81336ea91d7b)