### PR TITLE
Refresh EventSub health state after reconciliation

### DIFF
--- a/backend_app.py
+++ b/backend_app.py
@@ -7815,43 +7815,66 @@ def eventsub_health(
     remote data Twitch returns.
     """
 
+    def _compute_local_eventsub_state() -> tuple[list[dict[str, Any]], Optional[TwitchConduit], list[TwitchConduitShard], set[str], bool, bool]:
+        """Build local EventSub, conduit, shard, and coverage state.
+
+        Dependencies: Uses the enclosing SQLAlchemy ``db`` session plus
+        ``channel_pk`` to pull current rows from ``EventSubscription``,
+        ``TwitchConduit``, and ``TwitchConduitShard``.
+        Code customers: ``eventsub_health`` calls this before and (optionally)
+        after reconciliation so top-level diagnostics stay aligned.
+        Used variables/origin: Reads ``channel_pk`` from the route context and
+        derives ``shard_ids`` and assignment coverage from persisted DB rows.
+        """
+
+        local_state = [
+            {
+                "type": sub.type,
+                "status": sub.status,
+                "last_verified_at": sub.last_verified_at,
+                "last_notified_at": sub.last_notified_at,
+                "callback": sub.callback,
+                "transport": sub.transport,
+                "conduit_id": sub.conduit_id,
+                "shard_id": sub.shard_id,
+                "meta": sub.meta,
+            }
+            for sub in db.query(EventSubscription).filter(EventSubscription.channel_id == channel_pk)
+        ]
+        conduit_state = db.query(TwitchConduit).order_by(TwitchConduit.id.asc()).first()
+        shard_state = (
+            db.query(TwitchConduitShard)
+            .filter(TwitchConduitShard.conduit_fk == conduit_state.id)
+            .order_by(TwitchConduitShard.shard_id.asc())
+            .all()
+            if conduit_state
+            else []
+        )
+        channel_chat_sub = next((sub for sub in local_state if sub["type"] == EVENTSUB_CONDUIT_CHAT_TYPE), None)
+        shard_ids_state = {row.shard_id for row in shard_state}
+        assignment_ok_state = bool(channel_chat_sub and channel_chat_sub.get("shard_id") in shard_ids_state)
+        return (
+            local_state,
+            conduit_state,
+            shard_state,
+            shard_ids_state,
+            bool(channel_chat_sub),
+            assignment_ok_state,
+        )
+
     channel_pk = get_channel_pk(channel, db)
     channel_obj = db.get(ActiveChannel, channel_pk)
     if not channel_obj:
         raise HTTPException(status_code=404, detail="channel not found")
-    local = [
-        {
-            "type": sub.type,
-            "status": sub.status,
-            "last_verified_at": sub.last_verified_at,
-            "last_notified_at": sub.last_notified_at,
-            "callback": sub.callback,
-            "transport": sub.transport,
-            "conduit_id": sub.conduit_id,
-            "shard_id": sub.shard_id,
-            "meta": sub.meta,
-        }
-        for sub in db.query(EventSubscription).filter(EventSubscription.channel_id == channel_pk)
-    ]
+    local, conduit_row, shards, shard_ids, channel_chat_present, assignment_ok = _compute_local_eventsub_state()
     remote = _fetch_remote_eventsubs(channel_obj)
     if not remote:
         logger.info("Remote EventSub data unavailable for %s; check token/scopes", channel)
-    conduit_row = db.query(TwitchConduit).order_by(TwitchConduit.id.asc()).first()
-    shards = (
-        db.query(TwitchConduitShard)
-        .filter(TwitchConduitShard.conduit_fk == conduit_row.id)
-        .order_by(TwitchConduitShard.shard_id.asc())
-        .all()
-        if conduit_row
-        else []
-    )
-    channel_chat_sub = next((sub for sub in local if sub["type"] == EVENTSUB_CONDUIT_CHAT_TYPE), None)
-    shard_ids = {row.shard_id for row in shards}
-    assignment_ok = bool(channel_chat_sub and channel_chat_sub.get("shard_id") in shard_ids)
     reconcile_state: Optional[dict[str, Any]] = None
     if reconcile:
         try:
             reconcile_state = reconcile_eventsub_conduit_subscriptions(request, db)
+            local, conduit_row, shards, shard_ids, channel_chat_present, assignment_ok = _compute_local_eventsub_state()
         except Exception as exc:
             reconcile_state = {"errors": [str(exc)], "status": "failed"}
 
@@ -7873,7 +7896,7 @@ def eventsub_health(
             for row in shards
         ],
         "coverage": {
-            "channel_chat_subscription_present": bool(channel_chat_sub),
+            "channel_chat_subscription_present": channel_chat_present,
             "channel_shard_assignment_ok": assignment_ok,
             "known_shard_ids": sorted(shard_ids),
         },

--- a/docs/README.md
+++ b/docs/README.md
@@ -84,7 +84,8 @@ unlocks the API for the bot, queue manager, and public web frontend.
 - EventSub health endpoints now include conduit + shard coverage summaries:
   - `GET /system/health` reports global conduit assignment coverage.
   - `GET /channels/{channel}/eventsub/health` reports per-channel shard
-    assignment state and can trigger reconcile with `?reconcile=true`.
+    assignment state and can trigger reconcile with `?reconcile=true`, which
+    refreshes local/conduit/shard/coverage fields after reconciliation.
 - EventSub callback operations contract:
   - `/twitch/eventsub/callback` must be publicly reachable via HTTPS from
     Twitch (no private-only callback hostnames).

--- a/docs/backend_api.md
+++ b/docs/backend_api.md
@@ -357,7 +357,7 @@ Certain events award priority points and are fed by EventSub subscriptions creat
 - Conduit/subscription metadata is persisted in existing storage:
   - `twitch_conduits`, `twitch_conduit_shards`
   - `event_subscriptions` with `transport="conduit"` for `channel.chat.message`.
-- `GET /channels/{channel}/eventsub/health?reconcile=true` runs reconciliation on-demand and reports any reconciliation errors alongside local/remote state snapshots.
+- `GET /channels/{channel}/eventsub/health?reconcile=true` runs reconciliation on-demand, then recomputes local subscriptions/conduit/shards/coverage before responding so top-level diagnostics match the new reconciliation state.
 
 ### EventSub callback contract (operations)
 


### PR DESCRIPTION
### Motivation
- Ensure that when `GET /channels/{channel}/eventsub/health?reconcile=true` is used, the top-level diagnostics (`local`, `conduit`, `shards`, `coverage`) reflect the state after reconciliation instead of mixing old top-level fields with new `reconciliation` details.

### Description
- Added a helper `def _compute_local_eventsub_state()` inside `eventsub_health` that builds current local subscriptions, the selected `TwitchConduit` row, `TwitchConduitShard` rows, known `shard_ids`, a `channel_chat_present` flag, and an assignment-ok boolean, and documented the helper with dependencies/code-customers/used variables/origin in its docstring.  
- Replaced duplicated local/conduit/shard queries in `eventsub_health` with a single call to `_compute_local_eventsub_state()` and recompute those values immediately after `reconcile_eventsub_conduit_subscriptions(request, db)` when `reconcile=true`.  
- Updated top-level response to use the computed `channel_chat_present` and `assignment_ok` values so `coverage` is consistent with the recomputed state.  
- Updated `docs/backend_api.md` and `docs/README.md` to note that `?reconcile=true` recomputes local subscriptions/conduit/shards/coverage before responding.

### Testing
- Ran `python -m py_compile backend_app.py` to verify there are no syntax errors and the module compiles successfully (passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc016af2808328a1a21c26622223cf)