### PR TITLE
Add Bot Control settings section with join/part virtual row

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -199,8 +199,17 @@ them via `/me/channels`.
   - `mute|normal|verbose|debug` -> `PUT /channels/{channel}/settings` with
     `{ "bot_message_level": "<level>" }`
 - The Settings tab reuses the same dropdown renderer for
-  `bot_message_level`, so message-level selection behavior stays aligned with
-  the header control.
+  bot controls so behavior stays aligned with the header control while each
+  surface remains independently usable.
+- Settings organization now includes a dedicated **Bot Control** section with
+  two rows:
+  - **Bot connection** (`join/part`) -> `PUT /channels/{channel}?join_active=1|0`
+  - **Bot message level** (`mute|normal|verbose|debug`) ->
+    `PUT /channels/{channel}/settings` with
+    `{ "bot_message_level": "<level>" }`
+- After successful bot-control updates, the Queue Manager syncs header and
+  Settings state via `updateRegButton()` plus a settings refresh so both
+  controls stay consistent without coupling their rendering lifecycles.
 
 ## Queue Manager quick controls strip
 - The Queue tab now includes a compact **quick controls** strip above the queue

--- a/queue_manager/public/queue_manager.js
+++ b/queue_manager/public/queue_manager.js
@@ -631,6 +631,7 @@ function formatScopeWarning(key) {
 
 const SETTING_GROUP_LABELS = {
   main: 'Main Queue Controls',
+  bot: 'Bot Control',
   caps: 'Queue Caps',
   earn: 'Earn points',
   followers: 'Followers/Raids',
@@ -639,7 +640,9 @@ const SETTING_GROUP_LABELS = {
   other: 'Other settings',
 };
 
-const SETTING_GROUP_ORDER = ['main', 'caps', 'earn', 'followers', 'reset', 'experimental', 'other'];
+const SETTING_GROUP_ORDER = ['main', 'bot', 'caps', 'earn', 'followers', 'reset', 'experimental', 'other'];
+
+const BOT_CONNECTION_SETTING_KEY = '__bot_connection_state';
 
 const SETTINGS_CONFIG = {
   queue_closed: {
@@ -819,10 +822,17 @@ const SETTINGS_CONFIG = {
     group: 'main',
   },
   bot_message_level: {
-    type: 'select',
+    type: 'bot-message-level',
     label: 'Bot message level',
     description: 'Choose chat output verbosity. Uses the same dropdown behavior as the header bot control.',
-    group: 'main',
+    group: 'bot',
+  },
+  [BOT_CONNECTION_SETTING_KEY]: {
+    type: 'bot-connection',
+    label: 'Bot connection',
+    description: 'Connect or disconnect the chat bot for this channel using the same join/part flow as the header control.',
+    group: 'bot',
+    virtual: true,
   },
   other_flags: {
     type: 'text',
@@ -871,7 +881,7 @@ function getBotControlOptions(channelInfo, { includeConnectionActions = true, in
  * Code customers: header dropdown and settings-level selector save handlers.
  * Used variables/origin: maps `connect`/`disconnect` to `PUT /channels/{channel}?join_active=...` and levels to `PUT /channels/{channel}/settings`.
  */
-async function applyBotControlSelection(selectionValue) {
+async function applyBotControlSelection(selectionValue, { refreshSettingsView = true } = {}) {
   if (!channelName) { return false; }
   const option = BOT_CONTROL_OPTION_MODEL.find(entry => entry.value === selectionValue);
   if (!option) { return false; }
@@ -897,7 +907,7 @@ async function applyBotControlSelection(selectionValue) {
       }
     }
     await updateRegButton();
-    if (option.action === 'message-level') {
+    if (refreshSettingsView) {
       await fetchSettings();
     }
     return true;
@@ -3013,6 +3023,14 @@ function normaliseSettingOrder(data) {
     grouped.other.push(...extras);
   }
 
+  Object.entries(SETTINGS_CONFIG).forEach(([key, meta]) => {
+    if (!meta?.virtual) { return; }
+    const groupId = SETTING_GROUP_ORDER.includes(meta.group) ? meta.group : 'other';
+    if (!grouped[groupId].includes(key)) {
+      grouped[groupId].push(key);
+    }
+  });
+
   return grouped;
 }
 
@@ -3143,38 +3161,57 @@ function createBotControlDropdown({
   return select;
 }
 
+/**
+ * Build a settings-row bot control backed by the shared dropdown model.
+ * Dependencies: uses createBotControlDropdown() and applyBotControlSelection() to keep API behavior aligned with the header control.
+ * Code customers: createSettingControl() for `bot-connection` and `bot-message-level` row types.
+ * Used variables/origin: derives join/message state from `getChannelInfo(channelName)` and uses setting/default values from row payload.
+ */
+function createBotSettingControl({ controlType, value, meta }) {
+  const wrapper = document.createElement('div');
+  wrapper.className = 'setting-select';
+  const channelInfo = getChannelInfo(channelName);
+  const isConnectionControl = controlType === 'bot-connection';
+  let currentSelection = isConnectionControl
+    ? (channelInfo?.join_active ? 'disconnect' : 'connect')
+    : (typeof value === 'string' ? value : 'normal');
+
+  const select = createBotControlDropdown({
+    channelInfo,
+    currentValue: currentSelection,
+    includeConnectionActions: isConnectionControl,
+    includeMessageLevels: !isConnectionControl,
+    placeholderLabel: '',
+    disabled: !!meta.disabled,
+    onSelection: async (_event, element) => {
+      const next = element.value;
+      if (next === currentSelection) {
+        return;
+      }
+      wrapper.classList.add('loading');
+      element.disabled = true;
+      const ok = await applyBotControlSelection(next, { refreshSettingsView: false });
+      if (ok) {
+        currentSelection = isConnectionControl
+          ? (next === 'connect' ? 'disconnect' : 'connect')
+          : next;
+        element.value = currentSelection;
+        await fetchSettings();
+      } else {
+        element.value = currentSelection;
+      }
+      element.disabled = !!meta.disabled;
+      wrapper.classList.remove('loading');
+    },
+  });
+  wrapper.appendChild(select);
+  return wrapper;
+}
+
 function createSettingControl(key, value, meta) {
   const type = meta.type || (typeof value === 'number' ? 'number' : 'text');
-  if (key === 'bot_message_level') {
-    const wrapper = document.createElement('div');
-    wrapper.className = 'setting-select';
-    const channelInfo = getChannelInfo(channelName);
-    let currentSelection = typeof value === 'string' ? value : 'normal';
-    const select = createBotControlDropdown({
-      channelInfo,
-      currentValue: currentSelection,
-      includeConnectionActions: false,
-      includeMessageLevels: true,
-      disabled: !!meta.disabled,
-      onSelection: async (_event, element) => {
-        const next = element.value;
-        if (next === currentSelection) {
-          return;
-        }
-        wrapper.classList.add('loading');
-        element.disabled = true;
-        const ok = await applyBotControlSelection(next);
-        if (ok) {
-          currentSelection = next;
-        } else {
-          element.value = currentSelection;
-        }
-        element.disabled = !!meta.disabled;
-        wrapper.classList.remove('loading');
-      },
-    });
-    wrapper.appendChild(select);
-    return wrapper;
+  if (type === 'bot-connection' || type === 'bot-message-level') {
+    return createBotSettingControl({ controlType: type, value, meta });
   }
 
   if (type === 'boolean') {

--- a/tests/test_queue_manager_users_ui.py
+++ b/tests/test_queue_manager_users_ui.py
@@ -70,6 +70,34 @@ class QueueManagerUsersUiTests(unittest.TestCase):
         self.assertIn("{ value: 'verbose'", script)
         self.assertIn("{ value: 'debug'", script)
 
+    def test_settings_bot_control_group_and_virtual_connection_row_exist(self) -> None:
+        """Settings should expose a dedicated Bot Control section with join/part and message-level rows."""
+
+        script = Path("queue_manager/public/queue_manager.js").read_text(encoding="utf-8")
+        self.assertIn("bot: 'Bot Control'", script)
+        self.assertIn("['main', 'bot', 'caps', 'earn', 'followers', 'reset', 'experimental', 'other']", script)
+        self.assertIn("const BOT_CONNECTION_SETTING_KEY = '__bot_connection_state';", script)
+        self.assertIn("type: 'bot-connection'", script)
+        self.assertIn("type: 'bot-message-level'", script)
+        self.assertIn("group: 'bot'", script)
+
+    def test_bot_connection_control_maps_join_part_api_path(self) -> None:
+        """Join/part control should map through channel-status endpoint with join_active query params."""
+
+        script = Path("queue_manager/public/queue_manager.js").read_text(encoding="utf-8")
+        self.assertIn("if (option.action === 'channel-status') {", script)
+        self.assertIn("`${API}/channels/${encodedChannel}?join_active=${option.joinActive}`", script)
+        self.assertIn("type === 'bot-connection' || type === 'bot-message-level'", script)
+        self.assertIn("await applyBotControlSelection(next, { refreshSettingsView: false });", script)
+
+    def test_verbosity_control_remains_mapped_to_bot_message_level_setting(self) -> None:
+        """Verbosity control should still persist via the bot_message_level settings payload."""
+
+        script = Path("queue_manager/public/queue_manager.js").read_text(encoding="utf-8")
+        self.assertIn("body: JSON.stringify({ bot_message_level: option.messageLevel })", script)
+        self.assertIn("bot_message_level: {", script)
+        self.assertIn("type: 'bot-message-level'", script)
+
     def test_disconnected_header_control_uses_placeholder_for_connect_action(self) -> None:
         """Disconnected header state should keep `connect` invokable via a placeholder-first dropdown."""
 


### PR DESCRIPTION
### Motivation
- Surface bot connect/part controls in the Settings tab alongside verbosity so operators can manage the bot from Settings without changing header UX.
- Reuse the existing dropdown/control builder so bot controls in Settings behave and persist identically to the header bot dropdown.
- Keep the header and Settings surfaces independent but synchronized after successful updates to avoid rendering coupling.

### Description
- Added a new `bot` settings group by updating `SETTING_GROUP_LABELS` and `SETTING_GROUP_ORDER`, and introduced `BOT_CONNECTION_SETTING_KEY = '__bot_connection_state'` as a virtual settings key. (file: `queue_manager/public/queue_manager.js`)
- Moved `bot_message_level` into the new `bot` group and introduced two dedicated control types: `type: 'bot-message-level'` and `type: 'bot-connection'` (virtual). (file: `queue_manager/public/queue_manager.js`)
- Implemented `createBotSettingControl(...)` which reuses the shared `createBotControlDropdown()`/`BOT_CONTROL_OPTION_MODEL` logic so both header and settings rows use the same option model and API mapping. (file: `queue_manager/public/queue_manager.js`)
- Made `applyBotControlSelection()` accept an optional `{ refreshSettingsView }` flag so header/settings share the same apply path while allowing the settings row to avoid duplicate refreshes; preserved the `updateRegButton()` synchronization call. (file: `queue_manager/public/queue_manager.js`)
- Ensured virtual rows are included in grouping via `normaliseSettingOrder()` so the Bot connection row appears in the Settings UI even though it is not present in the `/channels/{channel}/settings` payload. (file: `queue_manager/public/queue_manager.js`)
- Documented the Settings organization and API mappings for the new controls in `docs/README.md`. (file: `docs/README.md`)
- Added regression tests that assert the presence of the Bot Control section, the join/part API mapping, and that verbosity still writes `bot_message_level`. (file: `tests/test_queue_manager_users_ui.py`)
- New/modified functions include short descriptions and dependency/origin notes in-code (JSDoc-style) for maintainability; I scanned for newly unused code and did not add any removal markers.

### Testing
- Ran the focused UI-related unit suite with `python -m unittest tests/test_queue_manager_users_ui.py`, and all tests passed (12 tests). (files: `tests/test_queue_manager_users_ui.py`)
- Covered regressions: presence of the `Bot Control` section, `bot-connection` virtual row and mapping to `PUT /channels/{channel}?join_active=1|0`, and persistence of verbosity via `bot_message_level` payload.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c998dedab483288b6f5505e459a1d8)