### PR TITLE
docs: clarify conduit app-token auth and EventSub verification guidance

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -86,6 +86,23 @@ unlocks the API for the bot, queue manager, and public web frontend.
   - `GET /channels/{channel}/eventsub/health` reports per-channel shard
     assignment state and can trigger reconcile with `?reconcile=true`, which
     refreshes local/conduit/shard/coverage fields after reconciliation.
+- Conduit API + conduit-mode EventSub subscription management authentication:
+  - Reconciliation uses Twitch **app access token** auth (client credentials)
+    for conduit create/update/patch calls and conduit-transport subscriptions.
+  - Identity mapping remains:
+    - `broadcaster_user_id` = target channel.
+    - `user_id` = bot user id.
+- EventSub conduit troubleshooting quick map:
+
+  | HTTP status | Typical meaning | Operator action |
+  |---|---|---|
+  | `400` | Payload/condition/transport mismatch | Re-check EventSub type payload schema, conduit transport block, and required condition fields (`broadcaster_user_id`, `user_id`). |
+  | `401` | Invalid token/client pairing | Confirm app access token validity and that token `client_id` matches configured Twitch client credentials. |
+  | `403` | Permission/authorization context mismatch | Verify request context/token type and the authorized channel/bot relationship for the requested subscription. |
+
+- Operator verification steps:
+  1. Run `GET /system/health` and confirm global conduit/shard coverage is healthy.
+  2. Run `GET /channels/{channel}/eventsub/health?reconcile=true` and confirm per-channel reconciliation + coverage complete successfully.
 - EventSub callback operations contract:
   - `/twitch/eventsub/callback` must be publicly reachable via HTTPS from
     Twitch (no private-only callback hostnames).

--- a/docs/backend_api.md
+++ b/docs/backend_api.md
@@ -350,6 +350,10 @@ Certain events award priority points and are fed by EventSub subscriptions creat
 ### EventSub webhook + conduit reconciliation notes
 
 - Existing webhook subscriptions for follows/raids/cheers/subscriptions are preserved.
+- **Auth context for conduit APIs**: Conduit creation, shard patching, and conduit-mode EventSub subscription reconciliation use **Twitch app access token** authentication (client credentials), not user access tokens.
+- **Identity mapping for conduit subscriptions**:
+  - `broadcaster_user_id` = target channel Twitch user id.
+  - `user_id` = shared bot account Twitch user id.
 - In `webhook_conduit` mode (or when shadow mode is enabled), backend reconciliation now:
   - creates/reuses a Twitch conduit,
   - patches/reconciles shard transports to the webhook callback,
@@ -358,6 +362,14 @@ Certain events award priority points and are fed by EventSub subscriptions creat
   - `twitch_conduits`, `twitch_conduit_shards`
   - `event_subscriptions` with `transport="conduit"` for `channel.chat.message`.
 - `GET /channels/{channel}/eventsub/health?reconcile=true` runs reconciliation on-demand, then recomputes local subscriptions/conduit/shards/coverage before responding so top-level diagnostics match the new reconciliation state.
+
+### EventSub conduit troubleshooting quick map
+
+| HTTP status | Typical meaning | Operator action |
+|---|---|---|
+| `400` | Payload/condition/transport mismatch. | Re-check EventSub type payload schema, conduit transport block, and required condition fields (`broadcaster_user_id`, `user_id`). |
+| `401` | Invalid token/client pairing. | Confirm app access token validity and that token `client_id` matches the configured Twitch client credentials. |
+| `403` | Permission/authorization context mismatch. | Verify the request uses app-token context where required and that the authorized channel/bot relationship is valid for the requested subscription. |
 
 ### EventSub callback contract (operations)
 
@@ -395,6 +407,9 @@ Certain events award priority points and are fed by EventSub subscriptions creat
    - enable `chat_ingress_shadow_mode=true` first and confirm comparison logs are stable,
    - switch `chat_ingress_mode=webhook_conduit`,
    - disable shadow mode after validating authoritative webhook behavior.
+6. Operator verification endpoints:
+   - Call `GET /system/health` and confirm global conduit/shard coverage reports healthy.
+   - Call `GET /channels/{channel}/eventsub/health?reconcile=true` and confirm per-channel subscriptions/conduit/shard coverage reconcile successfully.
 
 ### Channel event stream
 


### PR DESCRIPTION
### Motivation
- Clarify operator-facing documentation around EventSub conduit operations so maintainers know which OAuth context to use for conduit/subscription calls.
- Preserve and make explicit the identity mapping used in conduit subscription payloads to avoid misconfiguration. 
- Provide quick troubleshooting guidance for common HTTP errors during conduit/subscription reconciliation. 

### Description
- Updated `docs/backend_api.md` to state that conduit creation, shard patching, and conduit-mode EventSub subscription reconciliation require a Twitch app access token (client credentials) and not user tokens. 
- Added an explicit identity mapping note that `broadcaster_user_id` targets the channel and `user_id` is the shared bot account. 
- Added an EventSub conduit troubleshooting table mapping `400`, `401`, and `403` responses to likely causes and operator actions. 
- Added operator verification steps referencing `GET /system/health` and `GET /channels/{channel}/eventsub/health?reconcile=true`. 
- Mirrored the same auth, identity, troubleshooting, and verification guidance in `docs/README.md` for operator-facing deployment documentation. 

### Testing
- Ran `git diff --check` to validate patch formatting and whitespace issues, which completed with no errors. 
- Verified the modified markdown files render and include the new troubleshooting table and verification steps by inspecting the diffs locally.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc026033c88328b2052ceb667fc40e)