### PR TITLE
Use toggle switch for bot connection setting

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -194,12 +194,13 @@ them via `/me/channels`.
   `PUT /channels/{channel}/settings` with
   `{ "bot_message_level": "<level>" }`.
 - Connect/disconnect actions were moved to the **Settings** tab.
-- The Settings tab reuses the same dropdown renderer for
-  bot controls so behavior stays aligned with the header control while each
-  surface remains independently usable.
+- The Settings tab now uses the same toggle-switch visual pattern as the main
+  queue toggles for **Bot connection**, including the matching
+  **Connected/Disconnected** state label text.
 - Settings organization now includes a dedicated **Bot Control** section with
   two rows:
-  - **Bot connection** (`join/part`) -> `PUT /channels/{channel}?join_active=1|0`
+  - **Bot connection** (toggle switch) ->
+    `PUT /channels/{channel}?join_active=1|0`
   - **Bot message level** (`mute|normal|verbose|debug`) ->
     `PUT /channels/{channel}/settings` with
     `{ "bot_message_level": "<level>" }`

--- a/queue_manager/public/queue_manager.js
+++ b/queue_manager/public/queue_manager.js
@@ -831,6 +831,8 @@ const SETTINGS_CONFIG = {
     type: 'bot-connection',
     label: 'Bot connection',
     description: 'Connect or disconnect the chat bot for this channel.',
+    onLabel: 'Connected',
+    offLabel: 'Disconnected',
     group: 'bot',
     virtual: true,
   },
@@ -857,17 +859,6 @@ const BOT_MESSAGE_LEVEL_OPTIONS = [
   { value: 'verbose', label: 'Verbose' },
   { value: 'debug', label: 'Debug' },
 ];
-
-/**
- * Resolve available connection options for the settings connect/disconnect control.
- * Dependencies: reads BOT_CONNECTION_OPTIONS and the active channel join state.
- * Code customers: settings `bot-connection` control renderer.
- * Used variables/origin: filters the connection model so users only see the next valid connect/disconnect action.
- */
-function getBotConnectionOptions(channelInfo) {
-  const connected = !!channelInfo?.join_active;
-  return BOT_CONNECTION_OPTIONS.filter(option => (connected ? option.value === 'disconnect' : option.value === 'connect'));
-}
 
 /**
  * Persist bot message verbosity for the active channel.
@@ -3174,19 +3165,58 @@ function createBotOptionsDropdown({
  * Used variables/origin: derives join/message state from `getChannelInfo(channelName)` and uses setting/default values from row payload.
  */
 function createBotSettingControl({ controlType, value, meta }) {
-  const wrapper = document.createElement('div');
-  wrapper.className = 'setting-select';
   const channelInfo = getChannelInfo(channelName);
   const isConnectionControl = controlType === 'bot-connection';
-  const options = isConnectionControl
-    ? getBotConnectionOptions(channelInfo)
-    : BOT_MESSAGE_LEVEL_OPTIONS;
-  let currentSelection = isConnectionControl
-    ? (options[0]?.value || 'connect')
-    : (typeof value === 'string' ? value : 'normal');
+  if (isConnectionControl) {
+    const wrapper = document.createElement('div');
+    wrapper.className = 'setting-toggle';
+    const switchLabel = document.createElement('label');
+    switchLabel.className = 'toggle-switch';
+    const input = document.createElement('input');
+    input.type = 'checkbox';
+    input.checked = !!channelInfo?.join_active;
+    input.setAttribute('aria-label', meta.label || 'Bot connection');
+    if (meta.disabled) {
+      input.disabled = true;
+    }
+    const slider = document.createElement('span');
+    slider.className = 'toggle-slider';
+    switchLabel.appendChild(input);
+    switchLabel.appendChild(slider);
+    const state = document.createElement('span');
+    state.className = 'toggle-state';
+    const onLabel = meta.onLabel || 'Connected';
+    const offLabel = meta.offLabel || 'Disconnected';
+    const refreshState = () => {
+      state.textContent = input.checked ? onLabel : offLabel;
+    };
+    refreshState();
+    wrapper.appendChild(switchLabel);
+    wrapper.appendChild(state);
+    if (!meta.disabled) {
+      input.addEventListener('change', async () => {
+        const next = input.checked ? 'connect' : 'disconnect';
+        wrapper.classList.add('loading');
+        input.disabled = true;
+        const ok = await applyBotConnectionSelection(next, { refreshSettingsView: false });
+        if (!ok) {
+          input.checked = !input.checked;
+        } else {
+          await fetchSettings();
+        }
+        refreshState();
+        input.disabled = false;
+        wrapper.classList.remove('loading');
+      });
+    }
+    return wrapper;
+  }
 
+  const wrapper = document.createElement('div');
+  wrapper.className = 'setting-select';
+  let currentSelection = typeof value === 'string' ? value : 'normal';
   const select = createBotOptionsDropdown({
-    options,
+    options: BOT_MESSAGE_LEVEL_OPTIONS,
     currentValue: currentSelection,
     disabled: !!meta.disabled,
     disabledTitle: meta.disabledReason || '',
@@ -3197,9 +3227,7 @@ function createBotSettingControl({ controlType, value, meta }) {
       }
       wrapper.classList.add('loading');
       element.disabled = true;
-      const ok = isConnectionControl
-        ? await applyBotConnectionSelection(next, { refreshSettingsView: false })
-        : await applyBotMessageLevelSelection(next, { refreshSettingsView: false });
+      const ok = await applyBotMessageLevelSelection(next, { refreshSettingsView: false });
       if (ok) {
         currentSelection = next;
         element.value = currentSelection;

--- a/tests/test_queue_manager_users_ui.py
+++ b/tests/test_queue_manager_users_ui.py
@@ -58,13 +58,14 @@ class QueueManagerUsersUiTests(unittest.TestCase):
         html = Path("queue_manager/public/index.html").read_text(encoding="utf-8")
         self.assertIn('id="bot-control-host"', html)
 
-    def test_bot_control_model_includes_connection_and_levels(self) -> None:
-        """Unified dropdown model should include connect/disconnect and all message levels."""
+    def test_bot_control_models_include_connection_and_levels(self) -> None:
+        """Bot controls should keep explicit connect/disconnect actions and message levels."""
 
         script = Path("queue_manager/public/queue_manager.js").read_text(encoding="utf-8")
-        self.assertIn("const BOT_CONTROL_OPTION_MODEL =", script)
+        self.assertIn("const BOT_CONNECTION_OPTIONS = [", script)
         self.assertIn("{ value: 'connect'", script)
         self.assertIn("{ value: 'disconnect'", script)
+        self.assertIn("const BOT_MESSAGE_LEVEL_OPTIONS = [", script)
         self.assertIn("{ value: 'mute'", script)
         self.assertIn("{ value: 'normal'", script)
         self.assertIn("{ value: 'verbose'", script)
@@ -81,32 +82,44 @@ class QueueManagerUsersUiTests(unittest.TestCase):
         self.assertIn("type: 'bot-message-level'", script)
         self.assertIn("group: 'bot'", script)
 
-    def test_bot_connection_control_maps_join_part_api_path(self) -> None:
-        """Join/part control should map through channel-status endpoint with join_active query params."""
+    def test_bot_connection_toggle_maps_join_part_api_path(self) -> None:
+        """Bot connection toggle should map to channel-status endpoint with join_active query params."""
 
         script = Path("queue_manager/public/queue_manager.js").read_text(encoding="utf-8")
-        self.assertIn("if (option.action === 'channel-status') {", script)
+        self.assertIn("const next = input.checked ? 'connect' : 'disconnect';", script)
+        self.assertIn("const option = BOT_CONNECTION_OPTIONS.find(entry => entry.value === selectionValue);", script)
         self.assertIn("`${API}/channels/${encodedChannel}?join_active=${option.joinActive}`", script)
         self.assertIn("type === 'bot-connection' || type === 'bot-message-level'", script)
-        self.assertIn("await applyBotControlSelection(next, { refreshSettingsView: false });", script)
+        self.assertIn("await applyBotConnectionSelection(next, { refreshSettingsView: false });", script)
+        self.assertIn("await fetchSettings();", script)
+
+    def test_settings_bot_section_renders_connection_toggle_pattern(self) -> None:
+        """Bot section should render connection as the shared toggle-switch pattern with connection labels."""
+
+        script = Path("queue_manager/public/queue_manager.js").read_text(encoding="utf-8")
+        self.assertIn("input.setAttribute('aria-label', meta.label || 'Bot connection');", script)
+        self.assertIn("switchLabel.className = 'toggle-switch';", script)
+        self.assertIn("slider.className = 'toggle-slider';", script)
+        self.assertIn("state.className = 'toggle-state';", script)
+        self.assertIn("const onLabel = meta.onLabel || 'Connected';", script)
+        self.assertIn("const offLabel = meta.offLabel || 'Disconnected';", script)
 
     def test_verbosity_control_remains_mapped_to_bot_message_level_setting(self) -> None:
         """Verbosity control should still persist via the bot_message_level settings payload."""
 
         script = Path("queue_manager/public/queue_manager.js").read_text(encoding="utf-8")
-        self.assertIn("body: JSON.stringify({ bot_message_level: option.messageLevel })", script)
+        self.assertIn("body: JSON.stringify({ bot_message_level: selectionValue })", script)
         self.assertIn("bot_message_level: {", script)
         self.assertIn("type: 'bot-message-level'", script)
 
-    def test_disconnected_header_control_uses_placeholder_for_connect_action(self) -> None:
-        """Disconnected header state should keep `connect` invokable via a placeholder-first dropdown."""
+    def test_disconnected_header_control_disables_verbosity_dropdown(self) -> None:
+        """Header verbosity dropdown should stay disabled whenever join_active is false."""
 
         script = Path("queue_manager/public/queue_manager.js").read_text(encoding="utf-8")
-        self.assertIn("placeholderLabel: 'Select action…'", script)
-        self.assertIn("placeholderOption.value = '';", script)
-        self.assertIn("placeholderOption.disabled = true;", script)
-        self.assertIn("if (!element.value) {", script)
-        self.assertIn("if (!selectedValue && !hasPlaceholder && options[0]?.value)", script)
+        self.assertIn("disabled: !channelInfo.join_active,", script)
+        self.assertIn("const disabledTitle = 'Connect bot in Settings to change verbosity.';", script)
+        self.assertIn("if (!channelInfo.join_active) {", script)
+        self.assertIn("controlHost.title = disabledTitle;", script)
 
     def test_quick_controls_responsive_wrap_hooks_exist(self) -> None:
         """Quick-controls should wrap by default and stay width-constrained across tabs."""


### PR DESCRIPTION
### Motivation
- Separate bot connection actions from verbosity controls by rendering connection as a boolean toggle that matches main queue controls and preserves accessibility/state labels like `Connected`/`Disconnected`.
- Keep `bot_message_level` as a dropdown persisted via the settings endpoint while mapping connect/disconnect to the channel status `join_active` query param.
- Simplify the settings renderer so header, status badge, and settings UI refresh consistently after connection changes.

### Description
- Rendered `bot-connection` as the shared boolean toggle pattern (`toggle-switch`, `toggle-slider`, `toggle-state`) and added `onLabel`/`offLabel` (`Connected`/`Disconnected`) to the `SETTINGS_CONFIG` entry for `BOT_CONNECTION_SETTING_KEY` in `queue_manager/public/queue_manager.js`.
- Replaced the dropdown-based bot-connection control with a checkbox that maps ON/OFF to `connect`/`disconnect` and calls `PUT /channels/{channel}?join_active=1|0` via the existing `applyBotConnectionSelection` flow, and preserved the `bot_message_level` dropdown targeting `PUT /channels/{channel}/settings`.
- Removed the previous `getBotConnectionOptions` dropdown helper and consolidated connection logic into `createBotSettingControl` while keeping ARIA labeling and loading/disabled states; successful toggles call `updateRegButton()` and `fetchSettings()` so header control, status badge, and settings view remain synchronized.
- Updated documentation in `docs/README.md` to describe the Bot connection as a toggle switch and adjusted tests in `tests/test_queue_manager_users_ui.py` to assert the new UI pattern and API mapping.

### Testing
- Ran the UI unit tests with `python -m unittest tests.test_queue_manager_users_ui` and all tests passed (`OK`).
- Verified the modified `queue_manager/public/queue_manager.js`, `docs/README.md`, and `tests/test_queue_manager_users_ui.py` reflect the new toggle behavior and expected API usage.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c99e2ff3f483288e38f94daab5f9a5)