### PR TITLE
Copy all bot Python modules into Docker image and document deployment notes

### DIFF
--- a/bot/Dockerfile
+++ b/bot/Dockerfile
@@ -3,7 +3,7 @@ WORKDIR /bot
 ENV PYTHONUNBUFFERED=1
 COPY bot/requirements.txt ./requirements.txt
 RUN pip install --no-cache-dir -r requirements.txt
-COPY bot/bot_app.py ./bot_app.py
+COPY bot/*.py ./
 COPY bot/commands.yml ./commands.yml
 COPY bot/messages.yml ./messages.yml
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -104,6 +104,16 @@ unlocks the API for the bot, queue manager, and public web frontend.
    complete the “Deployment Setup” flow before the API, queue manager, or bot
    pages are accessible.
 
+### Bot deployment notes
+- The bot image must copy all Python modules under `bot/` (for example
+  `bot_app.py`, `chat_command_core.py`, and future helper modules) into `/bot/`
+  so direct-script runtime mode keeps working with
+  `CMD ["python", "-u", "bot_app.py"]`.
+- `bot/Dockerfile` now uses `COPY bot/*.py ./` for future-proof module pickup.
+  If additional non-runtime files appear under `bot/`, add or update a
+  `.dockerignore` rule to keep image context small while preserving required
+  runtime modules.
+
 ## Backend Highlights
 - Uses a SQLite database stored at `/data/db.sqlite` and defines models for channels, songs, users, stream sessions, and requests.
 - Stores bot OAuth credentials via the `/bot/config` API and exposes an OAuth


### PR DESCRIPTION
### Motivation
- Ensure runtime imports like `bot/chat_command_core.py` and any future helper modules are present in the container so direct-script execution with `CMD ["python", "-u", "bot_app.py"]` continues to work and avoid accidental build failures when adding helper modules.

### Description
- Update `bot/Dockerfile` to `COPY bot/*.py ./` instead of copying only `bot_app.py`, and add a **Bot deployment notes** section to `docs/README.md` that documents the requirement and recommends `.dockerignore` rules to keep the build context small while preserving runtime modules; the container `CMD` is unchanged.

### Testing
- Ran `python -m compileall bot` to validate module syntax, and compilation completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cad4d5ddc883288cb922714f181ca7)