### PR TITLE
Fix header bot reconnect action and document placeholder behavior

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -186,9 +186,14 @@ them via `/me/channels`.
 - The Queue Manager header now shows a single bot-control dropdown beside the
   channel and bot badges whenever the selected channel is authorized.
 - Dropdown options are state-aware:
-  - **Disconnected (`join_active = 0`)**: only `connect` is shown.
+  - **Disconnected (`join_active = 0`)**: a disabled `Select action…`
+    placeholder plus `connect` are shown so reconnect is always a user-triggered
+    selection change.
   - **Connected (`join_active = 1`)**: `disconnect` plus message levels
     `mute`, `normal`, `verbose`, and `debug` are shown.
+- Reconnect behavior is explicit: after a disconnect, the control resets to the
+  placeholder and the next `connect` pick immediately calls the channel-status
+  endpoint (instead of leaving `connect` preselected and non-invokable).
 - API mapping is explicit:
   - `connect`/`disconnect` -> `PUT /channels/{channel}?join_active=1|0`
   - `mute|normal|verbose|debug` -> `PUT /channels/{channel}/settings` with

--- a/queue_manager/public/queue_manager.js
+++ b/queue_manager/public/queue_manager.js
@@ -3100,19 +3100,28 @@ function buildSettingRow(key, value, meta) {
  * Build a reusable bot-control dropdown element from the unified option model.
  * Dependencies: uses BOT_CONTROL_OPTION_MODEL and getBotControlOptions() filtering to render menu choices.
  * Code customers: header action slot and settings row for `bot_message_level`.
- * Used variables/origin: reads channel join state from `channelInfo` and current setting value from `currentValue`.
+ * Used variables/origin: reads channel join state from `channelInfo`, current setting value from `currentValue`, and optional placeholder text from `placeholderLabel`.
  */
 function createBotControlDropdown({
   channelInfo,
   currentValue,
   includeConnectionActions = true,
   includeMessageLevels = true,
+  placeholderLabel = '',
   onSelection,
   disabled = false,
 }) {
   const select = document.createElement('select');
   select.className = 'bot-control-select';
   const options = getBotControlOptions(channelInfo, { includeConnectionActions, includeMessageLevels });
+  const hasPlaceholder = typeof placeholderLabel === 'string' && placeholderLabel.trim().length > 0;
+  if (hasPlaceholder) {
+    const placeholderOption = document.createElement('option');
+    placeholderOption.value = '';
+    placeholderOption.textContent = placeholderLabel;
+    placeholderOption.disabled = true;
+    select.appendChild(placeholderOption);
+  }
   options.forEach(option => {
     const opt = document.createElement('option');
     opt.value = option.value;
@@ -3122,9 +3131,10 @@ function createBotControlDropdown({
 
   const selectedValue = options.some(option => option.value === currentValue)
     ? currentValue
-    : (options[0]?.value || '');
-  if (selectedValue) {
-    select.value = selectedValue;
+    : '';
+  select.value = selectedValue;
+  if (!selectedValue && !hasPlaceholder && options[0]?.value) {
+    select.value = options[0].value;
   }
   select.disabled = disabled || !options.length;
   if (typeof onSelection === 'function' && !select.disabled) {
@@ -3988,8 +3998,12 @@ async function updateRegButton() {
       currentValue,
       includeConnectionActions: true,
       includeMessageLevels: true,
+      placeholderLabel: 'Select action…',
       onSelection: async (_event, element) => {
         const previous = currentValue;
+        if (!element.value) {
+          return;
+        }
         element.disabled = true;
         const ok = await applyBotControlSelection(element.value);
         if (!ok) {

--- a/queue_manager/public/style.css
+++ b/queue_manager/public/style.css
@@ -22,7 +22,7 @@ a:hover{text-decoration:underline}
 .status-action.danger:hover{background:rgba(239,68,68,0.15)}
 .wrap{max-width:var(--w);margin:24px auto;padding:0 8px}
 .header{display:flex;gap:16px;align-items:center;margin-bottom:16px;position:relative}
-.bot-control-host{margin-left:auto;display:flex;align-items:center}
+.bot-control-host{display:flex;align-items:center}
 .bot-control-select{padding:.35rem .6rem;border-radius:8px;border:1px solid #24283b;background:#121423;color:var(--text);font-size:12px;min-width:200px}
 .bot-control-select:focus{outline:2px solid var(--accent);outline-offset:2px}
 .bot-control-select:disabled{opacity:.6;cursor:not-allowed}

--- a/tests/test_queue_manager_users_ui.py
+++ b/tests/test_queue_manager_users_ui.py
@@ -70,6 +70,16 @@ class QueueManagerUsersUiTests(unittest.TestCase):
         self.assertIn("{ value: 'verbose'", script)
         self.assertIn("{ value: 'debug'", script)
 
+    def test_disconnected_header_control_uses_placeholder_for_connect_action(self) -> None:
+        """Disconnected header state should keep `connect` invokable via a placeholder-first dropdown."""
+
+        script = Path("queue_manager/public/queue_manager.js").read_text(encoding="utf-8")
+        self.assertIn("placeholderLabel: 'Select action…'", script)
+        self.assertIn("placeholderOption.value = '';", script)
+        self.assertIn("placeholderOption.disabled = true;", script)
+        self.assertIn("if (!element.value) {", script)
+        self.assertIn("if (!selectedValue && !hasPlaceholder && options[0]?.value)", script)
+
     def test_quick_controls_container_and_setting_keys_exist(self) -> None:
         """Queue tab should expose quick controls wired to key queue setting toggles."""
 


### PR DESCRIPTION
### Motivation
- Ensure the header bot-control makes `connect` a real, invokable user action after a disconnect instead of being preselected and inert. 
- Keep the shared dropdown renderer usable by both the header and Settings while preserving a settings-only, message-level selector when required. 
- Surface the behavior in documentation and protect it with a small regression test to avoid future regressions.

### Description
- Remove forced right-alignment by deleting `margin-left:auto` from `.bot-control-host` so the bot control flows inline beside other header elements via `queue_manager/public/style.css`.
- Extend `createBotControlDropdown` with an optional `placeholderLabel` parameter that renders a disabled placeholder option and selection fallback logic, and update its JSDoc to document the new parameter in `queue_manager/public/queue_manager.js`.
- Wire the header renderer (`updateRegButton` / `renderHeaderBotControl`) to pass `placeholderLabel: 'Select action…'` and guard against empty placeholder selections so picking `connect` triggers `applyBotControlSelection('connect')` in `queue_manager/public/queue_manager.js`.
- Preserve the Settings control behavior by continuing to call `createBotControlDropdown` with `includeConnectionActions: false` for `bot_message_level` so it remains a pure message-level selector.
- Add a regression unit test `test_disconnected_header_control_uses_placeholder_for_connect_action` to `tests/test_queue_manager_users_ui.py` that asserts presence of placeholder wiring and guard checks, and update `docs/README.md` to explicitly document reconnect/placeholder behavior and endpoint expectations.

### Testing
- Ran the UI unit tests with `python -m pytest tests/test_queue_manager_users_ui.py` and all tests passed: `8 passed`.
- The changes were exercised by the added test `test_disconnected_header_control_uses_placeholder_for_connect_action` which verifies the placeholder and guard logic (automated test success shown above).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c99408d51c8328888b3628ccf2b42f)