### PR TITLE
Improve queue quick-controls responsive wrapping and width safety

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -213,6 +213,9 @@ them via `/me/channels`.
 - Scope-gated setting behavior is shared with the main settings renderer, so a
   quick-control toggle is disabled and carries the same warning text whenever a
   required Twitch scope is missing.
+- The strip now wraps by default to preserve queue card width parity with the
+  Playlists, Users, and Settings tabs, and only enables horizontal scrolling at
+  explicit wide breakpoints with a `max-width: 100%` guard.
 
 ## Development Tips
 - Install Python dependencies from `requirements.txt` for local development.

--- a/queue_manager/public/style.css
+++ b/queue_manager/public/style.css
@@ -74,16 +74,17 @@ a:hover{text-decoration:underline}
   .user-row{grid-template-columns:minmax(0,1fr);gap:10px}
   .user-actions{justify-content:flex-start;flex-wrap:wrap}
 }
-.queue-layout{display:flex;flex-direction:column;gap:24px}
-.quick-controls{display:flex;align-items:center;gap:8px;flex-wrap:nowrap;overflow-x:auto;padding:8px 10px;border:1px solid #24283b;border-radius:10px;background:#121423;margin-bottom:12px}
+.queue-layout{display:flex;flex-direction:column;gap:24px;min-width:0}
+.quick-controls{display:flex;align-items:center;gap:6px;flex-wrap:wrap;overflow-x:visible;max-width:100%;min-width:0;padding:6px 8px;border:1px solid #24283b;border-radius:10px;background:#121423;margin-bottom:12px}
+.quick-controls>*{min-width:0}
 .quick-controls.disabled{opacity:.7}
 .quick-controls-hint{margin:0;white-space:nowrap}
-.quick-control-item{display:inline-flex;align-items:center;gap:6px;padding:4px 8px;border-radius:8px;border:1px solid #24283b;background:#0f1117;white-space:nowrap;flex:0 0 auto}
+.quick-control-item{display:inline-flex;align-items:center;gap:5px;padding:3px 7px;border-radius:8px;border:1px solid #24283b;background:#0f1117;white-space:nowrap;flex:0 1 auto}
 .quick-control-item input{accent-color:var(--accent);margin:0}
 .quick-control-label{font-size:12px;font-weight:600}
 .quick-control-state{font-size:11px}
 .quick-control-warning{display:none}
-.queue-column{flex:1 1 auto;min-width:min(800px,100%);display:flex;flex-direction:column;gap:12px}
+.queue-column{flex:1 1 auto;min-width:0;display:flex;flex-direction:column;gap:12px}
 .preview-column{flex:1 1 auto}
 .preview-card{display:flex;flex-direction:column;gap:14px;background:#151821;border:1px solid #24283b;border-radius:14px;padding:14px}
 .section-header{display:flex;align-items:center;justify-content:space-between;gap:12px}
@@ -351,6 +352,6 @@ a:hover{text-decoration:underline}
 .channel-key-status{min-height:14px}
 .channel-key-card.loading{opacity:.7}
 .channel-key-hint{margin:0}
-@media (max-width: 760px){
-  .quick-controls{flex-wrap:wrap;overflow-x:visible}
+@media (min-width: 1200px){
+  .quick-controls{flex-wrap:nowrap;overflow-x:auto;max-width:100%}
 }

--- a/tests/test_queue_manager_users_ui.py
+++ b/tests/test_queue_manager_users_ui.py
@@ -80,6 +80,18 @@ class QueueManagerUsersUiTests(unittest.TestCase):
         self.assertIn("if (!element.value) {", script)
         self.assertIn("if (!selectedValue && !hasPlaceholder && options[0]?.value)", script)
 
+    def test_quick_controls_responsive_wrap_hooks_exist(self) -> None:
+        """Quick-controls should wrap by default and stay width-constrained across tabs."""
+
+        css = Path("queue_manager/public/style.css").read_text(encoding="utf-8")
+
+        self.assertIn('.queue-layout{display:flex;flex-direction:column;gap:24px;min-width:0}', css)
+        self.assertIn('.queue-column{flex:1 1 auto;min-width:0;display:flex;flex-direction:column;gap:12px}', css)
+        self.assertIn('.quick-controls{display:flex;align-items:center;gap:6px;flex-wrap:wrap;overflow-x:visible;max-width:100%;min-width:0;', css)
+        self.assertIn('.quick-controls>*{min-width:0}', css)
+        self.assertIn('@media (min-width: 1200px){', css)
+        self.assertIn('.quick-controls{flex-wrap:nowrap;overflow-x:auto;max-width:100%}', css)
+
     def test_quick_controls_container_and_setting_keys_exist(self) -> None:
         """Queue tab should expose quick controls wired to key queue setting toggles."""
 


### PR DESCRIPTION
### Motivation
- Prevent the quick-controls strip from forcing the Queue card wider than other tabs by allowing items to shrink and wrap safely inside the queue layout.
- Keep the strip visually compact while still permitting horizontal scrolling only at explicit wide breakpoints so outer card width is preserved.
- Add a static assertion to catch regressions in the CSS hooks that affect layout parity across Queue/Playlists/Users/Settings.

### Description
- Updated `queue_manager/public/style.css` to prefer `flex-wrap: wrap` for `.quick-controls`, add `min-width: 0` on `.queue-layout`, `.queue-column`, and quick-controls descendants (`.quick-controls>*`) to allow safe flex shrink, and tighten chip spacing/padding for a compact appearance.
- Constrained horizontal scrolling to an explicit wide breakpoint by replacing the old small-screen media rule with `@media (min-width: 1200px)` and guarding scroll with `max-width: 100%` so overflow does not expand outer card width.
- Added a new UI regression test `test_quick_controls_responsive_wrap_hooks_exist` in `tests/test_queue_manager_users_ui.py` that asserts the presence of the CSS hooks and expected responsive behavior.
- Updated `docs/README.md` to document that the quick-controls strip now wraps by default and only enables horizontal scrolling at wide breakpoints.

### Testing
- Ran the updated test suite for the Queue Manager UI: `python -m pytest tests/test_queue_manager_users_ui.py` and observed all tests passing (9 passed).
- The change is static/CSS+test-only and no runtime unit tests beyond the UI-file assertions were modified or required.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c9963ecbac8328acdba9a12404369d)