### PR TITLE
Add Users tab badge legend driven by shared badge definitions

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -161,6 +161,8 @@ them via `/me/channels`.
 - A square role badge precedes each name with priority Mod > VIP > Subscriber >
   Viewer; subscribers show their tier number inside the badge while viewers get
   a neutral grey marker.
+- A compact legend row appears above the user list (`M`, `V`, subscriber tier,
+  and `•`) so managers and screen readers can decode each symbol quickly.
 - Metadata is presented in bracketed chips (for example `[behind: 3]` and
   `[prio: 2]`) to keep “amount behind” context aligned across rows.
 - Each row includes a **Delete** action so managers can remove malformed or

--- a/queue_manager/public/index.html
+++ b/queue_manager/public/index.html
@@ -162,6 +162,7 @@
             <span id="users-page" class="muted" role="status" aria-live="polite"></span>
             <button id="users-next" type="button">Next</button>
           </div>
+          <div id="users-legend" class="users-legend" role="list" aria-label="User badge legend"></div>
           <div id="users" class="users-list"></div>
         </div>
 

--- a/queue_manager/public/queue_manager.js
+++ b/queue_manager/public/queue_manager.js
@@ -2207,6 +2207,7 @@ document.addEventListener('keydown', evt => {
 
 document.addEventListener('DOMContentLoaded', () => {
   initPlaylistPickerElements();
+  renderUsersLegend();
 });
 
 function formatTier(tier) {
@@ -2506,6 +2507,86 @@ function updateUsersPaginationControls() {
   }
 }
 
+const USER_BADGE_DEFINITIONS = Object.freeze([
+  {
+    role: 'mod',
+    legendLabel: 'Moderator',
+    legendSymbol: 'M',
+    ariaLabel: 'Moderator',
+    matches: user => user?.is_mod === true,
+    resolveLabel: () => 'M',
+  },
+  {
+    role: 'vip',
+    legendLabel: 'VIP',
+    legendSymbol: 'V',
+    ariaLabel: 'VIP',
+    matches: user => user?.is_vip === true,
+    resolveLabel: () => 'V',
+  },
+  {
+    role: 'sub',
+    legendLabel: 'Subscriber',
+    legendSymbol: '1',
+    ariaLabel: 'Subscriber',
+    matches: user => user?.is_subscriber === true,
+    resolveLabel: user => {
+      const tier = typeof user?.subscriber_tier === 'string' ? user.subscriber_tier : '';
+      const parsed = parseInt(tier, 10);
+      if (!Number.isNaN(parsed) && parsed >= 1000) {
+        return `${Math.floor(parsed / 1000)}`;
+      }
+      return tier?.slice(0, 1) || 'S';
+    },
+  },
+  {
+    role: 'viewer',
+    legendLabel: 'Viewer',
+    legendSymbol: '•',
+    ariaLabel: 'Viewer',
+    matches: () => true,
+    resolveLabel: () => '•',
+  },
+]);
+
+/**
+ * Render the compact badge legend row shown above the users list.
+ * Dependencies: uses `USER_BADGE_DEFINITIONS` to stay aligned with badge
+ * rendering and expects `#users-legend` to exist in index.html.
+ * Code customers: users tab bootstrap and regression tests verifying legend
+ * hooks. Used variables/origin: legend labels/symbols come from the shared
+ * badge definition map.
+ */
+function renderUsersLegend() {
+  const legend = qs('users-legend');
+  if (!legend) { return; }
+  legend.innerHTML = '';
+  USER_BADGE_DEFINITIONS.forEach(definition => {
+    const item = document.createElement('div');
+    item.className = 'users-legend-item';
+    item.setAttribute('role', 'listitem');
+
+    const badge = document.createElement('span');
+    badge.className = `user-role-badge user-role-${definition.role}`;
+    badge.textContent = definition.legendSymbol;
+    badge.setAttribute('role', 'img');
+    badge.setAttribute('aria-label', `${definition.legendLabel} badge`);
+    badge.title = `${definition.legendLabel} badge`;
+
+    const text = document.createElement('span');
+    text.className = 'users-legend-text';
+    if (definition.role === 'sub') {
+      text.textContent = `${definition.legendLabel} (tier)`;
+    } else {
+      text.textContent = definition.legendLabel;
+    }
+
+    item.appendChild(badge);
+    item.appendChild(text);
+    legend.appendChild(item);
+  });
+}
+
 /**
  * Determine the highest-priority badge to display for a user.
  * Dependencies: consumes role hints (`is_mod`, `is_vip`, `is_subscriber`,
@@ -2515,29 +2596,12 @@ function updateUsersPaginationControls() {
  * tier parsing helper for subscriber labels.
  */
 function resolveUserBadge(user) {
-  const badge = { role: 'viewer', label: '•' };
-  if (user?.is_mod) {
-    badge.role = 'mod';
-    badge.label = 'M';
-    return badge;
-  }
-  if (user?.is_vip) {
-    badge.role = 'vip';
-    badge.label = 'V';
-    return badge;
-  }
-  if (user?.is_subscriber) {
-    badge.role = 'sub';
-    const tier = typeof user.subscriber_tier === 'string' ? user.subscriber_tier : '';
-    const parsed = parseInt(tier, 10);
-    if (!Number.isNaN(parsed) && parsed >= 1000) {
-      badge.label = `${Math.floor(parsed / 1000)}`;
-    } else {
-      badge.label = tier?.slice(0, 1) || 'S';
-    }
-    return badge;
-  }
-  return badge;
+  const match = USER_BADGE_DEFINITIONS.find(definition => definition.matches(user)) || USER_BADGE_DEFINITIONS[USER_BADGE_DEFINITIONS.length - 1];
+  return {
+    role: match.role,
+    label: match.resolveLabel(user),
+    ariaLabel: `${match.ariaLabel} badge`,
+  };
 }
 
 /**
@@ -2551,7 +2615,9 @@ function renderUserBadge(user) {
   const el = document.createElement('span');
   el.className = `user-role-badge user-role-${badge.role}`;
   el.textContent = badge.label;
-  el.setAttribute('aria-hidden', 'true');
+  el.setAttribute('role', 'img');
+  el.setAttribute('aria-label', badge.ariaLabel);
+  el.title = badge.ariaLabel;
   return el;
 }
 

--- a/queue_manager/public/style.css
+++ b/queue_manager/public/style.css
@@ -45,6 +45,10 @@ a:hover{text-decoration:underline}
 .users-pagination button{padding:.35rem .7rem;border-radius:8px;border:1px solid #24283b;background:#1a1d29;color:var(--text);cursor:pointer;font-size:12px;font-weight:600}
 .users-pagination button:hover{background:#24283b}
 .users-pagination .muted{min-width:90px;text-align:center}
+.users-legend{display:flex;flex-wrap:wrap;gap:6px;margin:0 0 10px 0;padding:6px 8px;border-radius:8px;border:1px solid #24283b;background:#0f1117;align-items:center}
+.users-legend-item{display:inline-flex;align-items:center;gap:6px;padding:2px 6px;border-radius:999px;border:1px solid #24283b;background:#121423;min-height:22px}
+.users-legend-item .user-role-badge{width:16px;height:16px;font-size:10px;border-radius:4px}
+.users-legend-text{font-size:11px;color:var(--muted);line-height:1}
 .users-list{display:flex;flex-direction:column;gap:10px}
 .user-row{display:grid;grid-template-columns:minmax(0,1fr) auto;gap:12px;align-items:center;padding:10px 12px;border-radius:10px;border:1px solid #24283b;background:#121423}
 .user-row:hover{border-color:var(--accent)}

--- a/tests/test_queue_manager_users_ui.py
+++ b/tests/test_queue_manager_users_ui.py
@@ -21,15 +21,19 @@ class QueueManagerUsersUiTests(unittest.TestCase):
         self.assertIn('const USER_PAGE_SIZE = 25;', script)
 
     def test_users_layout_and_badge_hooks(self) -> None:
-        """Layout and badge CSS hooks should exist for regression coverage."""
+        """Layout, badge hooks, and users legend wiring should stay in place."""
 
         html = Path("queue_manager/public/index.html").read_text(encoding="utf-8")
         script = Path("queue_manager/public/queue_manager.js").read_text(encoding="utf-8")
         css = Path("queue_manager/public/style.css").read_text(encoding="utf-8")
 
         self.assertIn('class="users-list"', html)
+        self.assertIn('id="users-legend"', html)
         self.assertIn('resolveUserBadge', script)
+        self.assertIn('USER_BADGE_DEFINITIONS', script)
+        self.assertIn('renderUsersLegend', script)
         self.assertIn('.user-role-badge', css)
+        self.assertIn('.users-legend', css)
 
     def test_header_bot_dropdown_hook_exists(self) -> None:
         """Queue Manager header should expose the shared bot-control dropdown mount."""


### PR DESCRIPTION
### Motivation
- Ensure the Users tab legend and per-user badges come from a single source-of-truth to avoid visual/behavioral drift between legend and rendered badges.
- Surface all visible badge states (Moderator `M`, VIP `V`, Subscriber tier, Viewer `•`) and make symbols accessible to screen readers.
- Improve discoverability by adding a compact, low-height legend row above the users list and document it in the project docs.

### Description
- Add a compact legend container above the Users list in `queue_manager/public/index.html` as `#users-legend` with `role="list"` and an accessible label.
- Introduce `USER_BADGE_DEFINITIONS` in `queue_manager/public/queue_manager.js` and refactor `resolveUserBadge` to derive role, label and `ariaLabel` from this shared definition map so the legend and per-user badges are driven from the same model.
- Add `renderUsersLegend()` which builds legend items from `USER_BADGE_DEFINITIONS`, wire it into `DOMContentLoaded`, and retain subscriber tier label logic so subscriber badges show the appropriate tier or short label.
- Improve accessibility by setting `role="img"`, `aria-label`, and `title` for legend badges and per-user badges; add matching compact styles in `queue_manager/public/style.css` (`.users-legend`, `.users-legend-item`, `.users-legend-text`) to match existing chip/badge design.
- Add/extend regression tests in `tests/test_queue_manager_users_ui.py` to assert presence of `id="users-legend"`, `USER_BADGE_DEFINITIONS`, `renderUsersLegend`, and `.users-legend` hooks.
- Update `docs/README.md` Users tab section to mention the new legend row and symbol meanings.

### Testing
- Ran `python -m unittest tests/test_queue_manager_users_ui.py`, which executed 5 tests and succeeded (`OK`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c98092d1e0832888700a1fac445817)