### PR TITLE
Simplify Queue Manager bot controls and keep header verbosity-only

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -182,11 +182,13 @@ them via `/me/channels`.
 - Channel owners and the playlist automation helper are filtered out of the
   listing, and badges update automatically as pages load or refresh.
 
-## Queue Manager unified bot control dropdown
+## Queue Manager bot controls
 - The Queue Manager header shows a **verbosity-only** dropdown beside the
   channel and bot badges whenever the selected channel is authorized.
 - Header options are limited to message levels:
   `mute`, `normal`, `verbose`, and `debug`.
+- Header controls do **not** include connect/disconnect actions; those actions
+  are intentionally scoped to the Settings tab.
 - The header verbosity dropdown is disabled while the bot is disconnected
   (`join_active = 0`) and shows guidance to connect the bot in **Settings**
   before changing verbosity.

--- a/queue_manager/public/queue_manager.js
+++ b/queue_manager/public/queue_manager.js
@@ -848,27 +848,39 @@ const SETTINGS_CONFIG = {
 
 const QUICK_CONTROL_KEYS = ['queue_closed', 'prio_only', 'allow_bumps', 'full_auto_priority_mode'];
 
-const BOT_CONNECTION_OPTIONS = [
-  { value: 'connect', label: 'Connect bot to chat', joinActive: 1 },
-  { value: 'disconnect', label: 'Disconnect bot from chat', joinActive: 0 },
-];
+const BOT_CONTROL_OPTION_MODEL = {
+  connection: [
+    { value: 'connect', label: 'Connect bot to chat', joinActive: 1 },
+    { value: 'disconnect', label: 'Disconnect bot from chat', joinActive: 0 },
+  ],
+  verbosity: [
+    { value: 'mute', label: 'Mute' },
+    { value: 'normal', label: 'Normal' },
+    { value: 'verbose', label: 'Verbose' },
+    { value: 'debug', label: 'Debug' },
+  ],
+};
 
-const BOT_MESSAGE_LEVEL_OPTIONS = [
-  { value: 'mute', label: 'Mute' },
-  { value: 'normal', label: 'Normal' },
-  { value: 'verbose', label: 'Verbose' },
-  { value: 'debug', label: 'Debug' },
-];
+/**
+ * Resolve bot-control option sets for a specific control surface.
+ * Dependencies: reads BOT_CONTROL_OPTION_MODEL constants only.
+ * Code customers: applyBotMessageLevelSelection(), applyBotConnectionSelection(), createBotSettingControl(), and header verbosity rendering.
+ * Used variables/origin: returns a cloned options array for `connection` or `verbosity` from static in-file model data.
+ */
+function getBotControlOptions(type) {
+  const options = BOT_CONTROL_OPTION_MODEL[type];
+  return Array.isArray(options) ? options.slice() : [];
+}
 
 /**
  * Persist bot message verbosity for the active channel.
- * Dependencies: requires `channelName`, API origin, and BOT_MESSAGE_LEVEL_OPTIONS for validation.
- * Code customers: header bot verbosity control and settings `bot_message_level` row.
+ * Dependencies: requires `channelName`, API origin, and getBotControlOptions('verbosity') for validation.
+ * Code customers: header verbosity-only select and settings `bot_message_level` row.
  * Used variables/origin: writes `{ bot_message_level }` to `PUT /channels/{channel}/settings`.
  */
 async function applyBotMessageLevelSelection(selectionValue, { refreshSettingsView = true } = {}) {
   if (!channelName) { return false; }
-  const allowedLevels = new Set(BOT_MESSAGE_LEVEL_OPTIONS.map(option => option.value));
+  const allowedLevels = new Set(getBotControlOptions('verbosity').map(option => option.value));
   if (!allowedLevels.has(selectionValue)) { return false; }
   const encodedChannel = encodeURIComponent(channelName);
   try {
@@ -895,13 +907,13 @@ async function applyBotMessageLevelSelection(selectionValue, { refreshSettingsVi
 
 /**
  * Persist bot connect/disconnect state for the active channel.
- * Dependencies: requires `channelName`, API origin, and BOT_CONNECTION_OPTIONS for join-state mapping.
+ * Dependencies: requires `channelName`, API origin, and getBotControlOptions('connection') for join-state mapping.
  * Code customers: settings `bot-connection` row.
  * Used variables/origin: maps `connect`/`disconnect` to `PUT /channels/{channel}?join_active=...`.
  */
 async function applyBotConnectionSelection(selectionValue, { refreshSettingsView = true } = {}) {
   if (!channelName) { return false; }
-  const option = BOT_CONNECTION_OPTIONS.find(entry => entry.value === selectionValue);
+  const option = getBotControlOptions('connection').find(entry => entry.value === selectionValue);
   if (!option) { return false; }
   const encodedChannel = encodeURIComponent(channelName);
   try {
@@ -3121,12 +3133,12 @@ function buildSettingRow(key, value, meta) {
 }
 
 /**
- * Build a select element from explicit option items for bot settings controls.
- * Dependencies: receives a pre-filtered `options` array from caller-specific helpers.
- * Code customers: settings bot connection and bot message-level controls.
+ * Build a select element from explicit option items for bot verbosity controls.
+ * Dependencies: receives pre-filtered `options` from getBotControlOptions() and caller-provided selection handlers.
+ * Code customers: header verbosity selector and settings bot message-level row.
  * Used variables/origin: uses caller-provided options/current value and optional disabled title text.
  */
-function createBotOptionsDropdown({
+function createBotControlDropdown({
   options,
   currentValue,
   onSelection,
@@ -3159,10 +3171,10 @@ function createBotOptionsDropdown({
 }
 
 /**
- * Build a settings-row bot control for either connection state or message level.
- * Dependencies: uses createBotOptionsDropdown(), applyBotConnectionSelection(), and applyBotMessageLevelSelection().
+ * Build settings-row bot controls (connection toggle or verbosity select).
+ * Dependencies: uses createBotControlDropdown(), getBotControlOptions(), applyBotConnectionSelection(), and applyBotMessageLevelSelection().
  * Code customers: createSettingControl() for `bot-connection` and `bot-message-level` row types.
- * Used variables/origin: derives join/message state from `getChannelInfo(channelName)` and uses setting/default values from row payload.
+ * Used variables/origin: derives join state from `getChannelInfo(channelName)` and reads per-row setting defaults from settings payload.
  */
 function createBotSettingControl({ controlType, value, meta }) {
   const channelInfo = getChannelInfo(channelName);
@@ -3215,8 +3227,8 @@ function createBotSettingControl({ controlType, value, meta }) {
   const wrapper = document.createElement('div');
   wrapper.className = 'setting-select';
   let currentSelection = typeof value === 'string' ? value : 'normal';
-  const select = createBotOptionsDropdown({
-    options: BOT_MESSAGE_LEVEL_OPTIONS,
+  const select = createBotControlDropdown({
+    options: getBotControlOptions('verbosity'),
     currentValue: currentSelection,
     disabled: !!meta.disabled,
     disabledTitle: meta.disabledReason || '',
@@ -4064,8 +4076,8 @@ async function updateRegButton() {
     if (!channelName || !channelInfo || !channelInfo.authorized) { return; }
     let currentValue = channelInfo.bot_message_level || 'normal';
     const disabledTitle = 'Connect bot in Settings to change verbosity.';
-    const select = createBotOptionsDropdown({
-      options: BOT_MESSAGE_LEVEL_OPTIONS,
+    const select = createBotControlDropdown({
+      options: getBotControlOptions('verbosity'),
       currentValue,
       disabled: !channelInfo.join_active,
       disabledTitle: !channelInfo.join_active ? disabledTitle : '',

--- a/tests/test_queue_manager_users_ui.py
+++ b/tests/test_queue_manager_users_ui.py
@@ -58,18 +58,21 @@ class QueueManagerUsersUiTests(unittest.TestCase):
         html = Path("queue_manager/public/index.html").read_text(encoding="utf-8")
         self.assertIn('id="bot-control-host"', html)
 
-    def test_bot_control_models_include_connection_and_levels(self) -> None:
-        """Bot controls should keep explicit connect/disconnect actions and message levels."""
+    def test_bot_control_option_model_includes_connection_and_levels(self) -> None:
+        """Bot control option model should keep connection actions and message-level entries."""
 
         script = Path("queue_manager/public/queue_manager.js").read_text(encoding="utf-8")
-        self.assertIn("const BOT_CONNECTION_OPTIONS = [", script)
+        self.assertIn("const BOT_CONTROL_OPTION_MODEL = {", script)
+        self.assertIn("connection: [", script)
         self.assertIn("{ value: 'connect'", script)
         self.assertIn("{ value: 'disconnect'", script)
-        self.assertIn("const BOT_MESSAGE_LEVEL_OPTIONS = [", script)
+        self.assertIn("verbosity: [", script)
         self.assertIn("{ value: 'mute'", script)
         self.assertIn("{ value: 'normal'", script)
         self.assertIn("{ value: 'verbose'", script)
         self.assertIn("{ value: 'debug'", script)
+        self.assertIn("function getBotControlOptions(type) {", script)
+        self.assertIn("return Array.isArray(options) ? options.slice() : [];", script)
 
     def test_settings_bot_control_group_and_virtual_connection_row_exist(self) -> None:
         """Settings should expose a dedicated Bot Control section with join/part and message-level rows."""
@@ -87,7 +90,7 @@ class QueueManagerUsersUiTests(unittest.TestCase):
 
         script = Path("queue_manager/public/queue_manager.js").read_text(encoding="utf-8")
         self.assertIn("const next = input.checked ? 'connect' : 'disconnect';", script)
-        self.assertIn("const option = BOT_CONNECTION_OPTIONS.find(entry => entry.value === selectionValue);", script)
+        self.assertIn("const option = getBotControlOptions('connection').find(entry => entry.value === selectionValue);", script)
         self.assertIn("`${API}/channels/${encodedChannel}?join_active=${option.joinActive}`", script)
         self.assertIn("type === 'bot-connection' || type === 'bot-message-level'", script)
         self.assertIn("await applyBotConnectionSelection(next, { refreshSettingsView: false });", script)
@@ -116,6 +119,7 @@ class QueueManagerUsersUiTests(unittest.TestCase):
         """Header verbosity dropdown should stay disabled whenever join_active is false."""
 
         script = Path("queue_manager/public/queue_manager.js").read_text(encoding="utf-8")
+        self.assertIn("options: getBotControlOptions('verbosity'),", script)
         self.assertIn("disabled: !channelInfo.join_active,", script)
         self.assertIn("const disabledTitle = 'Connect bot in Settings to change verbosity.';", script)
         self.assertIn("if (!channelInfo.join_active) {", script)


### PR DESCRIPTION
### Motivation
- Consolidate bot control option data and simplify branching that existed solely to support header connect/disconnect actions. 
- Make a clear separation between header (verbosity-only) and Settings (connection toggle + verbosity) UI responsibilities. 
- Update inline function documentation to list dependencies, code customers, and used variables to match the simplified flow and clarify future maintenance.

### Description
- Introduced a centralized `BOT_CONTROL_OPTION_MODEL` and accessor `getBotControlOptions(type)` and replaced the prior separate constants with a single source-of-truth in `queue_manager/public/queue_manager.js`.
- Renamed `createBotOptionsDropdown()` to `createBotControlDropdown()` and narrowed its documented responsibility to render verbosity dropdowns; updated `createBotSettingControl()` and header rendering to use the new helper and `getBotControlOptions('verbosity')`.
- Updated `applyBotMessageLevelSelection()` and `applyBotConnectionSelection()` to validate/look up options via `getBotControlOptions()` and refreshed their doc comments to list dependencies, customers, and origin of used variables.
- Updated `docs/README.md` to explicitly state header controls do not include connect/disconnect actions and adjusted `tests/test_queue_manager_users_ui.py` to assert the new model/helper names and header-only verbosity wiring.

### Testing
- Ran the users UI unit tests with `python -m unittest tests.test_queue_manager_users_ui` which executed 13 tests and completed successfully (`OK`).
- The modified UI-related assertions in `tests/test_queue_manager_users_ui.py` pass with the updated helper and model names.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c9a075f4708328acfaf9f97946f040)