### PR TITLE
Seed Favorites playlist defaults across channel onboarding paths

### DIFF
--- a/backend_app.py
+++ b/backend_app.py
@@ -2489,6 +2489,16 @@ def _resolve_user_from_token(
 
 
 def _auto_register_channel_from_token(user: TwitchUser, data: dict[str, Any], db: Session) -> None:
+    """Auto-create/update channel ownership from a validated user OAuth token.
+
+    Dependencies: Consumes token metadata produced by ``_resolve_user_from_token``
+    and persists ``ActiveChannel``/settings/default playlists via SQLAlchemy.
+    Code customers: Invoked by ``/auth/session`` to complete self-service
+    onboarding for channel owners signing in with Twitch.
+    Used variables/origin: Reads ``data.scopes/login/user_id`` from Twitch
+    validation output and maps those values onto ``ActiveChannel`` ownership.
+    """
+
     scopes = set(data.get("scopes") or [])
     login = data.get("login")
     user_id = data.get("user_id")
@@ -2536,6 +2546,8 @@ def _auto_register_channel_from_token(user: TwitchUser, data: dict[str, Any], db
             owner_id=user.id,
         )
         db.add(channel)
+        db.flush()
+        _create_default_favorites_playlist(db, channel.id)
         db.commit()
         db.refresh(channel)
         get_or_create_settings(db, channel.id)
@@ -2740,6 +2752,8 @@ def auth_callback(
             owner_id=user.id,
         )
         db.add(ch)
+        db.flush()
+        _create_default_favorites_playlist(db, ch.id)
     else:
         ch.owner_id = user.id
         ch.authorized = True
@@ -3714,8 +3728,41 @@ def _aggregate_playlist_items(playlists: Iterable[Playlist]) -> List[PlaylistIte
     return collected
 
 
+FAVORITES_SEED_TRACKS: tuple[dict[str, str], ...] = (
+    {
+        "title": "Night Drive",
+        "artist": "FM-84",
+        "url": "https://www.youtube.com/watch?v=TvZskcqdYcE",
+        "video_id": "TvZskcqdYcE",
+    },
+    {
+        "title": "Strobe",
+        "artist": "deadmau5",
+        "url": "https://www.youtube.com/watch?v=tKi9Z-f6qX4",
+        "video_id": "tKi9Z-f6qX4",
+    },
+    {
+        "title": "Voices",
+        "artist": "LONG DISTANCE CALLING",
+        "url": "https://www.youtube.com/watch?v=uWQQbQ9jqU4",
+        "video_id": "uWQQbQ9jqU4",
+    },
+)
+
+
 def _create_default_favorites_playlist(db: Session, channel_pk: int) -> Playlist:
-    existing = (
+    """Ensure a channel has the seeded Favorites playlist without duplicating tracks.
+
+    Dependencies: Uses ``Playlist``/``PlaylistItem`` ORM models and
+    ``_canonicalize_video_url`` to normalize the configured seed metadata.
+    Code customers: Called during channel onboarding paths (manual creation,
+    OAuth callback registration, and token auto-registration).
+    Used variables/origin: ``channel_pk`` identifies the owning channel;
+    ``FAVORITES_SEED_TRACKS`` defines deterministic seeded title/artist/url/video
+    values that are inserted only when missing.
+    """
+
+    playlist = (
         db.query(Playlist)
         .filter(
             Playlist.channel_id == channel_pk,
@@ -3724,32 +3771,54 @@ def _create_default_favorites_playlist(db: Session, channel_pk: int) -> Playlist
         )
         .one_or_none()
     )
-    if existing:
-        return existing
-    playlist = Playlist(
-        channel_id=channel_pk,
-        title="Favorites",
-        description="Default favorites playlist",
-        source="manual",
-        visibility="public",
-    )
-    db.add(playlist)
-    db.flush()
+    if not playlist:
+        playlist = Playlist(
+            channel_id=channel_pk,
+            title="Favorites",
+            description="Default favorites playlist",
+            source="manual",
+            visibility="public",
+        )
+        db.add(playlist)
+        db.flush()
+
+    existing_keywords = {keyword.keyword for keyword in playlist.keywords}
     for keyword in ("default", "favorite"):
-        playlist.keywords.append(PlaylistKeyword(keyword=keyword))
-    url, video_id = _canonicalize_video_url(
-        "https://www.youtube.com/watch?v=9Pzj6U5c2cs",
-        "9Pzj6U5c2cs",
-    )
-    item = PlaylistItem(
-        playlist_id=playlist.id,
-        title="Default Favorite",
-        artist="Unknown",
-        position=1,
-        video_id=video_id,
-        url=url,
-    )
-    db.add(item)
+        if keyword not in existing_keywords:
+            playlist.keywords.append(PlaylistKeyword(keyword=keyword))
+
+    existing_item_keys: set[str] = set()
+    max_position = 0
+    for item in playlist.items:
+        normalized_url, normalized_video_id = _canonicalize_video_url(item.url, item.video_id)
+        if normalized_url and item.url != normalized_url:
+            item.url = normalized_url
+        if normalized_video_id and item.video_id != normalized_video_id:
+            item.video_id = normalized_video_id
+        key = normalized_video_id or normalized_url
+        if key:
+            existing_item_keys.add(key)
+        max_position = max(max_position, item.position or 0)
+
+    for seed in FAVORITES_SEED_TRACKS:
+        normalized_url, normalized_video_id = _canonicalize_video_url(seed["url"], seed["video_id"])
+        seed_key = normalized_video_id or normalized_url
+        if seed_key and seed_key in existing_item_keys:
+            continue
+        max_position += 1
+        db.add(
+            PlaylistItem(
+                playlist_id=playlist.id,
+                title=seed["title"],
+                artist=seed["artist"],
+                position=max_position,
+                video_id=normalized_video_id,
+                url=normalized_url,
+            )
+        )
+        if seed_key:
+            existing_item_keys.add(seed_key)
+
     db.flush()
     return playlist
 
@@ -4365,6 +4434,16 @@ def get_channel_live_status(db: Session = Depends(get_db)):
 
 @app.post("/channels", response_model=ChannelOut, dependencies=[Depends(require_token)])
 def add_channel(payload: ChannelIn, db: Session = Depends(get_db)):
+    """Create a channel and initialize default bot/settings/favorites resources.
+
+    Dependencies: Persists ``ActiveChannel`` plus helper-created settings/bot
+    state/favorites rows through the shared SQLAlchemy ``Session``.
+    Code customers: Admin bootstrap workflows and tests that provision channels
+    without Twitch OAuth.
+    Used variables/origin: ``payload`` provides persisted channel identifiers and
+    join-state; generated ``channel_key`` secures follow-up API operations.
+    """
+
     ch = ActiveChannel(
         channel_id=payload.channel_id,
         channel_name=payload.channel_name,
@@ -4372,12 +4451,12 @@ def add_channel(payload: ChannelIn, db: Session = Depends(get_db)):
         join_active=payload.join_active,
     )
     db.add(ch)
-    db.commit()
-    db.refresh(ch)
+    db.flush()
     get_or_create_settings(db, ch.id)
     get_or_create_bot_state(db, ch.id)
     _create_default_favorites_playlist(db, ch.id)
     db.commit()
+    db.refresh(ch)
     channel_pk = ch.id
     publish_queue_changed(channel_pk)
     return ch

--- a/docs/README.md
+++ b/docs/README.md
@@ -95,6 +95,11 @@ unlocks the API for the bot, queue manager, and public web frontend.
 - Uses a SQLite database stored at `/data/db.sqlite` and defines models for channels, songs, users, stream sessions, and requests.
 - Stores bot OAuth credentials via the `/bot/config` API and exposes an OAuth
   helper flow for authorizing the bot account.
+- Automatically creates a manual `Favorites` playlist for new channels during
+  admin channel creation and OAuth onboarding flows. The playlist is seeded
+  idempotently with three tracks: `Night Drive` (FM-84),
+  `Strobe` (deadmau5), and `LONG DISTANCE CALLING - Voices`
+  (`https://www.youtube.com/watch?v=uWQQbQ9jqU4`).
 - Exposes REST endpoints for managing songs and queue entries, plus SSE streams
   for queue updates and bot log streaming.
 - `run.sh` initializes the database and starts the server with Uvicorn.

--- a/docs/backend_api.md
+++ b/docs/backend_api.md
@@ -11,7 +11,7 @@ This document summarizes the REST endpoints exposed by `backend_app.py`.
 | Method | Path | Description |
 |--------|------|-------------|
 | GET | `/auth/login` | Build a Twitch OAuth authorization URL for a channel, optionally preserving a `return_url`. |
-| GET | `/auth/callback` | Twitch OAuth callback that stores the access token and marks the user as the channel owner. |
+| GET | `/auth/callback` | Twitch OAuth callback that stores the access token, marks the user as the channel owner, and seeds Favorites for new channels. |
 | POST | `/auth/session` | Exchange a user OAuth token for a server-side session cookie. |
 | POST | `/auth/logout` | Clear the admin session cookie. |
 
@@ -44,13 +44,14 @@ This document summarizes the REST endpoints exposed by `backend_app.py`.
 - **Behavior**
   - Exchanges `code` for an access token and requires the `channel:bot` scope.
   - Fetches the authenticated Twitch user and upserts `TwitchUser` plus the matching `ActiveChannel`, setting `authorized=True` and `owner_id` to the user.
+  - When this flow creates a new channel record, it also creates a manual `Favorites` playlist and seeds these tracks (idempotently): `Night Drive` (FM-84), `Strobe` (deadmau5), and `LONG DISTANCE CALLING - Voices` (`https://www.youtube.com/watch?v=uWQQbQ9jqU4`).
   - Redirects to `return_url` when supplied and using an `http`/`https` scheme; otherwise returns `{ "success": true }`.
 
 ### `/auth/session`
 - **Authentication**: `Authorization: Bearer <user OAuth token>`.
 - **Behavior**
   - Validates the token against `https://id.twitch.tv/oauth2/validate` and refreshes the stored `TwitchUser` record.
-  - Auto-registers the channel as owned when the token carries the `channel:bot` scope.
+  - Auto-registers the channel as owned when the token carries the `channel:bot` scope; newly auto-created channels are initialized with the same seeded manual `Favorites` playlist.
   - Sets the `admin_oauth_token` cookie (HTTP-only, `SameSite=lax`) for subsequent admin access, honoring Twitch `expires_in` when present.
 - **Response**: `{ "login": "<twitch username>" }`.
 - **Errors**: 401 when the bearer token is missing or invalid.
@@ -93,7 +94,7 @@ This document summarizes the REST endpoints exposed by `backend_app.py`.
 | Method | Path | Description |
 |--------|------|-------------|
 | GET | `/channels` | List all configured channels. |
-| POST | `/channels` | Add a new channel (requires admin token). |
+| POST | `/channels` | Add a new channel (requires admin token) and initialize seeded Favorites. |
 | PUT | `/channels/{channel}` | Update whether the bot should join a channel (admin). |
 | GET | `/channels/{channel}/settings` | Retrieve channel configuration. |
 | PUT | `/channels/{channel}/settings` | Update channel configuration (admin). |
@@ -102,6 +103,11 @@ The settings update endpoint accepts partial payloads and merges them with the
 existing record so omitted fields keep their persisted values. Frontend callers
 should prefer sending the full current state when possible or rely on the
 backend merge behavior to avoid unintentionally resetting values to defaults.
+
+`POST /channels` also ensures a manual `Favorites` playlist exists and seeds
+missing defaults idempotently (`Night Drive`, `Strobe`, and
+`LONG DISTANCE CALLING - Voices`), so repeated onboarding does not duplicate
+tracks.
 
 Channel settings include queue intake controls:
 

--- a/tests/test_playlists.py
+++ b/tests/test_playlists.py
@@ -452,9 +452,11 @@ class PlaylistApiTests(unittest.TestCase):
             keywords = sorted(kw.keyword for kw in favorites.keywords)
             self.assertEqual(keywords, ["default", "favorite"])
             items = db.query(backend_app.PlaylistItem).filter_by(playlist_id=favorites.id).all()
-            self.assertEqual(len(items), 1)
-            self.assertEqual(items[0].video_id, "9Pzj6U5c2cs")
-            self.assertEqual(items[0].position, 1)
+            self.assertGreaterEqual(len(items), 3)
+            video_ids = {item.video_id for item in items}
+            self.assertIn("uWQQbQ9jqU4", video_ids)
+            self.assertIn("TvZskcqdYcE", video_ids)
+            self.assertIn("tKi9Z-f6qX4", video_ids)
         finally:
             db.close()
 
@@ -703,3 +705,129 @@ class PlaylistApiTests(unittest.TestCase):
                 headers=self._admin_headers(),
             )
         self.assertEqual(public_pick.status_code, 200, public_pick.text)
+
+    def test_auth_callback_creates_favorites_with_seed_tracks(self) -> None:
+        _wipe_db()
+        db = backend_app.SessionLocal()
+        try:
+            backend_app.set_settings(
+                db,
+                {
+                    "setup_complete": "1",
+                    "twitch_client_id": "client",
+                    "twitch_client_secret": "secret",
+                },
+            )
+        finally:
+            db.close()
+        backend_app.settings_store.invalidate()
+
+        with mock.patch("backend_app.requests.post") as mock_post, mock.patch("backend_app.requests.get") as mock_get, mock.patch("backend_app.ensure_eventsub_subscriptions"):
+            mock_post.return_value.json.return_value = {
+                "access_token": "access",
+                "refresh_token": "refresh",
+                "scope": ["channel:bot"],
+            }
+            mock_get.return_value.json.return_value = {
+                "data": [{"id": "tw123", "login": "oauthchan"}]
+            }
+            response = self.client.get(
+                "/auth/callback",
+                params={"code": "abc", "state": "oauthchan"},
+            )
+
+        self.assertEqual(response.status_code, 200, response.text)
+        db = backend_app.SessionLocal()
+        try:
+            channel = db.query(backend_app.ActiveChannel).filter_by(channel_name="oauthchan").one()
+            favorites = (
+                db.query(backend_app.Playlist)
+                .filter_by(channel_id=channel.id, title="Favorites", source="manual")
+                .one()
+            )
+            items = db.query(backend_app.PlaylistItem).filter_by(playlist_id=favorites.id).all()
+            self.assertEqual(len(items), 3)
+            self.assertEqual({item.video_id for item in items}, {"TvZskcqdYcE", "tKi9Z-f6qX4", "uWQQbQ9jqU4"})
+        finally:
+            db.close()
+
+    def test_auth_callback_repeat_does_not_duplicate_seed_tracks(self) -> None:
+        _wipe_db()
+        db = backend_app.SessionLocal()
+        try:
+            backend_app.set_settings(
+                db,
+                {
+                    "setup_complete": "1",
+                    "twitch_client_id": "client",
+                    "twitch_client_secret": "secret",
+                },
+            )
+        finally:
+            db.close()
+        backend_app.settings_store.invalidate()
+
+        with mock.patch("backend_app.requests.post") as mock_post, mock.patch("backend_app.requests.get") as mock_get, mock.patch("backend_app.ensure_eventsub_subscriptions"):
+            mock_post.return_value.json.return_value = {
+                "access_token": "access",
+                "refresh_token": "refresh",
+                "scope": ["channel:bot"],
+            }
+            mock_get.return_value.json.return_value = {
+                "data": [{"id": "tw123", "login": "oauthchan"}]
+            }
+            first = self.client.get("/auth/callback", params={"code": "abc", "state": "oauthchan"})
+            self.assertEqual(first.status_code, 200, first.text)
+            second = self.client.get("/auth/callback", params={"code": "def", "state": "oauthchan"})
+            self.assertEqual(second.status_code, 200, second.text)
+
+        db = backend_app.SessionLocal()
+        try:
+            channel = db.query(backend_app.ActiveChannel).filter_by(channel_name="oauthchan").one()
+            favorites = db.query(backend_app.Playlist).filter_by(channel_id=channel.id, title="Favorites").one()
+            items = db.query(backend_app.PlaylistItem).filter_by(playlist_id=favorites.id).all()
+            self.assertEqual(len(items), 3)
+            self.assertEqual({item.video_id for item in items}, {"TvZskcqdYcE", "tKi9Z-f6qX4", "uWQQbQ9jqU4"})
+        finally:
+            db.close()
+
+    def test_auth_session_auto_register_creates_favorites_without_duplicates(self) -> None:
+        _wipe_db()
+        db = backend_app.SessionLocal()
+        try:
+            user = backend_app.TwitchUser(
+                twitch_id="usr1",
+                username="viewer",
+                access_token="token",
+                refresh_token="",
+                scopes="channel:bot",
+            )
+            db.add(user)
+            db.commit()
+            db.refresh(user)
+        finally:
+            db.close()
+
+        auth_data = {
+            "scopes": ["channel:bot"],
+            "login": "tokenchan",
+            "user_id": "tok123",
+            "expires_in": 3600,
+        }
+
+        with mock.patch.object(backend_app, "_resolve_user_from_token") as resolver:
+            resolver.return_value = (user, auth_data)
+            first = self.client.post("/auth/session", headers={"Authorization": "Bearer testtoken"})
+            self.assertEqual(first.status_code, 200, first.text)
+            second = self.client.post("/auth/session", headers={"Authorization": "Bearer testtoken"})
+            self.assertEqual(second.status_code, 200, second.text)
+
+        db = backend_app.SessionLocal()
+        try:
+            channel = db.query(backend_app.ActiveChannel).filter_by(channel_name="tokenchan").one()
+            favorites = db.query(backend_app.Playlist).filter_by(channel_id=channel.id, title="Favorites").one()
+            items = db.query(backend_app.PlaylistItem).filter_by(playlist_id=favorites.id).all()
+            self.assertEqual(len(items), 3)
+            self.assertEqual({item.video_id for item in items}, {"TvZskcqdYcE", "tKi9Z-f6qX4", "uWQQbQ9jqU4"})
+        finally:
+            db.close()


### PR DESCRIPTION
### Motivation
- Ensure every newly created channel receives a manual `Favorites` playlist seeded with at least three explicit tracks (two chosen defaults plus `LONG DISTANCE CALLING - Voices`) and that seeding is idempotent. 
- Run seeding from all channel onboarding paths so manual creation, OAuth callback, and token auto-registration produce the same default playlist experience. 

### Description
- Expanded `_create_default_favorites_playlist` to use a new `FAVORITES_SEED_TRACKS` constant and idempotently backfill missing seed items while normalizing existing item `url`/`video_id` values, preserving keywords, and avoiding duplicates. 
- Added descriptive docstrings to `/_auto_register_channel_from_token` and `add_channel` and documented dependencies/used variables in the new `Favorites` function docstring. 
- Wired ` _create_default_favorites_playlist(db, channel.id)` into all onboarding paths: `add_channel` (admin `POST /channels`), the `/auth/callback` branch when creating a new `ActiveChannel`, and `_auto_register_channel_from_token` when creating a new `ActiveChannel`, and adjusted `db.flush()`/`db.commit()` ordering so `channel_id`/`playlist_id` are stable before inserting playlist items. 
- Added/updated tests in `tests/test_playlists.py` to verify manual channel creation, `/auth/callback` creation, token auto-registration, required seeded tracks present, and that repeated onboarding does not duplicate seed tracks. 
- Updated docs in `docs/README.md` and `docs/backend_api.md` to describe the default Favorites behavior and list the seeded tracks. 

### Testing
- Ran the playlist test suite with `python -m pytest tests/test_playlists.py -q`; initial run failed due to missing `/data` directory (SQLite open error). 
- Created the directory and re-ran `mkdir -p /data && python -m pytest tests/test_playlists.py -q` and all playlist tests passed (`19 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c98384c25083289447a95e8bf541ff)