### PR TITLE
Add structured EventSub callback diagnostics for bad requests

### DIFF
--- a/backend_app.py
+++ b/backend_app.py
@@ -7965,18 +7965,40 @@ async def eventsub_callback(request: FastAPIRequest, db: Session = Depends(get_d
     timestamp = headers.get("Twitch-Eventsub-Message-Timestamp") or ""
     signature = headers.get("Twitch-Eventsub-Message-Signature") or ""
     message_type = headers.get("Twitch-Eventsub-Message-Type") or ""
+    logger.debug(
+        "Incoming EventSub callback message_type=%s message_id=%s",
+        message_type or "<missing>",
+        message_id or "<missing>",
+    )
 
     if not message_id or not timestamp or not signature:
+        logger.warning(
+            "EventSub callback rejected: missing signature headers; has_message_id=%s has_timestamp=%s has_signature=%s",
+            bool(message_id),
+            bool(timestamp),
+            bool(signature),
+        )
         raise HTTPException(status_code=400, detail="missing signature headers")
 
     try:
         payload = await request.json()
-    except Exception:
+    except Exception as exc:
+        logger.warning(
+            "EventSub callback rejected: invalid JSON decode; message_id=%s error_type=%s",
+            message_id,
+            type(exc).__name__,
+        )
         raise HTTPException(status_code=400, detail="invalid JSON")
 
     sub_info = payload.get("subscription") or {}
     sub_id = sub_info.get("id")
     if not sub_id:
+        logger.warning(
+            "EventSub callback rejected: subscription id missing; message_id=%s message_type=%s payload_has_subscription=%s",
+            message_id,
+            message_type or "<missing>",
+            bool(payload.get("subscription")),
+        )
         raise HTTPException(status_code=400, detail="subscription id missing")
 
     subscription = (


### PR DESCRIPTION
### Motivation
- Make the root cause of EventSub callback 400 responses visible in a single request cycle by emitting structured diagnostics immediately when headers and payloads are parsed.

### Description
- Added a debug log at the top of `eventsub_callback` to record the incoming `Twitch-Eventsub-Message-Type` and `Twitch-Eventsub-Message-Id` without exposing secrets.
- Added a structured warning log immediately before the `400` path for missing signature headers that includes boolean flags for presence of `message_id`, `timestamp`, and `signature`.
- Added a structured warning log on JSON decode failure that records the `message_id` and the JSON parse exception type without logging payload or secrets.
- Added a structured warning log when the subscription id is missing that records the `message_id`, `message_type`, and whether a `subscription` object was present in the payload.

### Testing
- Ran `python -m compileall backend_app.py`, which completed successfully.
- Verified the change was committed to the repository (commit created during the rollout).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc202d454c83289d9aa3027e845249)