### PR TITLE
Unify Queue Manager bot controls into a single state-aware dropdown

### DIFF
--- a/backend_app.py
+++ b/backend_app.py
@@ -1182,6 +1182,7 @@ class ChannelOut(BaseModel):
     authorized: bool
     bot_active: bool
     bot_last_error: Optional[str] = None
+    bot_message_level: Literal["mute", "normal", "verbose", "debug"] = "normal"
 
     class Config:
         from_attributes = True
@@ -4297,6 +4298,8 @@ def list_channels(db: Session = Depends(get_db)):
     for channel in channels:
         if not channel.bot_state:
             channel.bot_state = get_or_create_bot_state(db, channel.id)
+        settings = get_or_create_settings(db, channel.id)
+        channel.bot_message_level = settings.bot_message_level or "normal"
     return channels
 
 
@@ -4380,7 +4383,11 @@ def add_channel(payload: ChannelIn, db: Session = Depends(get_db)):
     return ch
 
 @app.put("/channels/{channel}", dependencies=[Depends(require_token)])
-def update_channel_status(channel: str, join_active: int, db: Session = Depends(get_db)):
+def update_channel_status(
+    channel: str,
+    join_active: int = Query(..., ge=0, le=1),
+    db: Session = Depends(get_db),
+):
     channel_pk = get_channel_pk(channel, db)
     ch = db.get(ActiveChannel, channel_pk)
     if not ch:

--- a/docs/README.md
+++ b/docs/README.md
@@ -169,6 +169,21 @@ them via `/me/channels`.
 - Channel owners and the playlist automation helper are filtered out of the
   listing, and badges update automatically as pages load or refresh.
 
+## Queue Manager unified bot control dropdown
+- The Queue Manager header now shows a single bot-control dropdown beside the
+  channel and bot badges whenever the selected channel is authorized.
+- Dropdown options are state-aware:
+  - **Disconnected (`join_active = 0`)**: only `connect` is shown.
+  - **Connected (`join_active = 1`)**: `disconnect` plus message levels
+    `mute`, `normal`, `verbose`, and `debug` are shown.
+- API mapping is explicit:
+  - `connect`/`disconnect` -> `PUT /channels/{channel}?join_active=1|0`
+  - `mute|normal|verbose|debug` -> `PUT /channels/{channel}/settings` with
+    `{ "bot_message_level": "<level>" }`
+- The Settings tab reuses the same dropdown renderer for
+  `bot_message_level`, so message-level selection behavior stays aligned with
+  the header control.
+
 ## Development Tips
 - Install Python dependencies from `requirements.txt` for local development.
 - Run the backend directly:

--- a/docs/backend_api.md
+++ b/docs/backend_api.md
@@ -113,6 +113,23 @@ Channel settings include queue intake controls:
 - Priority point pricing is configurable: `prio_follow_enabled`, `prio_raid_enabled`, `prio_bits_per_point`, `prio_gifts_per_point`, and per-tier fields (`prio_sub_tier1_points`, `prio_sub_tier2_points`, `prio_sub_tier3_points`) control how many points events grant. Reset bonuses (`prio_reset_points_tier1`, `prio_reset_points_tier2`, `prio_reset_points_tier3`, `prio_reset_points_vip`, `prio_reset_points_mod`) are awarded when the queue resets for a new stream. Use `free_mod_priority_requests` to allow moderators to request priority without spending points.
 - Existing deployments should apply `migrations/20240624_queue_caps.sql` to add the new capacity columns and backfill defaults for legacy channels; the application also attempts to patch missing columns on startup for SQLite/legacy installs before enforcing queue caps.
 
+### Queue Manager unified bot dropdown API mapping
+- Queue Manager uses a single state-aware dropdown model with options:
+  `connect`, `disconnect`, `mute`, `normal`, `verbose`, `debug`.
+- When a channel is disconnected (`join_active = 0`), the UI shows only
+  `connect`. When connected (`join_active = 1`), it shows `disconnect` plus the
+  four message levels.
+- Endpoint wiring:
+  - `connect` => `PUT /channels/{channel}?join_active=1`
+  - `disconnect` => `PUT /channels/{channel}?join_active=0`
+  - `mute|normal|verbose|debug` =>
+    `PUT /channels/{channel}/settings` with
+    `{ "bot_message_level": "<level>" }`
+- Validation alignment:
+  - `/channels/{channel}` accepts only `join_active` values `0` or `1`.
+  - `/channels/{channel}/settings` keeps `bot_message_level` strict to enum
+    values `mute|normal|verbose|debug`.
+
 ## Songs
 | Method | Path | Description |
 |--------|------|-------------|

--- a/queue_manager/public/index.html
+++ b/queue_manager/public/index.html
@@ -34,14 +34,15 @@
 </div>
 
 <div id="app" style="display:none">
-  <div class="wrap">
-    <div class="header">
-      <div class="brand">Queue Manager</div>
-      <span id="ch-badge" class="badge">channel: ?</span>
-      <span id="bot-status" class="badge" hidden>bot: unknown</span>
-      <button id="reg-btn" style="display:none"></button>
-      <div class="dev-stamp" id="qm-app-dev-stamp" hidden aria-hidden="true">DEV</div>
-    </div>
+    <div class="wrap">
+      <div class="header">
+        <div class="brand">Queue Manager</div>
+        <span id="ch-badge" class="badge">channel: ?</span>
+        <span id="bot-status" class="badge" hidden>bot: unknown</span>
+        <div id="bot-control-host" class="bot-control-host"></div>
+        <button id="reg-btn" style="display:none"></button>
+        <div class="dev-stamp" id="qm-app-dev-stamp" hidden aria-hidden="true">DEV</div>
+      </div>
 
     <div class="grid">
       <div class="card">
@@ -97,7 +98,6 @@
           </div>
           <div class="footer">
             <button id="archive-btn">Archive Stream</button>
-            <button id="mute-btn">Toggle Requests</button>
           </div>
         </div>
 

--- a/queue_manager/public/queue_manager.js
+++ b/queue_manager/public/queue_manager.js
@@ -817,6 +817,12 @@ const SETTINGS_CONFIG = {
     offLabel: 'Charged',
     group: 'main',
   },
+  bot_message_level: {
+    type: 'select',
+    label: 'Bot message level',
+    description: 'Choose chat output verbosity. Uses the same dropdown behavior as the header bot control.',
+    group: 'main',
+  },
   other_flags: {
     type: 'text',
     label: 'Experimental flags',
@@ -826,6 +832,78 @@ const SETTINGS_CONFIG = {
     group: 'experimental',
   },
 };
+
+const BOT_CONTROL_OPTION_MODEL = [
+  { value: 'connect', label: 'Connect bot to chat', action: 'channel-status', joinActive: 1, requiresConnection: false },
+  { value: 'disconnect', label: 'Disconnect bot from chat', action: 'channel-status', joinActive: 0, requiresConnection: true },
+  { value: 'mute', label: 'Messages: Mute', action: 'message-level', messageLevel: 'mute', requiresConnection: true },
+  { value: 'normal', label: 'Messages: Normal', action: 'message-level', messageLevel: 'normal', requiresConnection: true },
+  { value: 'verbose', label: 'Messages: Verbose', action: 'message-level', messageLevel: 'verbose', requiresConnection: true },
+  { value: 'debug', label: 'Messages: Debug', action: 'message-level', messageLevel: 'debug', requiresConnection: true },
+];
+
+/**
+ * Resolve dropdown options from the shared bot-control model based on connection state.
+ * Dependencies: reads BOT_CONTROL_OPTION_MODEL and optional channel info from `/channels` cache.
+ * Code customers: header bot dropdown and settings `bot_message_level` renderer.
+ * Used variables/origin: consumes `channelInfo.join_active` and rendering flags to include status actions and/or message levels.
+ */
+function getBotControlOptions(channelInfo, { includeConnectionActions = true, includeMessageLevels = true } = {}) {
+  const connected = !!channelInfo?.join_active;
+  if (includeConnectionActions && includeMessageLevels) {
+    if (!connected) {
+      return BOT_CONTROL_OPTION_MODEL.filter(option => option.value === 'connect');
+    }
+    return BOT_CONTROL_OPTION_MODEL.filter(option => option.value !== 'connect');
+  }
+  return BOT_CONTROL_OPTION_MODEL.filter(option => (
+    (includeConnectionActions && option.action === 'channel-status')
+    || (includeMessageLevels && option.action === 'message-level')
+  ));
+}
+
+/**
+ * Persist a bot-control dropdown selection to the API by routing to the matching endpoint.
+ * Dependencies: requires `channelName`, API origin, and the shared BOT_CONTROL_OPTION_MODEL metadata.
+ * Code customers: header dropdown and settings-level selector save handlers.
+ * Used variables/origin: maps `connect`/`disconnect` to `PUT /channels/{channel}?join_active=...` and levels to `PUT /channels/{channel}/settings`.
+ */
+async function applyBotControlSelection(selectionValue) {
+  if (!channelName) { return false; }
+  const option = BOT_CONTROL_OPTION_MODEL.find(entry => entry.value === selectionValue);
+  if (!option) { return false; }
+  const encodedChannel = encodeURIComponent(channelName);
+  try {
+    if (option.action === 'channel-status') {
+      const resp = await fetch(`${API}/channels/${encodedChannel}?join_active=${option.joinActive}`, {
+        method: 'PUT',
+        credentials: 'include'
+      });
+      if (!resp.ok) {
+        throw new Error(`channel status update failed (${resp.status})`);
+      }
+    } else {
+      const resp = await fetch(`${API}/channels/${encodedChannel}/settings`, {
+        method: 'PUT',
+        body: JSON.stringify({ bot_message_level: option.messageLevel }),
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include'
+      });
+      if (!resp.ok) {
+        throw new Error(`bot message level update failed (${resp.status})`);
+      }
+    }
+    await updateRegButton();
+    if (option.action === 'message-level') {
+      await fetchSettings();
+    }
+    return true;
+  } catch (err) {
+    console.error('Failed to apply bot control selection', selectionValue, err);
+    alert('Unable to apply this bot control option. Please try again.');
+    return false;
+  }
+}
 
 function getChannelInfo(name) {
   if (!name) { return null; }
@@ -2374,12 +2452,7 @@ async function markPlayed(id) {
 }
 
 qs('archive-btn').onclick = () => fetch(`${API}/channels/${channelName}/streams/archive`, { method: 'POST', credentials: 'include' });
-qs('mute-btn').onclick = () => fetch(`${API}/channels/${channelName}/settings`, {
-  method: 'PUT',
-  body: JSON.stringify({ queue_closed: 1 }),
-  headers: { 'Content-Type': 'application/json' },
-  credentials: 'include'
-});
+
 
 // ===== Users view =====
 /**
@@ -2836,8 +2909,77 @@ function buildSettingRow(key, value, meta) {
   return row;
 }
 
+/**
+ * Build a reusable bot-control dropdown element from the unified option model.
+ * Dependencies: uses BOT_CONTROL_OPTION_MODEL and getBotControlOptions() filtering to render menu choices.
+ * Code customers: header action slot and settings row for `bot_message_level`.
+ * Used variables/origin: reads channel join state from `channelInfo` and current setting value from `currentValue`.
+ */
+function createBotControlDropdown({
+  channelInfo,
+  currentValue,
+  includeConnectionActions = true,
+  includeMessageLevels = true,
+  onSelection,
+  disabled = false,
+}) {
+  const select = document.createElement('select');
+  select.className = 'bot-control-select';
+  const options = getBotControlOptions(channelInfo, { includeConnectionActions, includeMessageLevels });
+  options.forEach(option => {
+    const opt = document.createElement('option');
+    opt.value = option.value;
+    opt.textContent = option.label;
+    select.appendChild(opt);
+  });
+
+  const selectedValue = options.some(option => option.value === currentValue)
+    ? currentValue
+    : (options[0]?.value || '');
+  if (selectedValue) {
+    select.value = selectedValue;
+  }
+  select.disabled = disabled || !options.length;
+  if (typeof onSelection === 'function' && !select.disabled) {
+    select.addEventListener('change', event => onSelection(event, select));
+  }
+  return select;
+}
+
 function createSettingControl(key, value, meta) {
   const type = meta.type || (typeof value === 'number' ? 'number' : 'text');
+  if (key === 'bot_message_level') {
+    const wrapper = document.createElement('div');
+    wrapper.className = 'setting-select';
+    const channelInfo = getChannelInfo(channelName);
+    let currentSelection = typeof value === 'string' ? value : 'normal';
+    const select = createBotControlDropdown({
+      channelInfo,
+      currentValue: currentSelection,
+      includeConnectionActions: false,
+      includeMessageLevels: true,
+      disabled: !!meta.disabled,
+      onSelection: async (_event, element) => {
+        const next = element.value;
+        if (next === currentSelection) {
+          return;
+        }
+        wrapper.classList.add('loading');
+        element.disabled = true;
+        const ok = await applyBotControlSelection(next);
+        if (ok) {
+          currentSelection = next;
+        } else {
+          element.value = currentSelection;
+        }
+        element.disabled = !!meta.disabled;
+        wrapper.classList.remove('loading');
+      },
+    });
+    wrapper.appendChild(select);
+    return wrapper;
+  }
+
   if (type === 'boolean') {
     const wrapper = document.createElement('div');
     wrapper.className = 'setting-toggle';
@@ -3645,8 +3787,36 @@ if (loginButton) {
 
 async function updateRegButton() {
   const btn = qs('reg-btn');
+  const controlHost = qs('bot-control-host');
+  const renderHeaderBotControl = (channelInfo) => {
+    if (!controlHost) { return; }
+    controlHost.innerHTML = '';
+    if (!channelName || !channelInfo || !channelInfo.authorized) { return; }
+    let currentValue = channelInfo.join_active
+      ? (channelInfo.bot_message_level || 'normal')
+      : 'connect';
+    const select = createBotControlDropdown({
+      channelInfo,
+      currentValue,
+      includeConnectionActions: true,
+      includeMessageLevels: true,
+      onSelection: async (_event, element) => {
+        const previous = currentValue;
+        element.disabled = true;
+        const ok = await applyBotControlSelection(element.value);
+        if (!ok) {
+          element.value = previous;
+        } else {
+          currentValue = element.value;
+        }
+        element.disabled = false;
+      },
+    });
+    controlHost.appendChild(select);
+  };
   if (!userLogin || !btn) {
     if (btn) { btn.style.display = 'none'; }
+    if (controlHost) { controlHost.innerHTML = ''; }
     channelsCache = [];
     updateBotStatusBadge(null);
     return;
@@ -3655,6 +3825,7 @@ async function updateRegButton() {
     const resp = await fetch(`${API}/channels`, { credentials: 'include' });
     if (!resp.ok) {
       btn.style.display = 'none';
+      if (controlHost) { controlHost.innerHTML = ''; }
       channelsCache = [];
       updateBotStatusBadge(null);
       return;
@@ -3662,7 +3833,9 @@ async function updateRegButton() {
     const rawList = await resp.json();
     const list = Array.isArray(rawList) ? rawList : [];
     channelsCache = list;
-    updateBotStatusBadge(getChannelInfo(channelName));
+    const activeChannelInfo = getChannelInfo(channelName);
+    updateBotStatusBadge(activeChannelInfo);
+    renderHeaderBotControl(activeChannelInfo);
     const found = list.find(ch => ch.channel_name.toLowerCase() === userLogin.toLowerCase());
     const startChannelAuth = async () => {
       const returnUrl = window.location.href.split('#')[0];
@@ -3685,47 +3858,15 @@ async function updateRegButton() {
     };
 
     if (found && found.authorized) {
-      const channel = found.channel_name;
-      const joinActive = !!found.join_active;
-      btn.textContent = joinActive ? 'mute the bot' : 'join the bot to chat';
-      btn.onclick = async () => {
-        btn.disabled = true;
-        const desired = joinActive ? 0 : 1;
-        const encodedChannel = encodeURIComponent(channel);
-        try {
-          const toggleResp = await fetch(`${API}/channels/${encodedChannel}?join_active=${desired}`, {
-            method: 'PUT',
-            credentials: 'include'
-          });
-          if (!toggleResp.ok) {
-            throw new Error(`toggle failed with status ${toggleResp.status}`);
-          }
-          const queueState = joinActive ? 1 : 0;
-          try {
-            await fetch(`${API}/channels/${encodedChannel}/settings`, {
-              method: 'POST',
-              body: JSON.stringify({ queue_closed: queueState }),
-              headers: { 'Content-Type': 'application/json' },
-              credentials: 'include'
-            });
-          } catch (e) {
-            console.warn('Failed to update queue mute state', e);
-          }
-        } catch (e) {
-          console.error('Failed to update bot join status', e);
-          alert('Unable to update the bot status. Please try again.');
-        } finally {
-          btn.disabled = false;
-          updateRegButton();
-        }
-      };
+      btn.style.display = 'none';
     } else {
       btn.textContent = found ? 'authorize the bot for your channel' : 'register your channel';
       btn.onclick = startChannelAuth;
+      btn.style.display = '';
     }
-    btn.style.display = '';
   } catch (e) {
     btn.style.display = 'none';
+    if (controlHost) { controlHost.innerHTML = ''; }
     channelsCache = [];
     updateBotStatusBadge(null);
   }

--- a/queue_manager/public/style.css
+++ b/queue_manager/public/style.css
@@ -22,6 +22,10 @@ a:hover{text-decoration:underline}
 .status-action.danger:hover{background:rgba(239,68,68,0.15)}
 .wrap{max-width:var(--w);margin:24px auto;padding:0 8px}
 .header{display:flex;gap:16px;align-items:center;margin-bottom:16px;position:relative}
+.bot-control-host{margin-left:auto;display:flex;align-items:center}
+.bot-control-select{padding:.35rem .6rem;border-radius:8px;border:1px solid #24283b;background:#121423;color:var(--text);font-size:12px;min-width:200px}
+.bot-control-select:focus{outline:2px solid var(--accent);outline-offset:2px}
+.bot-control-select:disabled{opacity:.6;cursor:not-allowed}
 .dev-stamp{position:absolute;top:-16px;right:-16px;padding:.45rem 1.5rem;border:2px solid rgba(255,94,135,.65);border-radius:.5rem;background:rgba(255,94,135,.18);color:rgba(255,145,180,.95);font-weight:800;font-size:1.05rem;letter-spacing:.35rem;transform:rotate(-12deg);text-transform:uppercase;pointer-events:none;user-select:none;box-shadow:0 12px 30px rgba(255,94,135,.2)}
 .dev-stamp[hidden]{display:none!important}
 .brand{font-weight:700;font-size:20px}
@@ -296,7 +300,7 @@ a:hover{text-decoration:underline}
 .setting-control.disabled{opacity:.45;cursor:not-allowed}
 .setting-control.loading{opacity:.6}
 .scope-warning{color:#f7d046;font-size:12px;margin:0}
-.setting-toggle.loading,.setting-number.loading,.setting-text.loading{opacity:.6}
+.setting-toggle.loading,.setting-number.loading,.setting-text.loading,.setting-select.loading{opacity:.6}
 .setting-toggle{display:flex;align-items:center;gap:10px}
 .toggle-state{font-size:13px;font-weight:600;text-transform:uppercase;letter-spacing:.04em;color:var(--muted)}
 .toggle-switch{position:relative;display:inline-block;width:46px;height:26px}
@@ -320,6 +324,7 @@ a:hover{text-decoration:underline}
 .setting-input,.setting-textarea{width:100%;padding:.5rem .6rem;border-radius:10px;border:1px solid #24283b;background:#0f1117;color:var(--text)}
 .setting-input:focus,.setting-textarea:focus{outline:2px solid var(--accent);outline-offset:2px}
 .setting-textarea{min-height:90px;resize:vertical}
+.setting-select{min-width:220px}
 
 .channel-key-card{display:flex;flex-direction:column;gap:10px;margin-top:10px;padding:14px;border-radius:12px;border:1px solid #24283b;background:#121423}
 .channel-key-header{display:flex;gap:18px;align-items:flex-start;justify-content:space-between;flex-wrap:wrap}

--- a/tests/test_channel_events.py
+++ b/tests/test_channel_events.py
@@ -447,6 +447,58 @@ class ChannelEventTests(unittest.TestCase):
         )
         self.assertEqual(invalid.status_code, 422, invalid.text)
 
+    def test_channel_status_route_controls_join_active_and_rejects_invalid_values(self) -> None:
+        """Connect/disconnect should use `/channels/{channel}` with strict join_active validation."""
+
+        details = _setup_channel()
+        channel = details["channel_name"]
+        headers = {"X-Admin-Token": backend_app.ADMIN_TOKEN}
+
+        disconnect = self.client.put(
+            f"/channels/{channel}",
+            params={"join_active": 0},
+            headers=headers,
+        )
+        self.assertEqual(disconnect.status_code, 200, disconnect.text)
+
+        with backend_app.SessionLocal() as db:
+            stored = db.query(backend_app.ActiveChannel).filter_by(channel_name=channel).one()
+            self.assertEqual(stored.join_active, 0)
+
+        reconnect = self.client.put(
+            f"/channels/{channel}",
+            params={"join_active": 1},
+            headers=headers,
+        )
+        self.assertEqual(reconnect.status_code, 200, reconnect.text)
+
+        invalid = self.client.put(
+            f"/channels/{channel}",
+            params={"join_active": 2},
+            headers=headers,
+        )
+        self.assertEqual(invalid.status_code, 422, invalid.text)
+
+    def test_settings_route_ignores_join_active_and_only_updates_message_level(self) -> None:
+        """Settings updates should keep join state untouched while still applying bot message level."""
+
+        details = _setup_channel()
+        channel = details["channel_name"]
+        headers = {"X-Admin-Token": backend_app.ADMIN_TOKEN}
+
+        update = self.client.put(
+            f"/channels/{channel}/settings",
+            json={"join_active": 0, "bot_message_level": "verbose"},
+            headers=headers,
+        )
+        self.assertEqual(update.status_code, 200, update.text)
+
+        with backend_app.SessionLocal() as db:
+            stored_channel = db.query(backend_app.ActiveChannel).filter_by(channel_name=channel).one()
+            stored_settings = backend_app.get_or_create_settings(db, stored_channel.id)
+            self.assertEqual(stored_channel.join_active, 1)
+            self.assertEqual(stored_settings.bot_message_level, "verbose")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_queue_manager_users_ui.py
+++ b/tests/test_queue_manager_users_ui.py
@@ -31,6 +31,24 @@ class QueueManagerUsersUiTests(unittest.TestCase):
         self.assertIn('resolveUserBadge', script)
         self.assertIn('.user-role-badge', css)
 
+    def test_header_bot_dropdown_hook_exists(self) -> None:
+        """Queue Manager header should expose the shared bot-control dropdown mount."""
+
+        html = Path("queue_manager/public/index.html").read_text(encoding="utf-8")
+        self.assertIn('id="bot-control-host"', html)
+
+    def test_bot_control_model_includes_connection_and_levels(self) -> None:
+        """Unified dropdown model should include connect/disconnect and all message levels."""
+
+        script = Path("queue_manager/public/queue_manager.js").read_text(encoding="utf-8")
+        self.assertIn("const BOT_CONTROL_OPTION_MODEL =", script)
+        self.assertIn("{ value: 'connect'", script)
+        self.assertIn("{ value: 'disconnect'", script)
+        self.assertIn("{ value: 'mute'", script)
+        self.assertIn("{ value: 'normal'", script)
+        self.assertIn("{ value: 'verbose'", script)
+        self.assertIn("{ value: 'debug'", script)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
### Motivation
- Replace the scattered mute/footer control with a single, consistent control that reflects bot connection state and message verbosity in one place. 
- Keep UI and backend API semantics aligned so connect/disconnect uses channel status while verbosity remains a settings update. 
- Reuse the same renderer in Settings to avoid duplicated control logic and ensure consistent UX.

### Description
- Added a header-mounted dropdown mount `#bot-control-host` and removed the legacy footer `#mute-btn` in `queue_manager/public/index.html` and `style.css` (new `.bot-control-*` styles). 
- Introduced a shared option model `BOT_CONTROL_OPTION_MODEL` in `queue_manager/public/queue_manager.js` with `connect`, `disconnect`, `mute`, `normal`, `verbose`, and `debug`, plus helpers `getBotControlOptions`, `createBotControlDropdown`, and `applyBotControlSelection` to render and persist selections. 
- Made the dropdown state-aware (shows only `connect` when `join_active` is false; shows `disconnect` + message levels when connected) and reused that dropdown for the Settings `bot_message_level` control instead of the generic control generator. 
- Wired `connect`/`disconnect` to `PUT /channels/{channel}?join_active=...` and message-level choices to `PUT /channels/{channel}/settings` with `{ "bot_message_level": "<level>" }`. 
- Backend validation and payload alignment: added `bot_message_level` to `/channels` responses for UI state, and constrained the `/channels/{channel}` `join_active` parameter to `0..1` via query validation. 
- Updated documentation (`docs/README.md`, `docs/backend_api.md`) to describe the unified control behavior and exact API mapping. 

### Testing
- Ran the focused unit tests `tests.test_queue_manager_users_ui` and `tests.test_channel_events` after ensuring the test SQLite path; the initial attempt failed due to a missing `/data` directory, then `mkdir -p /data` was created and tests were re-run. 
- Both test modules passed on the final run (tests for header dropdown hooks, option model presence, `bot_message_level` validation, and `join_active` route behavior all succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c97ecae6b88328ba5c048c44f71021)