### PR TITLE
Add collapsible toggles for public playlist song lists

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -121,6 +121,12 @@ unlocks the API for the bot, queue manager, and public web frontend.
 
 ## Web Interface
 The web container hosts files in `web/public/`, including a simple `index.html`, `app.js`, and `style.css` for viewing the queue.
+- Public playlist cards now render with per-playlist **Show songs / Hide songs**
+  controls so song rows are collapsible.
+- Playlist song rows default to collapsed, and each card remembers its expanded
+  state during in-page rerenders using an in-memory map keyed by playlist slug.
+- Toggle buttons are wired for accessibility with `aria-expanded` plus
+  `aria-controls` targeting each `.public-playlist__items` container.
 
 ## Authentication & Channel Access
 Songbot relies on two distinct OAuth flows that map to the two management panels:

--- a/tests/test_public_playlists_ui.py
+++ b/tests/test_public_playlists_ui.py
@@ -1,0 +1,29 @@
+import unittest
+from pathlib import Path
+
+
+class PublicPlaylistsUiTests(unittest.TestCase):
+    """Guard public playlist markup/state hooks used by the static queue web UI."""
+
+    def test_playlist_toggle_button_markup_and_labels_exist(self) -> None:
+        """Public playlist cards should expose accessible show/hide toggle controls."""
+
+        script = Path("web/public/app.js").read_text(encoding="utf-8")
+        self.assertIn("public-playlist__toggle", script)
+        self.assertIn("'Show songs'", script)
+        self.assertIn("'Hide songs'", script)
+        self.assertIn("aria-expanded", script)
+        self.assertIn("aria-controls", script)
+        self.assertIn("itemsContainer.hidden =", script)
+
+    def test_playlist_toggle_state_cache_is_present(self) -> None:
+        """Queue context should keep per-playlist expansion state across rerenders."""
+
+        script = Path("web/public/app.js").read_text(encoding="utf-8")
+        self.assertIn("playlistExpandState: new Map()", script)
+        self.assertIn("isPublicPlaylistExpanded", script)
+        self.assertIn("setPublicPlaylistExpanded", script)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/web/public/app.js
+++ b/web/public/app.js
@@ -457,6 +457,26 @@ function render(list, container) {
   list.forEach(({ q, song, user }) => container.appendChild(itemNode(q, song, user)));
 }
 
+/**
+ * Resolve the in-memory expansion state for a public playlist card.
+ * Dependencies: `queueCtx.playlistExpandState` (state store initialized in queue mode).
+ * Consumers: `renderPublicPlaylists` during initial render and button toggles during rerenders.
+ */
+function isPublicPlaylistExpanded(playlistKey) {
+  if (!queueCtx || !(queueCtx.playlistExpandState instanceof Map)) return false;
+  return Boolean(queueCtx.playlistExpandState.get(playlistKey));
+}
+
+/**
+ * Persist the in-memory expansion state for a public playlist card.
+ * Dependencies: `queueCtx.playlistExpandState` map and playlist slug/id keys.
+ * Consumers: toggle-button click handlers and initial state seeding in `renderPublicPlaylists`.
+ */
+function setPublicPlaylistExpanded(playlistKey, expanded) {
+  if (!queueCtx || !(queueCtx.playlistExpandState instanceof Map)) return;
+  queueCtx.playlistExpandState.set(playlistKey, Boolean(expanded));
+}
+
 function renderPublicPlaylists(list, { errored = false } = {}) {
   if (!queueCtx || !queueCtx.playlistsEl) return;
   const container = queueCtx.playlistsEl;
@@ -487,7 +507,7 @@ function renderPublicPlaylists(list, { errored = false } = {}) {
   if (cta && defaultCta) {
     cta.innerHTML = defaultCta;
   }
-  normalized.forEach((playlist) => {
+  normalized.forEach((playlist, playlistIdx) => {
     const card = document.createElement('div');
     card.className = 'public-playlist';
 
@@ -527,12 +547,34 @@ function renderPublicPlaylists(list, { errored = false } = {}) {
       keywordsLabel.textContent = `Keywords: ${keywords.join(', ')}`;
       meta.appendChild(keywordsLabel);
     }
+    const playlistKey = slug || `playlist-${playlistIdx}`;
+    if (!queueCtx.playlistExpandState.has(playlistKey)) {
+      setPublicPlaylistExpanded(playlistKey, false);
+    }
+    const toggleBtn = document.createElement('button');
+    toggleBtn.type = 'button';
+    toggleBtn.className = 'public-playlist__toggle';
+    const isExpanded = isPublicPlaylistExpanded(playlistKey);
+    toggleBtn.textContent = isExpanded ? 'Hide songs' : 'Show songs';
+    toggleBtn.setAttribute('aria-expanded', isExpanded ? 'true' : 'false');
+    meta.appendChild(toggleBtn);
 
     header.appendChild(meta);
     card.appendChild(header);
 
     const itemsContainer = document.createElement('div');
     itemsContainer.className = 'public-playlist__items';
+    const itemsContainerId = `public-playlist-items-${playlistIdx}-${slug.replace(/[^a-z0-9_-]+/gi, '-').toLowerCase() || 'default'}`;
+    itemsContainer.id = itemsContainerId;
+    itemsContainer.hidden = !isExpanded;
+    toggleBtn.setAttribute('aria-controls', itemsContainerId);
+    toggleBtn.addEventListener('click', () => {
+      const nextExpanded = !isPublicPlaylistExpanded(playlistKey);
+      setPublicPlaylistExpanded(playlistKey, nextExpanded);
+      itemsContainer.hidden = !nextExpanded;
+      toggleBtn.textContent = nextExpanded ? 'Hide songs' : 'Show songs';
+      toggleBtn.setAttribute('aria-expanded', nextExpanded ? 'true' : 'false');
+    });
     const items = Array.isArray(playlist?.items) ? playlist.items : [];
     if (!items.length) {
       const emptyRow = document.createElement('div');
@@ -785,6 +827,7 @@ function initQueueMode() {
     playlistCta: playlistCtaEl || null,
     playlistCtaDefault: playlistCtaEl ? playlistCtaEl.innerHTML : '',
     playlistCache: null,
+    playlistExpandState: new Map(),
     lastPlaylistFetch: 0,
   };
 

--- a/web/public/style.css
+++ b/web/public/style.css
@@ -565,6 +565,28 @@ body[data-mode="queue"] .playlists-card {
   color: var(--text);
 }
 
+.public-playlist__toggle {
+  padding: 0.35rem 0.7rem;
+  border-radius: 8px;
+  border: 1px solid #2b3244;
+  background: rgba(148, 163, 184, 0.14);
+  color: var(--text);
+  font-weight: 600;
+  font-size: 12px;
+  cursor: pointer;
+  transition: background 0.2s ease, border-color 0.2s ease;
+}
+
+.public-playlist__toggle:hover {
+  background: rgba(148, 163, 184, 0.24);
+}
+
+.public-playlist__toggle[aria-expanded="true"] {
+  border-color: rgba(139, 92, 246, 0.5);
+  background: rgba(139, 92, 246, 0.18);
+  color: var(--accent);
+}
+
 .public-playlist__items {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
### Motivation
- Make long public playlist cards easier to scan by adding a per-playlist collapse/expand control so users can hide or show song rows.
- Preserve user preference across rerenders by storing expansion state in memory per playlist rather than resetting on each render.
- Ensure the new control is accessible by toggling `hidden` on the items container and setting `aria-expanded` and `aria-controls` on the button.

### Description
- Added two helper functions with short descriptions: `isPublicPlaylistExpanded` and `setPublicPlaylistExpanded` which read/write expansion state from `queueCtx.playlistExpandState` (the state map is initialized in `initQueueMode`).
- Updated `renderPublicPlaylists()` to render a `Show songs` / `Hide songs` toggle button for each playlist, generate an `id` for the `.public-playlist__items` container, toggle `itemsContainer.hidden`, and update `aria-expanded`/`aria-controls` accordingly.
- Initialized per-playlist state with `playlistExpandState: new Map()` on `queueCtx` and keyed states by playlist slug or an index-based fallback.
- Added styles for `.public-playlist__toggle` in `web/public/style.css` to match existing card control patterns and show a distinct expanded visual state.
- Added a small static frontend regression test `tests/test_public_playlists_ui.py` that asserts presence of toggle class, labels, `aria-*` hooks, hidden toggling code, and state helpers, and updated `docs/README.md` to document the new collapsible playlist behavior.

### Testing
- Ran `python -m unittest tests/test_public_playlists_ui.py` and the tests passed (OK).
- Ran `python -m unittest tests/test_queue_manager_users_ui.py` and the existing suite passed (OK).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c98255b99c8328988ecf72b1fc09a0)