### PR TITLE
Add regression test to prevent duplicate `const badge` in resolveUserBadge

### DIFF
--- a/tests/test_queue_manager_users_ui.py
+++ b/tests/test_queue_manager_users_ui.py
@@ -35,6 +35,23 @@ class QueueManagerUsersUiTests(unittest.TestCase):
         self.assertIn('.user-role-badge', css)
         self.assertIn('.users-legend', css)
 
+    def test_resolve_user_badge_has_no_duplicate_badge_declaration(self) -> None:
+        """resolveUserBadge should not re-declare `badge` (regression for duplicate const parsing failures)."""
+
+        script = Path("queue_manager/public/queue_manager.js").read_text(encoding="utf-8")
+        function_start = script.find("function resolveUserBadge(user) {")
+        self.assertNotEqual(function_start, -1, "resolveUserBadge definition should exist")
+
+        function_end = script.find("\n}\n\n/**", function_start)
+        self.assertNotEqual(function_end, -1, "resolveUserBadge closing block should be discoverable")
+
+        function_block = script[function_start:function_end]
+        self.assertLessEqual(
+            function_block.count("const badge ="),
+            1,
+            "resolveUserBadge should not contain duplicate `const badge` declarations",
+        )
+
     def test_header_bot_dropdown_hook_exists(self) -> None:
         """Queue Manager header should expose the shared bot-control dropdown mount."""
 


### PR DESCRIPTION
### Motivation
- Prevent a regression where duplicate `const badge =` declarations in `function resolveUserBadge(user)` cause parsing or lint failures by adding a focused, static test guard.

### Description
- Added a lightweight unit test in `tests/test_queue_manager_users_ui.py` that extracts the `resolveUserBadge` function block from `queue_manager/public/queue_manager.js` and asserts that the string `const badge =` appears at most once.

### Testing
- Ran a syntax check with `node --check queue_manager/public/queue_manager.js`, which succeeded.
- Ran the updated test suite with `python -m unittest tests.test_queue_manager_users_ui`, which ran 7 tests and passed (OK).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c986e22d748328a4babc4ce966989f)