### PR TITLE
Add EventSub conduit migration, startup schema patching, and chat ingress flags

### DIFF
--- a/backend_app.py
+++ b/backend_app.py
@@ -77,6 +77,8 @@ SETTINGS_ENV_MAP: Dict[str, str] = {
 SETTINGS_DEFAULTS: Dict[str, Optional[str]] = {
     "twitch_scopes": "channel:bot channel:read:subscriptions channel:read:vips bits:read moderator:read:followers",
     "bot_app_scopes": "user:read:chat user:write:chat user:bot",
+    "chat_ingress_mode": "websocket",
+    "chat_ingress_shadow_mode": "0",
 }
 
 SETUP_REQUIRED_KEYS = ("twitch_client_id", "twitch_client_secret")
@@ -278,6 +280,82 @@ def ensure_channel_settings_schema() -> None:
             )
 
 
+def ensure_eventsub_conduit_schema() -> None:
+    """Additive startup patch for EventSub conduit/idempotency schema compatibility.
+
+    Dependencies: Uses SQLAlchemy ``inspect`` plus raw SQL statements executed
+    against the module-level ``engine``.
+    Code customers: Startup bootstrap and webhook/conduit workers that rely on
+    replay dedupe and conduit metadata tables.
+    Used variables/origin: Inspects existing ``event_subscriptions`` columns and
+    creates/patches ``eventsub_message_dedupe``, ``twitch_conduits``, and
+    ``twitch_conduit_shards`` tables in-place for staggered deploy safety.
+    """
+
+    with engine.begin() as conn:
+        inspector = inspect(conn)
+        table_names = set(inspector.get_table_names())
+
+        if "event_subscriptions" in table_names:
+            eventsub_columns = {
+                col["name"] for col in inspector.get_columns("event_subscriptions")
+            }
+            if "conduit_id" not in eventsub_columns:
+                conn.execute(text("ALTER TABLE event_subscriptions ADD COLUMN conduit_id VARCHAR"))
+            if "shard_id" not in eventsub_columns:
+                conn.execute(text("ALTER TABLE event_subscriptions ADD COLUMN shard_id VARCHAR"))
+
+        if "eventsub_message_dedupe" not in table_names:
+            conn.execute(
+                text(
+                    """
+                    CREATE TABLE eventsub_message_dedupe (
+                        id INTEGER PRIMARY KEY,
+                        message_id VARCHAR NOT NULL,
+                        received_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                        CONSTRAINT uq_eventsub_message_dedupe_message_id UNIQUE (message_id)
+                    )
+                    """
+                )
+            )
+
+        if "twitch_conduits" not in table_names:
+            conn.execute(
+                text(
+                    """
+                    CREATE TABLE twitch_conduits (
+                        id INTEGER PRIMARY KEY,
+                        conduit_id VARCHAR NOT NULL,
+                        status VARCHAR NOT NULL DEFAULT 'pending',
+                        last_sync_at DATETIME,
+                        created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                        updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                        CONSTRAINT uq_twitch_conduits_conduit_id UNIQUE (conduit_id)
+                    )
+                    """
+                )
+            )
+
+        if "twitch_conduit_shards" not in table_names:
+            conn.execute(
+                text(
+                    """
+                    CREATE TABLE twitch_conduit_shards (
+                        id INTEGER PRIMARY KEY,
+                        conduit_fk INTEGER NOT NULL REFERENCES twitch_conduits(id) ON DELETE CASCADE,
+                        shard_id VARCHAR NOT NULL,
+                        transport_callback TEXT,
+                        status VARCHAR NOT NULL DEFAULT 'pending',
+                        last_sync_at DATETIME,
+                        created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                        updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                        CONSTRAINT uq_twitch_conduit_shards UNIQUE (conduit_fk, shard_id)
+                    )
+                    """
+                )
+            )
+
+
 def backfill_missing_channel_keys() -> None:
     """Assign generated keys to any existing channels lacking a `channel_key` value.
 
@@ -473,6 +551,34 @@ def get_bot_app_scopes() -> list[str]:
     return scopes or list(DEFAULT_BOT_APP_SCOPES)
 
 
+def get_chat_ingress_mode() -> str:
+    """Return the configured chat ingress mode with a safe fallback.
+
+    Dependencies: Reads persisted values through ``get_setting``.
+    Code customers: ``/system/config`` payload consumers and chat ingress
+    workers deciding websocket vs webhook/conduit intake.
+    Used variables/origin: Pulls the ``chat_ingress_mode`` app setting and
+    normalizes unsupported values back to ``websocket``.
+    """
+
+    value = (get_setting("chat_ingress_mode", "websocket") or "websocket").strip().lower()
+    if value not in {"websocket", "webhook_conduit"}:
+        return "websocket"
+    return value
+
+
+def get_chat_ingress_shadow_mode() -> bool:
+    """Return whether dual-run ingress shadow mode is enabled.
+
+    Dependencies: Uses ``get_setting`` plus ``_env_flag`` for boolean parsing.
+    Code customers: ``/system/config`` responses and chat validation workers.
+    Used variables/origin: Reads the ``chat_ingress_shadow_mode`` app setting
+    and interprets string truthy values such as ``1``/``true``/``yes``.
+    """
+
+    return _env_flag(get_setting("chat_ingress_shadow_mode", "0"))
+
+
 def _system_config_payload() -> Dict[str, Any]:
     return {
         "setup_complete": is_setup_complete(),
@@ -482,6 +588,8 @@ def _system_config_payload() -> Dict[str, Any]:
         "bot_redirect_uri": get_bot_redirect_uri(),
         "twitch_scopes": get_twitch_scopes(),
         "bot_app_scopes": get_bot_app_scopes(),
+        "chat_ingress_mode": get_chat_ingress_mode(),
+        "chat_ingress_shadow_mode": get_chat_ingress_shadow_mode(),
     }
 
 
@@ -973,6 +1081,8 @@ class EventSubscription(Base):
     secret = Column(String, nullable=False)
     callback = Column(Text, nullable=False)
     transport = Column(String, nullable=False, default="webhook")
+    conduit_id = Column(String)
+    shard_id = Column(String)
     created_at = Column(DateTime, default=datetime.utcnow, nullable=False)
     updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow, nullable=False)
     last_notified_at = Column(DateTime)
@@ -982,6 +1092,47 @@ class EventSubscription(Base):
     __table_args__ = (
         UniqueConstraint("channel_id", "type", name="uq_channel_eventsub"),
     )
+
+
+class EventSubMessageDedupe(Base):
+    __tablename__ = "eventsub_message_dedupe"
+
+    id = Column(Integer, primary_key=True)
+    message_id = Column(String, nullable=False, unique=True)
+    received_at = Column(DateTime, default=datetime.utcnow, nullable=False)
+
+
+class TwitchConduit(Base):
+    __tablename__ = "twitch_conduits"
+
+    id = Column(Integer, primary_key=True)
+    conduit_id = Column(String, nullable=False, unique=True)
+    status = Column(String, nullable=False, default="pending")
+    last_sync_at = Column(DateTime)
+    created_at = Column(DateTime, default=datetime.utcnow, nullable=False)
+    updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow, nullable=False)
+
+    shards = relationship("TwitchConduitShard", back_populates="conduit", cascade="all, delete-orphan")
+
+
+class TwitchConduitShard(Base):
+    __tablename__ = "twitch_conduit_shards"
+
+    id = Column(Integer, primary_key=True)
+    conduit_fk = Column(Integer, ForeignKey("twitch_conduits.id", ondelete="CASCADE"), nullable=False)
+    shard_id = Column(String, nullable=False)
+    transport_callback = Column(Text)
+    status = Column(String, nullable=False, default="pending")
+    last_sync_at = Column(DateTime)
+    created_at = Column(DateTime, default=datetime.utcnow, nullable=False)
+    updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow, nullable=False)
+
+    conduit = relationship("TwitchConduit", back_populates="shards")
+
+    __table_args__ = (
+        UniqueConstraint("conduit_fk", "shard_id", name="uq_twitch_conduit_shards"),
+    )
+
 
 class TwitchUser(Base):
     __tablename__ = "twitch_users"
@@ -1164,6 +1315,7 @@ def _ensure_playlist_schema() -> None:
 
 ensure_channel_settings_schema()
 _ensure_playlist_schema()
+ensure_eventsub_conduit_schema()
 bootstrap_settings_from_env()
 
 # =====================================
@@ -1364,6 +1516,8 @@ class SystemConfigOut(BaseModel):
     bot_redirect_uri: Optional[str]
     twitch_scopes: List[str]
     bot_app_scopes: List[str]
+    chat_ingress_mode: Literal["websocket", "webhook_conduit"]
+    chat_ingress_shadow_mode: bool
 
 
 class SystemConfigUpdate(BaseModel):
@@ -1373,6 +1527,8 @@ class SystemConfigUpdate(BaseModel):
     bot_redirect_uri: Optional[str] = None
     twitch_scopes: Optional[List[str]] = None
     bot_app_scopes: Optional[List[str]] = None
+    chat_ingress_mode: Optional[Literal["websocket", "webhook_conduit"]] = None
+    chat_ingress_shadow_mode: Optional[bool] = None
     setup_complete: Optional[bool] = None
 
 
@@ -4315,6 +4471,10 @@ def update_system_config(
     if payload.bot_app_scopes is not None:
         normalized_bot_scopes = _normalize_scope_list(payload.bot_app_scopes)
         updates["bot_app_scopes"] = " ".join(normalized_bot_scopes) if normalized_bot_scopes else None
+    if payload.chat_ingress_mode is not None:
+        updates["chat_ingress_mode"] = payload.chat_ingress_mode
+    if payload.chat_ingress_shadow_mode is not None:
+        updates["chat_ingress_shadow_mode"] = "1" if payload.chat_ingress_shadow_mode else "0"
 
     current = settings_store.snapshot()
     merged: Dict[str, Optional[str]] = dict(current)

--- a/docs/README.md
+++ b/docs/README.md
@@ -69,6 +69,19 @@ the required fields are saved (client ID, client secret, redirect URIs, and any
 desired scope overrides) the admin can mark the deployment as ready, which
 unlocks the API for the bot, queue manager, and public web frontend.
 
+### Chat ingress defaults and staged rollout flags
+- `/system/config` now exposes `chat_ingress_mode` with:
+  - `websocket` (default)
+  - `webhook_conduit`
+- `/system/config` also exposes `chat_ingress_shadow_mode` (default `false`) so
+  operators can run dual-path validation before a full ingress cutover.
+- Migration `migrations/20260330_eventsub_conduits.sql` adds additive EventSub
+  replay/conduit tables (`eventsub_message_dedupe`, `twitch_conduits`,
+  `twitch_conduit_shards`) plus conduit linkage columns on
+  `event_subscriptions`.
+- Startup now includes a compatibility patch for the same tables/columns so
+  staggered deploys on legacy SQLite/prod databases continue booting safely.
+
 ## Running with Docker
 1. Copy `example.env` to `stack.env` and adjust values such as `ADMIN_TOKEN`,
    `ADMIN_BASIC_AUTH_USERNAME`, `ADMIN_BASIC_AUTH_PASSWORD`, and `BACKEND_URL`
@@ -237,6 +250,15 @@ them via `/me/channels`.
   ```
 
 ## Changelog
+### 2026-03-30
+- Added EventSub webhook replay idempotency and conduit schema support via
+  `migrations/20260330_eventsub_conduits.sql`.
+- Added `/system/config` defaults for `chat_ingress_mode` (`websocket`) and
+  `chat_ingress_shadow_mode` (`false`), including startup compatibility patch
+  logic for staggered deploys.
+- Marked ingress shadow mode as a rollout guard; if rollout strategy changes
+  permanently, review for future cleanup.
+
 ### 2026-03-29
 - Removed duplicate channel-settings bootstrap technical debt by retiring
   `_ensure_channel_settings_schema()` and keeping

--- a/docs/backend_api.md
+++ b/docs/backend_api.md
@@ -6,6 +6,18 @@ This document summarizes the REST endpoints exposed by `backend_app.py`.
 | Method | Path | Description |
 |--------|------|-------------|
 | GET | `/system/health` | Health check that verifies database connectivity. |
+| GET | `/system/config` | Read deployment configuration defaults and ingress mode toggles. |
+| PUT | `/system/config` | Update deployment configuration, scopes, and ingress mode toggles (admin token required). |
+
+### `/system/config`
+- **GET response fields**
+  - Existing setup/OAuth fields (`setup_complete`, client IDs/secrets, redirect URIs, scopes).
+  - `chat_ingress_mode`: `websocket` (default) or `webhook_conduit`.
+  - `chat_ingress_shadow_mode`: boolean dual-run switch for validation mode (default `false`).
+- **PUT payload additions**
+  - `chat_ingress_mode?: "websocket" | "webhook_conduit"`
+  - `chat_ingress_shadow_mode?: boolean`
+- **Compatibility note**: Startup includes additive schema patching for staggered deployments so older SQLite/prod DBs can run until the dedicated migration is applied.
 
 ## Authentication
 | Method | Path | Description |
@@ -118,6 +130,10 @@ Channel settings include queue intake controls:
 - `bot_message_level` controls how chatty the bot is in channel responses; allowed values are exactly `mute`, `normal`, `verbose`, and `debug` (default `normal`).
 - Priority point pricing is configurable: `prio_follow_enabled`, `prio_raid_enabled`, `prio_bits_per_point`, `prio_gifts_per_point`, and per-tier fields (`prio_sub_tier1_points`, `prio_sub_tier2_points`, `prio_sub_tier3_points`) control how many points events grant. Reset bonuses (`prio_reset_points_tier1`, `prio_reset_points_tier2`, `prio_reset_points_tier3`, `prio_reset_points_vip`, `prio_reset_points_mod`) are awarded when the queue resets for a new stream. Use `free_mod_priority_requests` to allow moderators to request priority without spending points.
 - Existing deployments should apply `migrations/20240624_queue_caps.sql` to add the new capacity columns and backfill defaults for legacy channels; the application also attempts to patch missing columns on startup for SQLite/legacy installs before enforcing queue caps.
+- EventSub conduit/replay storage is added in `migrations/20260330_eventsub_conduits.sql`:
+  - `eventsub_message_dedupe` for message idempotency (`message_id`, `received_at`, unique message IDs).
+  - `twitch_conduits` and `twitch_conduit_shards` for conduit/shard sync state.
+  - additive `event_subscriptions.conduit_id` and `event_subscriptions.shard_id` linkage columns.
 
 ### Queue Manager unified bot dropdown API mapping
 - Queue Manager uses a single state-aware dropdown model with options:

--- a/migrations/20260330_eventsub_conduits.sql
+++ b/migrations/20260330_eventsub_conduits.sql
@@ -1,0 +1,35 @@
+BEGIN TRANSACTION;
+
+CREATE TABLE IF NOT EXISTS eventsub_message_dedupe (
+    id INTEGER PRIMARY KEY,
+    message_id VARCHAR NOT NULL,
+    received_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT uq_eventsub_message_dedupe_message_id UNIQUE (message_id)
+);
+
+CREATE TABLE IF NOT EXISTS twitch_conduits (
+    id INTEGER PRIMARY KEY,
+    conduit_id VARCHAR NOT NULL,
+    status VARCHAR NOT NULL DEFAULT 'pending',
+    last_sync_at DATETIME,
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT uq_twitch_conduits_conduit_id UNIQUE (conduit_id)
+);
+
+CREATE TABLE IF NOT EXISTS twitch_conduit_shards (
+    id INTEGER PRIMARY KEY,
+    conduit_fk INTEGER NOT NULL REFERENCES twitch_conduits(id) ON DELETE CASCADE,
+    shard_id VARCHAR NOT NULL,
+    transport_callback TEXT,
+    status VARCHAR NOT NULL DEFAULT 'pending',
+    last_sync_at DATETIME,
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT uq_twitch_conduit_shards UNIQUE (conduit_fk, shard_id)
+);
+
+ALTER TABLE event_subscriptions ADD COLUMN conduit_id VARCHAR;
+ALTER TABLE event_subscriptions ADD COLUMN shard_id VARCHAR;
+
+COMMIT;


### PR DESCRIPTION
### Motivation
- Add additive DB support for EventSub webhook replay/idempotency and conduit/shard metadata so webhook-based chat ingress can be introduced without breaking existing deployments. 
- Provide runtime settings to control chat ingress behavior (`websocket` vs `webhook_conduit`) and a shadow/dual-run mode for safe cutovers. 
- Ensure staggered/staged deploys (SQLite and older prod DBs) can boot during rollout by applying the same legacy-style in-process schema patches used elsewhere.

### Description
- Added an additive migration file `migrations/20260330_eventsub_conduits.sql` that creates `eventsub_message_dedupe`, `twitch_conduits`, and `twitch_conduit_shards`, and adds `conduit_id`/`shard_id` columns to `event_subscriptions` (DDL inside a single transaction). 
- Extended the SQLAlchemy model layer in `backend_app.py` with `EventSubMessageDedupe`, `TwitchConduit`, and `TwitchConduitShard` ORM classes and optional `conduit_id`/`shard_id` columns on the existing `EventSubscription` model. 
- Implemented startup compatibility patch `ensure_eventsub_conduit_schema()` (same additive/inspect/`ALTER TABLE` pattern as other helpers) and invoked it during bootstrap to allow older DBs to tolerate staggered deploys. 
- Added settings defaults and serialization for ingress flags by updating `SETTINGS_DEFAULTS` and adding `get_chat_ingress_mode()` and `get_chat_ingress_shadow_mode()` helpers, plus extending `SystemConfigOut`/`SystemConfigUpdate` and wiring update handling in `/system/config` to persist the new flags. 
- Updated documentation in `docs/backend_api.md` and `docs/README.md` to describe the new migration, the `chat_ingress_mode` and `chat_ingress_shadow_mode` fields, and the compatibility/startup patch behavior.

### Testing
- Ran `python -m py_compile backend_app.py` to validate Python syntax, which completed successfully.
- Created and validated the additive migration file `migrations/20260330_eventsub_conduits.sql` and confirmed the startup patch function is invoked during bootstrap (static inspection and local syntax checks only).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cacc5d97ac83288486ded85a7ad89c)