### PR TITLE
Fix EventSub callback verification for classic and conduit payloads

### DIFF
--- a/backend_app.py
+++ b/backend_app.py
@@ -349,6 +349,7 @@ def ensure_eventsub_conduit_schema() -> None:
                         conduit_fk INTEGER NOT NULL REFERENCES twitch_conduits(id) ON DELETE CASCADE,
                         shard_id VARCHAR NOT NULL,
                         transport_callback TEXT,
+                        transport_secret TEXT,
                         status VARCHAR NOT NULL DEFAULT 'pending',
                         last_sync_at DATETIME,
                         created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
@@ -358,6 +359,10 @@ def ensure_eventsub_conduit_schema() -> None:
                     """
                 )
             )
+        else:
+            shard_columns = {col["name"] for col in inspector.get_columns("twitch_conduit_shards")}
+            if "transport_secret" not in shard_columns:
+                conn.execute(text("ALTER TABLE twitch_conduit_shards ADD COLUMN transport_secret TEXT"))
 
 
 def backfill_missing_channel_keys() -> None:
@@ -1385,11 +1390,23 @@ def _reconcile_twitch_conduit_shards(
 
     errors: list[str] = []
     desired_ids = [str(index) for index in range(max(1, target_shard_count))]
-    secret = secrets.token_urlsafe(32)
+    secret_by_shard: dict[str, str] = {}
+    for shard_id in desired_ids:
+        existing = (
+            db.query(TwitchConduitShard)
+            .filter(
+                TwitchConduitShard.conduit_fk == conduit_row.id,
+                TwitchConduitShard.shard_id == shard_id,
+            )
+            .one_or_none()
+        )
+        secret_by_shard[shard_id] = (
+            existing.transport_secret if existing and existing.transport_secret else secrets.token_urlsafe(32)
+        )
     shards_payload = [
         {
             "id": shard_id,
-            "transport": {"method": "webhook", "callback": callback, "secret": secret},
+            "transport": {"method": "webhook", "callback": callback, "secret": secret_by_shard[shard_id]},
         }
         for shard_id in desired_ids
     ]
@@ -1439,6 +1456,7 @@ def _reconcile_twitch_conduit_shards(
             db.add(row)
         transport = shard.get("transport") or {}
         row.transport_callback = transport.get("callback") or callback
+        row.transport_secret = secret_by_shard.get(shard_id) or row.transport_secret
         row.status = shard.get("status") or "enabled"
         row.last_sync_at = now
 
@@ -1458,9 +1476,46 @@ def _reconcile_twitch_conduit_shards(
             row = TwitchConduitShard(conduit_fk=conduit_row.id, shard_id=shard_id)
             db.add(row)
         row.transport_callback = callback
+        row.transport_secret = secret_by_shard.get(shard_id) or row.transport_secret
         row.status = "pending"
         row.last_sync_at = now
     return assignment, errors
+
+
+def _resolve_conduit_verification_secret(
+    payload: Mapping[str, Any],
+    db: Session,
+) -> tuple[Optional[str], Optional[str], Optional[str]]:
+    """Resolve webhook secret for conduit-shard callback verification payloads.
+
+    Dependencies: Uses ``TwitchConduit`` + ``TwitchConduitShard`` persistence.
+    Code customers: ``eventsub_callback`` verification branch for
+    ``verification_shape=conduit_shard``.
+    Used variables/origin: Reads ``conduit_shard.id`` and optional
+    ``conduit_shard.conduit_id`` or ``subscription.transport.conduit_id`` from
+    EventSub verification payloads.
+    """
+
+    conduit_shard = payload.get("conduit_shard") or {}
+    shard_id = str(conduit_shard.get("id")) if conduit_shard.get("id") is not None else None
+    if not shard_id:
+        return None, None, "missing_conduit_shard_id"
+    conduit_id = conduit_shard.get("conduit_id")
+    if not conduit_id:
+        transport = (payload.get("subscription") or {}).get("transport") or {}
+        conduit_id = transport.get("conduit_id")
+    query = db.query(TwitchConduitShard).join(TwitchConduit, TwitchConduitShard.conduit_fk == TwitchConduit.id)
+    query = query.filter(TwitchConduitShard.shard_id == shard_id)
+    if conduit_id:
+        query = query.filter(TwitchConduit.conduit_id == conduit_id)
+    rows = query.limit(2).all()
+    if not rows:
+        return None, shard_id, "unknown_conduit_shard"
+    if len(rows) > 1 and not conduit_id:
+        return None, shard_id, "ambiguous_conduit_shard"
+    if not rows[0].transport_secret:
+        return None, shard_id, "missing_conduit_shard_secret"
+    return rows[0].transport_secret, shard_id, None
 
 
 def _format_eventsub_http_error(exc: Exception, auth_mode: str) -> str:
@@ -1932,6 +1987,7 @@ class TwitchConduitShard(Base):
     conduit_fk = Column(Integer, ForeignKey("twitch_conduits.id", ondelete="CASCADE"), nullable=False)
     shard_id = Column(String, nullable=False)
     transport_callback = Column(Text)
+    transport_secret = Column(Text)
     status = Column(String, nullable=False, default="pending")
     last_sync_at = Column(DateTime)
     created_at = Column(DateTime, default=datetime.utcnow, nullable=False)
@@ -7973,7 +8029,7 @@ async def eventsub_callback(request: FastAPIRequest, db: Session = Depends(get_d
 
     if not message_id or not timestamp or not signature:
         logger.warning(
-            "EventSub callback rejected: missing signature headers; has_message_id=%s has_timestamp=%s has_signature=%s",
+            "EventSub callback rejected: reason_code=missing_signature_headers has_message_id=%s has_timestamp=%s has_signature=%s",
             bool(message_id),
             bool(timestamp),
             bool(signature),
@@ -7984,20 +8040,102 @@ async def eventsub_callback(request: FastAPIRequest, db: Session = Depends(get_d
         payload = await request.json()
     except Exception as exc:
         logger.warning(
-            "EventSub callback rejected: invalid JSON decode; message_id=%s error_type=%s",
+            "EventSub callback rejected: reason_code=invalid_json message_id=%s error_type=%s",
             message_id,
             type(exc).__name__,
         )
         raise HTTPException(status_code=400, detail="invalid JSON")
 
+    if message_type == "webhook_callback_verification":
+        sub_info = payload.get("subscription") or {}
+        conduit_shard = payload.get("conduit_shard") or {}
+        verification_shape = "subscription" if sub_info else "conduit_shard" if conduit_shard else "unknown"
+        logger.info(
+            "EventSub verification callback received message_type=%s message_id=%s verification_shape=%s",
+            message_type,
+            message_id,
+            verification_shape,
+        )
+        if verification_shape == "subscription":
+            sub_id = sub_info.get("id")
+            if not sub_id:
+                logger.warning(
+                    "EventSub callback rejected: reason_code=missing_subscription_id message_id=%s message_type=%s verification_shape=%s",
+                    message_id,
+                    message_type,
+                    verification_shape,
+                )
+                raise HTTPException(status_code=400, detail="subscription id missing")
+            subscription = (
+                db.query(EventSubscription)
+                .filter(EventSubscription.twitch_subscription_id == sub_id)
+                .one_or_none()
+            )
+            if not subscription:
+                logger.warning(
+                    "EventSub callback ignored: reason_code=unknown_subscription message_id=%s message_type=%s verification_shape=%s subscription_id=%s",
+                    message_id,
+                    message_type,
+                    verification_shape,
+                    sub_id,
+                )
+                return JSONResponse(status_code=202, content={"detail": "unknown subscription"})
+            secret = subscription.secret
+            if not _verify_eventsub_signature(secret, message_id, timestamp, body, signature):
+                logger.warning(
+                    "EventSub callback rejected: reason_code=invalid_signature message_id=%s message_type=%s verification_shape=%s",
+                    message_id,
+                    message_type,
+                    verification_shape,
+                )
+                raise HTTPException(status_code=403, detail="invalid signature")
+            subscription.status = sub_info.get("status") or subscription.status
+            subscription.last_verified_at = datetime.utcnow()
+            subscription.updated_at = datetime.utcnow()
+            db.commit()
+        elif verification_shape == "conduit_shard":
+            secret, shard_id, resolve_error = _resolve_conduit_verification_secret(payload, db)
+            if resolve_error or not secret:
+                logger.warning(
+                    "EventSub callback rejected: reason_code=%s message_id=%s message_type=%s verification_shape=%s shard_id=%s",
+                    resolve_error or "unknown_secret_resolution_error",
+                    message_id,
+                    message_type,
+                    verification_shape,
+                    shard_id or "<missing>",
+                )
+                raise HTTPException(status_code=400, detail="conduit shard secret unavailable")
+            if not _verify_eventsub_signature(secret, message_id, timestamp, body, signature):
+                logger.warning(
+                    "EventSub callback rejected: reason_code=invalid_signature message_id=%s message_type=%s verification_shape=%s shard_id=%s",
+                    message_id,
+                    message_type,
+                    verification_shape,
+                    shard_id or "<missing>",
+                )
+                raise HTTPException(status_code=403, detail="invalid signature")
+        else:
+            logger.warning(
+                "EventSub callback rejected: reason_code=unsupported_verification_shape message_id=%s message_type=%s",
+                message_id,
+                message_type,
+            )
+            raise HTTPException(status_code=400, detail="unsupported verification payload shape")
+        challenge = payload.get("challenge") or ""
+        return Response(content=challenge, media_type="text/plain")
+
+    # Deprecated/removed assumption note:
+    # historically this callback required subscription.id for every message
+    # type, which broke conduit-shard verification payloads that omit
+    # ``subscription``. Keep subscription lookup scoped to message types that
+    # process EventSubscription rows.
     sub_info = payload.get("subscription") or {}
     sub_id = sub_info.get("id")
     if not sub_id:
         logger.warning(
-            "EventSub callback rejected: subscription id missing; message_id=%s message_type=%s payload_has_subscription=%s",
+            "EventSub callback rejected: reason_code=missing_subscription_id message_id=%s message_type=%s",
             message_id,
             message_type or "<missing>",
-            bool(payload.get("subscription")),
         )
         raise HTTPException(status_code=400, detail="subscription id missing")
 
@@ -8007,22 +8145,26 @@ async def eventsub_callback(request: FastAPIRequest, db: Session = Depends(get_d
         .one_or_none()
     )
     if not subscription:
-        logger.warning("Ignoring callback for unknown EventSub %s", sub_id)
+        logger.warning(
+            "EventSub callback ignored: reason_code=unknown_subscription message_id=%s message_type=%s subscription_id=%s",
+            message_id,
+            message_type or "<missing>",
+            sub_id,
+        )
         return JSONResponse(status_code=202, content={"detail": "unknown subscription"})
 
     if not _verify_eventsub_signature(subscription.secret, message_id, timestamp, body, signature):
-        logger.warning("EventSub signature mismatch for %s", sub_id)
+        logger.warning(
+            "EventSub callback rejected: reason_code=invalid_signature message_id=%s message_type=%s subscription_id=%s",
+            message_id,
+            message_type or "<missing>",
+            sub_id,
+        )
         raise HTTPException(status_code=403, detail="invalid signature")
 
     subscription.status = sub_info.get("status") or subscription.status
     subscription.updated_at = datetime.utcnow()
     db.flush()
-
-    if message_type == "webhook_callback_verification":
-        subscription.last_verified_at = datetime.utcnow()
-        db.commit()
-        challenge = payload.get("challenge") or ""
-        return Response(content=challenge, media_type="text/plain")
 
     if message_type == "notification":
         if not _record_eventsub_notification_dedupe(db, message_id):

--- a/docs/README.md
+++ b/docs/README.md
@@ -79,6 +79,9 @@ unlocks the API for the bot, queue manager, and public web frontend.
   replay/conduit tables (`eventsub_message_dedupe`, `twitch_conduits`,
   `twitch_conduit_shards`) plus conduit linkage columns on
   `event_subscriptions`.
+- Conduit shard metadata now persists `twitch_conduit_shards.transport_secret`
+  so callback verification can validate Twitch conduit-shard challenges without
+  requiring `subscription.id`.
 - Startup now includes a compatibility patch for the same tables/columns so
   staggered deploys on legacy SQLite/prod databases continue booting safely.
 - EventSub health endpoints now include conduit + shard coverage summaries:
@@ -123,6 +126,13 @@ unlocks the API for the bot, queue manager, and public web frontend.
     `eventsub_callback_override` to avoid stale env drift.
   - Callback source precedence is: `eventsub_callback_override` >
     `public_backend_origin` > `request_url` fallback.
+  - Callback verification supports both payload variants:
+    - classic verification payloads (`subscription` shape),
+    - conduit shard verification payloads (`conduit_shard` shape with no
+      `subscription`).
+  - Legacy `subscription id missing` errors for conduit verification were caused
+    by an older global subscription-id assumption; this is fixed by routing
+    verification shape before subscription lookup.
   - Reconciliation warning output now includes callback source metadata:
     `eventsub_callback_override`, `public_backend_origin`, or `request_url`.
   - Invalid callback candidates degrade reconciliation status with explicit

--- a/docs/backend_api.md
+++ b/docs/backend_api.md
@@ -418,7 +418,12 @@ Certain events award priority points and are fed by EventSub subscriptions creat
   - `Twitch-Eventsub-Message-Type`
 - **Signature verification**:
   - The backend computes `HMAC_SHA256(secret, message_id + timestamp + raw_body)` and rejects mismatches with `403`.
-  - The `secret` is taken from the stored `event_subscriptions.secret` value for the incoming subscription id.
+  - For classic payloads (`verification_shape=subscription` and normal notifications), the `secret` is taken from `event_subscriptions.secret` via `subscription.id`.
+  - For conduit verification payloads (`verification_shape=conduit_shard`), the `secret` is taken from `twitch_conduit_shards.transport_secret` using `conduit_shard.id` plus `conduit_id` context when provided.
+- **Verification payload variants**:
+  - Classic webhook verification payloads with `subscription` are supported.
+  - Conduit shard verification payloads with `conduit_shard` and no `subscription` are supported.
+  - Legacy behavior that globally required `subscription.id` has been removed for verification callbacks.
 - **Idempotency / retries**:
   - `notification` deliveries are inserted into `eventsub_message_dedupe` keyed by `message_id` before processing.
   - Duplicate retries are acknowledged with success and skipped to prevent duplicate command/event execution.
@@ -438,6 +443,7 @@ Certain events award priority points and are fed by EventSub subscriptions creat
 4. Monitor callback logs for:
    - signature failures,
    - unknown subscription IDs,
+   - conduit shard secret resolution failures (`missing_conduit_shard_secret`, `unknown_conduit_shard`, `ambiguous_conduit_shard`),
    - dedupe hits (retry storms),
    - webhook/websocket comparison deltas while shadow mode is enabled.
 5. During cutover:
@@ -447,6 +453,8 @@ Certain events award priority points and are fed by EventSub subscriptions creat
 6. Operator verification endpoints:
    - Call `GET /system/health` and confirm global conduit/shard coverage reports healthy.
    - Call `GET /channels/{channel}/eventsub/health?reconcile=true` and confirm per-channel subscriptions/conduit/shard coverage reconcile successfully.
+7. Legacy bug note:
+   - If you previously saw `subscription id missing` on valid conduit verification callbacks, upgrade to this patch level; the callback now branches verification shape before subscription lookup.
 
 ### Channel event stream
 

--- a/migrations/20260330_eventsub_conduits.sql
+++ b/migrations/20260330_eventsub_conduits.sql
@@ -22,6 +22,7 @@ CREATE TABLE IF NOT EXISTS twitch_conduit_shards (
     conduit_fk INTEGER NOT NULL REFERENCES twitch_conduits(id) ON DELETE CASCADE,
     shard_id VARCHAR NOT NULL,
     transport_callback TEXT,
+    transport_secret TEXT,
     status VARCHAR NOT NULL DEFAULT 'pending',
     last_sync_at DATETIME,
     created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,

--- a/tests/test_channel_events.py
+++ b/tests/test_channel_events.py
@@ -20,6 +20,8 @@ def _wipe_db() -> None:
             backend_app.Event,
             backend_app.EventSubscription,
             backend_app.EventSubMessageDedupe,
+            backend_app.TwitchConduitShard,
+            backend_app.TwitchConduit,
             backend_app.PlaylistItem,
             backend_app.PlaylistKeyword,
             backend_app.Playlist,
@@ -378,6 +380,182 @@ class ChannelEventTests(unittest.TestCase):
             )
         finally:
             db.close()
+
+    def test_eventsub_verification_accepts_subscription_shape(self) -> None:
+        """Ensure classic verification payloads succeed via subscription secret.
+
+        Dependencies: Persists an ``EventSubscription`` row and exercises
+        ``/twitch/eventsub/callback`` signature validation.
+        Code customers: Twitch classic webhook verification.
+        Used variables/origin: Uses payload ``subscription.id`` and challenge.
+        """
+
+        details = _setup_channel()
+        secret = "verify-sub-secret"
+        db = backend_app.SessionLocal()
+        try:
+            db.add(
+                backend_app.EventSubscription(
+                    channel_id=details["channel_pk"],
+                    twitch_subscription_id="sub-verify-1",
+                    type="channel.follow",
+                    status="enabled",
+                    secret=secret,
+                    callback="https://example/callback",
+                )
+            )
+            db.commit()
+        finally:
+            db.close()
+
+        body = {
+            "subscription": {"id": "sub-verify-1", "status": "enabled", "type": "channel.follow", "version": "1"},
+            "challenge": "challenge-sub",
+        }
+        raw = json.dumps(body).encode()
+        message_id = "msg-verify-sub"
+        timestamp = "2023-01-01T00:00:00Z"
+        digest = hmac.new(secret.encode(), msg=(message_id + timestamp).encode() + raw, digestmod=hashlib.sha256)
+        response = self.client.post(
+            "/twitch/eventsub/callback",
+            data=raw,
+            headers={
+                "Twitch-Eventsub-Message-Id": message_id,
+                "Twitch-Eventsub-Message-Timestamp": timestamp,
+                "Twitch-Eventsub-Message-Signature": f"sha256={digest.hexdigest()}",
+                "Twitch-Eventsub-Message-Type": "webhook_callback_verification",
+            },
+        )
+        self.assertEqual(response.status_code, 200, response.text)
+        self.assertEqual(response.text, "challenge-sub")
+
+    def test_eventsub_verification_accepts_conduit_shard_shape_without_subscription(self) -> None:
+        """Ensure conduit-shard verification works without subscription payload.
+
+        Dependencies: Persists conduit + shard metadata including
+        ``transport_secret`` and calls callback route.
+        Code customers: Twitch conduit shard verification callbacks.
+        Used variables/origin: Uses payload ``conduit_shard.id`` and
+        ``conduit_shard.conduit_id`` context.
+        """
+
+        shard_secret = "verify-conduit-secret"
+        db = backend_app.SessionLocal()
+        try:
+            conduit = backend_app.TwitchConduit(conduit_id="conduit-1", status="enabled")
+            db.add(conduit)
+            db.commit()
+            db.refresh(conduit)
+            db.add(
+                backend_app.TwitchConduitShard(
+                    conduit_fk=conduit.id,
+                    shard_id="0",
+                    transport_callback="https://example/callback",
+                    transport_secret=shard_secret,
+                    status="enabled",
+                )
+            )
+            db.commit()
+        finally:
+            db.close()
+
+        body = {
+            "conduit_shard": {"id": "0", "conduit_id": "conduit-1"},
+            "challenge": "challenge-conduit",
+        }
+        raw = json.dumps(body).encode()
+        message_id = "msg-verify-conduit"
+        timestamp = "2023-01-01T00:00:00Z"
+        digest = hmac.new(shard_secret.encode(), msg=(message_id + timestamp).encode() + raw, digestmod=hashlib.sha256)
+        response = self.client.post(
+            "/twitch/eventsub/callback",
+            data=raw,
+            headers={
+                "Twitch-Eventsub-Message-Id": message_id,
+                "Twitch-Eventsub-Message-Timestamp": timestamp,
+                "Twitch-Eventsub-Message-Signature": f"sha256={digest.hexdigest()}",
+                "Twitch-Eventsub-Message-Type": "webhook_callback_verification",
+            },
+        )
+        self.assertEqual(response.status_code, 200, response.text)
+        self.assertEqual(response.text, "challenge-conduit")
+
+    def test_eventsub_verification_rejects_invalid_signature_for_subscription_and_conduit(self) -> None:
+        """Ensure invalid signatures are rejected for both verification shapes.
+
+        Dependencies: Persists subscription and conduit shard secrets then hits
+        callback route with intentionally mismatched HMAC signatures.
+        Code customers: Signature integrity checks for callback verification.
+        Used variables/origin: Uses wrong local signing secret for each shape.
+        """
+
+        details = _setup_channel()
+        db = backend_app.SessionLocal()
+        try:
+            db.add(
+                backend_app.EventSubscription(
+                    channel_id=details["channel_pk"],
+                    twitch_subscription_id="sub-verify-bad",
+                    type="channel.follow",
+                    status="enabled",
+                    secret="good-sub-secret",
+                    callback="https://example/callback",
+                )
+            )
+            conduit = backend_app.TwitchConduit(conduit_id="conduit-bad", status="enabled")
+            db.add(conduit)
+            db.commit()
+            db.refresh(conduit)
+            db.add(
+                backend_app.TwitchConduitShard(
+                    conduit_fk=conduit.id,
+                    shard_id="1",
+                    transport_callback="https://example/callback",
+                    transport_secret="good-conduit-secret",
+                    status="enabled",
+                )
+            )
+            db.commit()
+        finally:
+            db.close()
+
+        sub_body = {"subscription": {"id": "sub-verify-bad", "type": "channel.follow"}, "challenge": "x"}
+        sub_raw = json.dumps(sub_body).encode()
+        sub_digest = hmac.new(
+            b"wrong-sub-secret",
+            msg=("msg-verify-bad-sub" + "2023-01-01T00:00:00Z").encode() + sub_raw,
+            digestmod=hashlib.sha256,
+        )
+        sub_resp = self.client.post(
+            "/twitch/eventsub/callback",
+            data=sub_raw,
+            headers={
+                "Twitch-Eventsub-Message-Id": "msg-verify-bad-sub",
+                "Twitch-Eventsub-Message-Timestamp": "2023-01-01T00:00:00Z",
+                "Twitch-Eventsub-Message-Signature": f"sha256={sub_digest.hexdigest()}",
+                "Twitch-Eventsub-Message-Type": "webhook_callback_verification",
+            },
+        )
+        self.assertEqual(sub_resp.status_code, 403, sub_resp.text)
+
+        conduit_body = {"conduit_shard": {"id": "1", "conduit_id": "conduit-bad"}, "challenge": "y"}
+        conduit_raw = json.dumps(conduit_body).encode()
+        conduit_digest = hmac.new(
+            b"wrong-conduit-secret",
+            msg=("msg-verify-bad-conduit" + "2023-01-01T00:00:00Z").encode() + conduit_raw,
+            digestmod=hashlib.sha256,
+        )
+        conduit_resp = self.client.post(
+            "/twitch/eventsub/callback",
+            data=conduit_raw,
+            headers={
+                "Twitch-Eventsub-Message-Id": "msg-verify-bad-conduit",
+                "Twitch-Eventsub-Message-Timestamp": "2023-01-01T00:00:00Z",
+                "Twitch-Eventsub-Message-Signature": f"sha256={conduit_digest.hexdigest()}",
+                "Twitch-Eventsub-Message-Type": "webhook_callback_verification",
+            },
+        )
+        self.assertEqual(conduit_resp.status_code, 403, conduit_resp.text)
 
     def test_eventsub_chat_notification_shadow_mode_records_dedupe(self) -> None:
         """Verify chat webhook notifications in shadow mode stay non-authoritative.


### PR DESCRIPTION
### Motivation
- Make EventSub webhook verification succeed for both classic `subscription`-shaped payloads and conduit `conduit_shard`-shaped payloads without incorrectly requiring `subscription.id` for verification pings.
- Persist conduit-shard transport secrets so conduit verification can validate HMAC signatures independently of `event_subscriptions` secrets.
- Improve diagnostics so verification mode and precise reason codes appear in logs to aid troubleshooting and avoid silent 400/403 ambiguity.

### Description
- Branch `webhook_callback_verification` handling in `eventsub_callback` before enforcing subscription lookup and accept both payload shapes (`subscription` and `conduit_shard`) with `verification_shape` markers in logs and structured `reason_code` messages. (backend_app.py)
- Add `_resolve_conduit_verification_secret(payload, db)` to resolve a shard secret using `conduit_shard.id` and optional `conduit_id` context and return clear resolution error codes for logging. (backend_app.py)
- Persist per-shard transport secrets: add `transport_secret` column to ORM `TwitchConduitShard`, add additive startup/ALTER logic in `ensure_eventsub_conduit_schema`, and generate/reuse secrets during `_reconcile_twitch_conduit_shards` so shard patch/list flows store `transport_secret`. (backend_app.py, migrations/20260330_eventsub_conduits.sql)
- Keep existing subscription-secret verification path unchanged for notifications and non-conduit verification; move the `subscription id missing` check to only apply when subscription lookup is required. (backend_app.py)
- Add structured logs that include `verification_shape` and `reason_code` (without secrets/signatures) and mark the old global `subscription.id` assumption as deprecated/removed in comments to avoid regressions. (backend_app.py)
- Add tests in `tests/test_channel_events.py` covering classic `webhook_callback_verification` (subscription shape), conduit-shard verification (conduit_shard shape with no subscription), and invalid signature rejection for both shapes, and update the test DB cleanup list to include conduit models. (tests/test_channel_events.py)
- Update docs to document both verification payload variants, the conduit-shard secret storage/validation model, and a legacy note about previously observed `subscription id missing` failures. (docs/backend_api.md, docs/README.md)

### Testing
- Ran byte-compile checks: `python -m py_compile backend_app.py tests/test_channel_events.py` — success.
- Ran unit tests for the EventSub callback file: `pytest -q tests/test_channel_events.py` — collection/bootstrap failed in this environment with a startup SQLite error `unable to open database file` (environmental/config limitation during import), so the new tests were not able to be executed end-to-end here.
- Added tests exercised locally in CI (intended):
  - `test_eventsub_verification_accepts_subscription_shape`
  - `test_eventsub_verification_accepts_conduit_shard_shape_without_subscription`
  - `test_eventsub_verification_rejects_invalid_signature_for_subscription_and_conduit`
  - Existing notification/dedupe tests remain unchanged and were kept compatible with the refactor.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc22e6a9408328abc83a87239f45cc)