### PR TITLE
Add admin-managed EventSub callback override with validation and admin UI

### DIFF
--- a/admin/public/admin.js
+++ b/admin/public/admin.js
@@ -85,6 +85,7 @@ const credentialsSecretInput = document.getElementById('credentials-client-secre
 const credentialsSecretHint = document.getElementById('credentials-secret-hint');
 const credentialsRedirectInput = document.getElementById('credentials-redirect');
 const credentialsBotRedirectInput = document.getElementById('credentials-bot-redirect');
+const credentialsEventSubCallbackInput = document.getElementById('credentials-eventsub-callback');
 const scopesForm = document.getElementById('scopes-form');
 const twitchScopesInput = document.getElementById('twitch-scopes-input');
 const botScopesInput = document.getElementById('bot-scopes-input');
@@ -169,6 +170,34 @@ function parseScopesInput(value) {
     .filter(Boolean);
 }
 
+function validateEventSubCallbackInput(value) {
+  const raw = (value || '').trim();
+  if (!raw) return { valid: true, normalized: '' };
+  let parsed;
+  try {
+    parsed = new URL(raw);
+  } catch (err) {
+    return { valid: false, message: 'EventSub Callback URI must be a valid absolute HTTPS URL.' };
+  }
+  const host = (parsed.hostname || '').toLowerCase().replace(/\.$/, '');
+  if (parsed.protocol !== 'https:') {
+    return { valid: false, message: 'EventSub Callback URI must start with https://.' };
+  }
+  if (parsed.pathname !== '/twitch/eventsub/callback') {
+    return { valid: false, message: 'EventSub Callback URI path must be exactly /twitch/eventsub/callback.' };
+  }
+  if (!host || host === 'localhost' || host === 'backend' || host === 'api'
+    || host.endsWith('.localhost')
+    || /\.(local|internal|lan|home|svc|cluster\.local)$/.test(host)) {
+    return { valid: false, message: 'EventSub Callback URI hostname must be public (no localhost/internal hosts).' };
+  }
+  if (!host.includes('.')) {
+    return { valid: false, message: 'EventSub Callback URI hostname must be a public DNS name.' };
+  }
+  const normalized = `${parsed.origin}/twitch/eventsub/callback`;
+  return { valid: true, normalized };
+}
+
 function setSetupStatus(text, variant) {
   if (!setupStatusEl) return;
   setupStatusEl.textContent = text;
@@ -233,6 +262,10 @@ function applySystemConfig(config) {
   }
   if (credentialsBotRedirectInput) {
     credentialsBotRedirectInput.value = state.systemConfig?.bot_redirect_uri || '';
+  }
+  if (credentialsEventSubCallbackInput) {
+    credentialsEventSubCallbackInput.value = state.systemConfig?.eventsub_callback_override || '';
+    credentialsEventSubCallbackInput.setCustomValidity('');
   }
   if (credentialsSecretInput) {
     credentialsSecretInput.value = '';
@@ -340,6 +373,20 @@ async function handleCredentialsSubmit(event) {
     const botRedirect = credentialsBotRedirectInput.value.trim();
     if ((state.systemConfig.bot_redirect_uri || '') !== botRedirect) {
       patch.bot_redirect_uri = botRedirect || null;
+    }
+  }
+  if (credentialsEventSubCallbackInput) {
+    const parsed = validateEventSubCallbackInput(credentialsEventSubCallbackInput.value);
+    if (!parsed.valid) {
+      credentialsEventSubCallbackInput.setCustomValidity(parsed.message || 'Invalid EventSub Callback URI.');
+      credentialsEventSubCallbackInput.reportValidity();
+      showSetupAlert(parsed.message || 'Invalid EventSub Callback URI.', 'error');
+      return;
+    }
+    credentialsEventSubCallbackInput.setCustomValidity('');
+    const eventSubCallback = parsed.normalized || '';
+    if ((state.systemConfig.eventsub_callback_override || '') !== eventSubCallback) {
+      patch.eventsub_callback_override = eventSubCallback || null;
     }
   }
   if (!Object.keys(patch).length) {
@@ -1674,6 +1721,12 @@ window.addEventListener('DOMContentLoaded', () => {
   });
   if (credentialsForm) {
     credentialsForm.addEventListener('submit', handleCredentialsSubmit);
+  }
+  if (credentialsEventSubCallbackInput) {
+    credentialsEventSubCallbackInput.addEventListener('input', () => {
+      const parsed = validateEventSubCallbackInput(credentialsEventSubCallbackInput.value);
+      credentialsEventSubCallbackInput.setCustomValidity(parsed.valid ? '' : (parsed.message || 'Invalid EventSub Callback URI.'));
+    });
   }
   if (scopesForm) {
     scopesForm.addEventListener('submit', handleScopesSubmit);

--- a/admin/public/index.html
+++ b/admin/public/index.html
@@ -44,6 +44,11 @@
               <span>Bot Redirect URI</span>
               <input type="text" id="credentials-bot-redirect" autocomplete="off" placeholder="https://admin.example.com/bot/callback" />
             </label>
+            <label class="field">
+              <span>EventSub Callback URI</span>
+              <input type="text" id="credentials-eventsub-callback" autocomplete="off" placeholder="https://api.example.com/twitch/eventsub/callback" />
+              <span class="form-hint">Must be a public <code>https://</code> URL with exact path <code>/twitch/eventsub/callback</code>.</span>
+            </label>
             <div class="form-actions">
               <button type="submit" id="credentials-save">Save credentials</button>
             </div>

--- a/backend_app.py
+++ b/backend_app.py
@@ -627,6 +627,39 @@ def _eventsub_callback_hostname_issue(hostname: Optional[str]) -> Optional[str]:
     return None
 
 
+def normalize_eventsub_callback_override(value: Optional[str]) -> Optional[str]:
+    """Validate and normalize an admin-supplied EventSub callback override URL.
+
+    Dependencies: Uses Starlette ``URL`` parsing and
+    ``_eventsub_callback_hostname_issue`` host safety checks.
+    Code customers: ``update_system_config`` validates/persists
+    ``eventsub_callback_override`` updates using this helper.
+    Used variables/origin: Accepts operator-provided ``/system/config`` payload
+    values, enforces HTTPS + canonical callback path + public hostname, and
+    strips query/fragment from accepted values before persistence.
+    """
+
+    raw = (value or "").strip()
+    if not raw:
+        return None
+    try:
+        parsed = URL(raw)
+    except Exception as exc:
+        raise ValueError("EventSub Callback URI must be a valid absolute HTTPS URL.") from exc
+    if not parsed.scheme or not parsed.hostname:
+        raise ValueError("EventSub Callback URI must be an absolute URL with scheme and hostname.")
+    if (parsed.scheme or "").lower() != "https":
+        raise ValueError("EventSub Callback URI must start with https://.")
+    if parsed.path != "/twitch/eventsub/callback":
+        raise ValueError("EventSub Callback URI path must be exactly /twitch/eventsub/callback.")
+    host_issue = _eventsub_callback_hostname_issue(parsed.hostname)
+    if host_issue:
+        raise ValueError(
+            "EventSub Callback URI hostname must be publicly reachable; internal/private hosts are not allowed."
+        )
+    return str(parsed.replace(query="", fragment=""))
+
+
 def _public_eventsub_callback_url(request: FastAPIRequest) -> tuple[Optional[str], Optional[str], dict[str, Any]]:
     """Build the webhook callback URL Twitch should register for EventSub.
 
@@ -753,6 +786,7 @@ def _system_config_payload() -> Dict[str, Any]:
         "twitch_client_secret_set": bool(get_twitch_client_secret()),
         "twitch_redirect_uri": get_twitch_redirect_uri(),
         "bot_redirect_uri": get_bot_redirect_uri(),
+        "eventsub_callback_override": get_eventsub_callback_override(),
         "public_backend_origin": get_public_backend_origin(),
         "twitch_scopes": get_twitch_scopes(),
         "bot_app_scopes": get_bot_app_scopes(),
@@ -2290,6 +2324,7 @@ class SystemConfigOut(BaseModel):
     twitch_client_secret_set: bool
     twitch_redirect_uri: Optional[str]
     bot_redirect_uri: Optional[str]
+    eventsub_callback_override: Optional[str]
     public_backend_origin: Optional[str]
     twitch_scopes: List[str]
     bot_app_scopes: List[str]
@@ -2302,6 +2337,7 @@ class SystemConfigUpdate(BaseModel):
     twitch_client_secret: Optional[str] = None
     twitch_redirect_uri: Optional[str] = None
     bot_redirect_uri: Optional[str] = None
+    eventsub_callback_override: Optional[str] = None
     public_backend_origin: Optional[str] = None
     twitch_scopes: Optional[List[str]] = None
     bot_app_scopes: Optional[List[str]] = None
@@ -5243,6 +5279,11 @@ def update_system_config(
         updates["twitch_redirect_uri"] = payload.twitch_redirect_uri.strip() or None
     if payload.bot_redirect_uri is not None:
         updates["bot_redirect_uri"] = payload.bot_redirect_uri.strip() or None
+    if payload.eventsub_callback_override is not None:
+        try:
+            updates["eventsub_callback_override"] = normalize_eventsub_callback_override(payload.eventsub_callback_override)
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
     if payload.public_backend_origin is not None:
         updates["public_backend_origin"] = payload.public_backend_origin.strip() or None
     if payload.twitch_scopes is not None:

--- a/docs/README.md
+++ b/docs/README.md
@@ -112,15 +112,24 @@ unlocks the API for the bot, queue manager, and public web frontend.
   - Internal/private-only callback hostnames are explicitly rejected during
     reconciliation (`backend`, `api`, `localhost`, private IPs, and bare
     private-only hostnames without public DNS suffixes).
-  - Set `/system/config.public_backend_origin` (or environment bootstrap
-    `PUBLIC_BACKEND_ORIGIN`) to the canonical public HTTPS backend origin so
-    registration always uses:
+  - Preferred: set `/system/config.eventsub_callback_override` to the exact
+    public callback URI, for example:
+    `https://api.example.com/twitch/eventsub/callback`.
+  - Fallback: set `/system/config.public_backend_origin` (or environment
+    bootstrap `PUBLIC_BACKEND_ORIGIN`) so registration can derive:
     `https://<public-backend-origin>/twitch/eventsub/callback`.
+  - Legacy bootstrap: `TWITCH_EVENTSUB_CALLBACK` is kept for initial/default
+    bootstrap only; runtime operations should use admin-managed
+    `eventsub_callback_override` to avoid stale env drift.
+  - Callback source precedence is: `eventsub_callback_override` >
+    `public_backend_origin` > `request_url` fallback.
   - Reconciliation warning output now includes callback source metadata:
     `eventsub_callback_override`, `public_backend_origin`, or `request_url`.
   - Invalid callback candidates degrade reconciliation status with explicit
     remediation text instead of silently failing with limited context.
-  - HTTP callback registration is blocked with `callback_url_not_https`.
+  - HTTP callback registration is blocked with `callback_url_not_https`;
+    `/system/config` also returns HTTP 400 details when an override is invalid
+    (non-HTTPS, wrong path, or internal/private host).
   - `301` redirecting `http://...` to `https://...` is not a supported
     substitute for reliable Twitch callback registration.
   - Signatures are validated against the persisted per-subscription secret

--- a/docs/backend_api.md
+++ b/docs/backend_api.md
@@ -12,10 +12,12 @@ This document summarizes the REST endpoints exposed by `backend_app.py`.
 ### `/system/config`
 - **GET response fields**
   - Existing setup/OAuth fields (`setup_complete`, client IDs/secrets, redirect URIs, scopes).
+  - `eventsub_callback_override`: optional admin-managed full callback override URL (example: `https://api.example.com/twitch/eventsub/callback`).
   - `public_backend_origin`: canonical public backend origin used for EventSub callback URL generation (example: `https://api.example.com`).
   - `chat_ingress_mode`: `websocket` (default) or `webhook_conduit`.
   - `chat_ingress_shadow_mode`: boolean dual-run switch for validation mode (default `false`).
 - **PUT payload additions**
+  - `eventsub_callback_override?: string`
   - `public_backend_origin?: string`
   - `chat_ingress_mode?: "websocket" | "webhook_conduit"`
   - `chat_ingress_shadow_mode?: boolean`
@@ -24,12 +26,17 @@ This document summarizes the REST endpoints exposed by `backend_app.py`.
 ### EventSub callback URL reliability requirements
 - Twitch EventSub webhook registration must use a **publicly reachable HTTPS callback URL**.
 - Callback validation enforces:
+  - Absolute URL.
   - `https://` scheme.
   - Exact path `/twitch/eventsub/callback`.
+  - Public hostname (no localhost/internal aliases/private-only hosts).
+- Valid override example: `https://api.example.com/twitch/eventsub/callback` (query/fragment are stripped during normalization).
+- Troubleshooting: HTTP URLs or internal hosts like `http://backend/...` and `https://localhost/...` are rejected with HTTP 400 details during `/system/config` update.
 - Callback source priority is:
-  1. `eventsub_callback_override`
+  1. `eventsub_callback_override` (admin-managed runtime override)
   2. `public_backend_origin`
   3. `request_url` fallback
+- Environment `TWITCH_EVENTSUB_CALLBACK` is now a **legacy bootstrap fallback** only; use `/system/config.eventsub_callback_override` for operational changes to avoid drift.
 - Reconciliation output now includes structured callback warnings with source
   metadata so operators can see which source failed validation and why.
 - Internal/private-only callback hostnames are rejected (examples:


### PR DESCRIPTION
### Motivation
- Allow operators to correct the Twitch EventSub callback URL at runtime via the admin UI/API without redeploying environment variables.
- Preserve existing environment bootstrap (`TWITCH_EVENTSUB_CALLBACK`) as a legacy initial/default source while making admin-managed override the preferred runtime control.

### Description
- Add `eventsub_callback_override` to `SystemConfigOut` and `SystemConfigUpdate`, include it in the `/system/config` payload, and persist via the existing `set_settings` flow in `update_system_config`.
- Implement `normalize_eventsub_callback_override(...)` to validate and normalize admin-supplied callback URIs (absolute `https://`, exact path `/twitch/eventsub/callback`, strip query/fragment, and reject internal/private hostnames) and wire it to return clear HTTP 400 details on invalid input.
- Ensure `_public_eventsub_callback_url(request)` prefers the persisted `eventsub_callback_override`, then `public_backend_origin`, then the request-derived URL, and continue to emit structured warning metadata for reconciliation reporting.
- Add an “EventSub Callback URI” input to the admin Credentials panel with client-side validation and help text, load/save via `GET /system/config` and `PUT /system/config`, and normalize the value before sending the patch payload.
- Update `docs/backend_api.md` and `docs/README.md` to document the new `eventsub_callback_override` field, precedence (override > public origin > request), valid example, troubleshooting guidance, and mark env-only callback mapping as a legacy bootstrap fallback.
- Include descriptive docstrings for the new normalization helper and note that no obvious unused code paths were found for immediate removal (mark for future review if desired).

### Testing
- Ran `python -m py_compile backend_app.py` to validate Python syntax; the check succeeded.
- Ran `node --check admin/public/admin.js` to validate the admin JavaScript; the check succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc19ca56988328a458f8a0cfb696d1)