### PR TITLE
Use app-auth headers for EventSub conduit management

### DIFF
--- a/backend_app.py
+++ b/backend_app.py
@@ -677,6 +677,24 @@ def _eventsub_headers(access_token: str) -> dict[str, str]:
     return {"Authorization": f"Bearer {access_token}", "Client-Id": client_id}
 
 
+def _eventsub_app_headers() -> dict[str, str]:
+    """Return Twitch Helix headers for EventSub app-auth conduit management APIs.
+
+    Dependencies: Reads the configured Twitch client ID and app access token
+    via ``get_twitch_client_id`` and ``get_app_access_token``.
+    Code customers: Conduit and shard reconciliation helpers call this for
+    app-auth Helix endpoints that should not use owner user tokens.
+    Used variables/origin: ``app_token`` comes from OAuth client credentials;
+    ``client_id`` comes from configured Twitch application credentials.
+    """
+
+    client_id = get_twitch_client_id()
+    if not client_id:
+        raise RuntimeError("twitch oauth credentials are not configured")
+    app_token = get_app_access_token()
+    return {"Authorization": f"Bearer {app_token}", "Client-Id": client_id}
+
+
 def ensure_eventsub_subscriptions(request: FastAPIRequest, channel_pk: int, db: Session) -> None:
     """Ensure required EventSub subscriptions are registered for a channel.
 
@@ -1061,8 +1079,8 @@ def _ensure_twitch_conduit(
     Dependencies: Calls Twitch Helix conduit list/create APIs and persists to
     ``TwitchConduit`` through SQLAlchemy.
     Code customers: EventSub conduit reconciliation workflows.
-    Used variables/origin: ``headers`` come from ``_eventsub_headers`` using a
-    channel owner token; ``shard_count`` is derived from active channels.
+    Used variables/origin: ``headers`` come from ``_eventsub_app_headers`` and
+    carry app-auth credentials; ``shard_count`` is derived from active channels.
     """
 
     errors: list[str] = []
@@ -1113,8 +1131,9 @@ def _reconcile_twitch_conduit_shards(
     Dependencies: Uses Twitch Helix conduit shard list/update APIs and
     SQLAlchemy persistence via ``TwitchConduitShard``.
     Code customers: Conduit reconciliation and eventsub health coverage checks.
-    Used variables/origin: shard IDs come from Helix payloads and fallback to a
-    local range when Twitch omits data; callback originates from API route URL.
+    Used variables/origin: ``headers`` are app-auth conduit credentials; shard
+    IDs come from Helix payloads and fallback to a local range when Twitch omits
+    data; callback originates from API route URL.
     """
 
     errors: list[str] = []
@@ -1200,8 +1219,9 @@ def _reconcile_twitch_conduit_shards(
 def reconcile_eventsub_conduit_subscriptions(request: FastAPIRequest, db: Session) -> dict[str, Any]:
     """Reconcile conduit + shards + chat subscriptions for every active channel.
 
-    Dependencies: Uses channel-owner tokens via ``_eventsub_headers`` and Twitch
-    Helix conduit/subscription APIs, persisting into ``TwitchConduit``,
+    Dependencies: Uses app-auth via ``_eventsub_app_headers`` for conduit/shard
+    Helix APIs, plus channel-owner tokens via ``_eventsub_headers`` only for
+    per-channel subscription list/create APIs; persists into ``TwitchConduit``,
     ``TwitchConduitShard``, and ``EventSubscription``.
     Code customers: Health routes and onboarding setup call this to surface
     conduit alignment status without disabling websocket subscriptions.
@@ -1226,9 +1246,8 @@ def reconcile_eventsub_conduit_subscriptions(request: FastAPIRequest, db: Sessio
 
     now = datetime.utcnow()
     callback = str(request.url_for("eventsub_callback"))
-    primary_owner = owner_channel_pairs[0][1]
     try:
-        headers = _eventsub_headers(primary_owner.access_token)
+        headers = _eventsub_app_headers()
     except RuntimeError as exc:
         result["errors"].append(f"headers_unavailable: {exc}")
         return result


### PR DESCRIPTION
### Motivation
- Switch conduit and shard management calls to app-auth so conduit APIs use the application access token instead of channel-owner tokens, aligning with intended Helm/Helix usage.
- Preserve per-channel owner token usage only for subscription list/create operations that require user-scoped auth and avoid any schema changes for a safe hotfix.

### Description
- Added a new helper ` _eventsub_app_headers()` that returns app-auth `Authorization` and `Client-Id` headers using `get_app_access_token()` and `get_twitch_client_id()` with a short docstring describing dependencies, code customers, and used variables/origin.
- Updated `_ensure_twitch_conduit`, `_reconcile_twitch_conduit_shards`, and `reconcile_eventsub_conduit_subscriptions` docstrings to reflect app-auth usage and clarify variable origins in the existing style.
- Replaced the channel-owner header usage in `reconcile_eventsub_conduit_subscriptions` with `headers = _eventsub_app_headers()` so conduit list/create and shard patch/list calls use app-auth; kept owner-token calls (via ` _eventsub_headers`) for per-channel `/helix/eventsub/subscriptions` list/create operations.
- No database schema or model changes were made and no other behavioral changes to per-channel subscription creation logic were introduced.

### Testing
- Ran `python -m py_compile backend_app.py` to validate syntax and the check completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69caf82eef4c8328b55acab4b485428f)