### PR TITLE
Use conduit shard secrets for EventSub chat notification signature verification

### DIFF
--- a/backend_app.py
+++ b/backend_app.py
@@ -1520,6 +1520,74 @@ def _resolve_conduit_verification_secret(
     return rows[0].transport_secret, conduit_id, shard_id, None
 
 
+def _resolve_conduit_notification_secret(
+    subscription: EventSubscription,
+    payload: Mapping[str, Any],
+    db: Session,
+) -> tuple[Optional[str], Optional[str], Optional[str], Optional[str]]:
+    """Resolve conduit shard secret for ``notification`` callback signature checks.
+
+    Dependencies: Uses ``json`` for persisted ``EventSubscription.meta`` parsing
+    and ``TwitchConduit``/``TwitchConduitShard`` tables for secret lookup.
+    Code customers: ``eventsub_callback`` notification branch for
+    conduit-delivered chat messages.
+    Used variables/origin: Reads conduit identity from subscription columns,
+    subscription metadata, and payload transport fields; shard identity comes
+    from subscription column/metadata.
+    """
+
+    sub_info = payload.get("subscription") or {}
+    sub_transport = sub_info.get("transport") or {}
+    meta_payload: dict[str, Any] = {}
+    if subscription.meta:
+        try:
+            parsed_meta = json.loads(subscription.meta)
+            if isinstance(parsed_meta, dict):
+                meta_payload = parsed_meta
+        except Exception:
+            meta_payload = {}
+    meta_transport = meta_payload.get("transport") if isinstance(meta_payload.get("transport"), dict) else {}
+    conduit_meta = meta_payload.get("conduit_shard") if isinstance(meta_payload.get("conduit_shard"), dict) else {}
+
+    conduit_id = (
+        subscription.conduit_id
+        or meta_payload.get("conduit_id")
+        or conduit_meta.get("conduit_id")
+        or meta_transport.get("conduit_id")
+        or sub_transport.get("conduit_id")
+    )
+    if conduit_id is not None:
+        conduit_id = str(conduit_id)
+    if not conduit_id:
+        return None, None, None, "missing_conduit_shard_field_conduit_id"
+
+    shard_id = (
+        subscription.shard_id
+        or meta_payload.get("shard_id")
+        or conduit_meta.get("shard_id")
+        or conduit_meta.get("shard")
+    )
+    if shard_id is not None:
+        shard_id = str(shard_id)
+    if not shard_id:
+        return None, conduit_id, None, "missing_conduit_shard_field_shard"
+
+    shard_row = (
+        db.query(TwitchConduitShard)
+        .join(TwitchConduit, TwitchConduitShard.conduit_fk == TwitchConduit.id)
+        .filter(
+            TwitchConduit.conduit_id == conduit_id,
+            TwitchConduitShard.shard_id == shard_id,
+        )
+        .one_or_none()
+    )
+    if not shard_row:
+        return None, conduit_id, shard_id, "unknown_conduit_shard"
+    if not shard_row.transport_secret:
+        return None, conduit_id, shard_id, "missing_conduit_shard_secret"
+    return shard_row.transport_secret, conduit_id, shard_id, None
+
+
 def _format_eventsub_http_error(exc: Exception, auth_mode: str) -> str:
     """Build a safe compact EventSub HTTP error summary for operator triage.
 
@@ -1729,6 +1797,7 @@ def reconcile_eventsub_conduit_subscriptions(request: FastAPIRequest, db: Sessio
         meta_payload = {
             "condition": desired_condition,
             "transport": {"method": "conduit", "conduit_id": conduit_row.conduit_id},
+            "conduit_shard": {"conduit_id": conduit_row.conduit_id, "shard_id": shard_id},
             "shard_id": shard_id,
             "reconciled_at": now.isoformat() + "Z",
         }
@@ -8171,13 +8240,60 @@ async def eventsub_callback(request: FastAPIRequest, db: Session = Depends(get_d
         )
         return JSONResponse(status_code=202, content={"detail": "unknown subscription"})
 
-    if not _verify_eventsub_signature(subscription.secret, message_id, timestamp, body, signature):
-        logger.warning(
-            "EventSub callback rejected: reason_code=invalid_signature message_id=%s message_type=%s subscription_id=%s",
-            message_id,
-            message_type or "<missing>",
-            sub_id,
+    sub_payload_type = sub_info.get("type")
+    sub_payload_transport = (sub_info.get("transport") or {}).get("method")
+    is_conduit_chat_notification = (
+        message_type == "notification"
+        and (subscription.type == EVENTSUB_CONDUIT_CHAT_TYPE or sub_payload_type == EVENTSUB_CONDUIT_CHAT_TYPE)
+        and (subscription.transport == "conduit" or sub_payload_transport == "conduit")
+    )
+
+    verification_secret = subscription.secret
+    conduit_id: Optional[str] = None
+    shard_id: Optional[str] = None
+    if is_conduit_chat_notification:
+        verification_secret, conduit_id, shard_id, resolve_error = _resolve_conduit_notification_secret(
+            subscription, payload, db
         )
+        if resolve_error or not verification_secret:
+            status_code = 503 if resolve_error == "missing_conduit_shard_secret" else 403
+            logger.warning(
+                "EventSub callback rejected: reason_code=%s message_id=%s message_type=%s subscription_id=%s conduit_id=%s shard_id=%s diagnostics=conduit_notification_secret_resolution_failed",
+                resolve_error or "unknown_conduit_secret_resolution_error",
+                message_id,
+                message_type or "<missing>",
+                sub_id,
+                conduit_id or "<missing>",
+                shard_id or "<missing>",
+            )
+            raise HTTPException(
+                status_code=status_code,
+                detail={
+                    "reason_code": resolve_error or "conduit_notification_secret_unavailable",
+                    "message": "Conduit shard secret unavailable for notification verification.",
+                    "conduit_id": conduit_id,
+                    "shard_id": shard_id,
+                    "subscription_id": sub_id,
+                },
+            )
+
+    if not _verify_eventsub_signature(verification_secret, message_id, timestamp, body, signature):
+        if is_conduit_chat_notification:
+            logger.warning(
+                "EventSub callback rejected: reason_code=invalid_signature message_id=%s message_type=%s subscription_id=%s conduit_id=%s shard_id=%s signature_mode=conduit_shard_secret",
+                message_id,
+                message_type or "<missing>",
+                sub_id,
+                conduit_id or "<missing>",
+                shard_id or "<missing>",
+            )
+        else:
+            logger.warning(
+                "EventSub callback rejected: reason_code=invalid_signature message_id=%s message_type=%s subscription_id=%s signature_mode=legacy_subscription_secret",
+                message_id,
+                message_type or "<missing>",
+                sub_id,
+            )
         raise HTTPException(status_code=403, detail="invalid signature")
 
     subscription.status = sub_info.get("status") or subscription.status

--- a/docs/backend_api.md
+++ b/docs/backend_api.md
@@ -418,7 +418,9 @@ Certain events award priority points and are fed by EventSub subscriptions creat
   - `Twitch-Eventsub-Message-Type`
 - **Signature verification**:
   - The backend computes `HMAC_SHA256(secret, message_id + timestamp + raw_body)` and rejects mismatches with `403`.
-  - For classic payloads (`verification_shape=subscription` and normal notifications), the `secret` is taken from `event_subscriptions.secret` via `subscription.id`.
+  - For classic webhook payloads, the `secret` is taken from `event_subscriptions.secret` via `subscription.id`.
+  - For conduit chat notifications (`subscription.type=channel.chat.message` and/or `subscription.transport.method=conduit`), the `secret` is resolved from `twitch_conduit_shards.transport_secret` using the persisted `(conduit_id, shard_id)` linkage from `event_subscriptions` columns/metadata/transport data.
+  - If a conduit notification cannot resolve shard secret material, the callback returns explicit diagnostics with reason code (for example `missing_conduit_shard_secret`) and uses `503` for missing secret state so operators can distinguish config drift from invalid signatures.
   - For conduit verification payloads (`verification_shape=conduit_shard`), the `secret` is taken from `twitch_conduit_shards.transport_secret` using the persisted `(conduit_shard.conduit_id, conduit_shard.shard)` pair.
 - **Verification payload variants**:
   - Classic webhook verification payloads with `subscription` are supported.

--- a/tests/test_channel_events.py
+++ b/tests/test_channel_events.py
@@ -616,17 +616,41 @@ class ChannelEventTests(unittest.TestCase):
 
         details = _setup_channel()
         secret = "chatsecret"
+        conduit_id = "conduit-chat-shadow"
+        shard_id = "2"
         db = backend_app.SessionLocal()
         try:
             backend_app.set_settings(db, {"chat_ingress_mode": "websocket", "chat_ingress_shadow_mode": "1"})
+            conduit = backend_app.TwitchConduit(conduit_id=conduit_id, status="enabled")
+            db.add(conduit)
+            db.commit()
+            db.refresh(conduit)
+            db.add(
+                backend_app.TwitchConduitShard(
+                    conduit_fk=conduit.id,
+                    shard_id=shard_id,
+                    transport_callback="https://example/callback",
+                    transport_secret=secret,
+                    status="enabled",
+                )
+            )
             chat_sub = backend_app.EventSubscription(
                 channel_id=details["channel_pk"],
                 twitch_subscription_id="sub-chat-shadow",
                 type="channel.chat.message",
                 status="enabled",
-                secret=secret,
+                secret="legacy-subscription-secret",
                 callback="https://example/callback",
                 transport="conduit",
+                conduit_id=conduit_id,
+                shard_id=shard_id,
+                meta=json.dumps(
+                    {
+                        "transport": {"method": "conduit", "conduit_id": conduit_id},
+                        "conduit_shard": {"conduit_id": conduit_id, "shard_id": shard_id},
+                        "shard_id": shard_id,
+                    }
+                ),
             )
             db.add(chat_sub)
             db.commit()
@@ -640,6 +664,7 @@ class ChannelEventTests(unittest.TestCase):
                 "status": "enabled",
                 "version": "1",
                 "condition": {"broadcaster_user_id": "cid"},
+                "transport": {"method": "conduit", "conduit_id": conduit_id},
             },
             "event": {
                 "chatter_user_id": "chat-user-1",
@@ -675,6 +700,86 @@ class ChannelEventTests(unittest.TestCase):
             self.assertEqual(db.query(backend_app.Event).filter(backend_app.Event.channel_id == details["channel_pk"]).count(), 0)
         finally:
             db.close()
+
+    def test_eventsub_conduit_chat_notification_missing_shard_secret_returns_503(self) -> None:
+        """Fail conduit chat notifications when persisted shard secret is missing.
+
+        Dependencies: EventSub callback signature validation, conduit/shard
+        persistence, and HTTP error diagnostics. Code customers: operators
+        diagnosing conduit reconciliation/state drift. Used variables/origin:
+        creates a conduit chat subscription pointing at a shard row without a
+        stored secret.
+        """
+
+        details = _setup_channel()
+        conduit_id = "conduit-missing-secret"
+        shard_id = "7"
+        db = backend_app.SessionLocal()
+        try:
+            conduit = backend_app.TwitchConduit(conduit_id=conduit_id, status="enabled")
+            db.add(conduit)
+            db.commit()
+            db.refresh(conduit)
+            db.add(
+                backend_app.TwitchConduitShard(
+                    conduit_fk=conduit.id,
+                    shard_id=shard_id,
+                    transport_callback="https://example/callback",
+                    transport_secret=None,
+                    status="enabled",
+                )
+            )
+            db.add(
+                backend_app.EventSubscription(
+                    channel_id=details["channel_pk"],
+                    twitch_subscription_id="sub-chat-missing-secret",
+                    type="channel.chat.message",
+                    status="enabled",
+                    secret="legacy-secret-unused",
+                    callback="https://example/callback",
+                    transport="conduit",
+                    conduit_id=conduit_id,
+                    shard_id=shard_id,
+                )
+            )
+            db.commit()
+        finally:
+            db.close()
+
+        body = {
+            "subscription": {
+                "id": "sub-chat-missing-secret",
+                "type": "channel.chat.message",
+                "status": "enabled",
+                "version": "1",
+                "condition": {"broadcaster_user_id": "cid"},
+                "transport": {"method": "conduit", "conduit_id": conduit_id},
+            },
+            "event": {
+                "chatter_user_id": "chat-user-1",
+                "chatter_user_login": "chatuser",
+                "message": {"text": "!request song"},
+            },
+        }
+        raw = json.dumps(body).encode()
+        message_id = "msg-missing-shard-secret"
+        timestamp = "2023-01-01T00:00:00Z"
+        signature = hmac.new(b"legacy-secret-unused", msg=(message_id + timestamp).encode() + raw, digestmod=hashlib.sha256)
+        response = self.client.post(
+            "/twitch/eventsub/callback",
+            data=raw,
+            headers={
+                "Twitch-Eventsub-Message-Id": message_id,
+                "Twitch-Eventsub-Message-Timestamp": timestamp,
+                "Twitch-Eventsub-Message-Signature": f"sha256={signature.hexdigest()}",
+                "Twitch-Eventsub-Message-Type": "notification",
+            },
+        )
+        self.assertEqual(response.status_code, 503, response.text)
+        payload = response.json().get("detail") or {}
+        self.assertEqual(payload.get("reason_code"), "missing_conduit_shard_secret")
+        self.assertEqual(payload.get("conduit_id"), conduit_id)
+        self.assertEqual(payload.get("shard_id"), shard_id)
 
     def test_get_or_create_settings_backfills_queue_caps(self) -> None:
         """Ensure legacy channel settings rows gain default queue caps.


### PR DESCRIPTION
### Motivation
- Conduit-delivered chat notifications need to validate HMAC using the per-shard secret material persisted for EventSub conduits to avoid relying solely on legacy subscription secrets.
- Reconciliation must persist shard linkage so notification-time secret resolution is robust across rollouts and state drift.
- Callback failures for missing shard secret material should return explicit diagnostics so operators can distinguish missing secret state from invalid signatures.

### Description
- Added `_resolve_conduit_notification_secret(subscription, payload, db)` to locate `conduit_id`/`shard_id` from persisted `EventSubscription` columns, `meta`, and incoming payload transport fields and to load the HMAC secret from `twitch_conduit_shards.transport_secret`.
- Updated `eventsub_callback` notification path to detect conduit chat notifications (`channel.chat.message` and/or `transport=conduit`) and to use the shard secret from `_resolve_conduit_notification_secret` for HMAC validation while preserving legacy `EventSubscription.secret` verification for non-conduit flows.
- Reconciliation now persists explicit `conduit_shard` linkage inside `EventSubscription.meta` (`conduit_id` and `shard_id`) so notification-time secret lookup has multiple durable sources.
- Docs updated (`docs/backend_api.md`) to describe the conduit-chat notification signature behavior and the new explicit diagnostic (`missing_conduit_shard_secret`) and 503 semantics when shard secret material is unavailable.

### Testing
- Ran the focused tests with `PYTHONPATH=. pytest -q tests/test_channel_events.py::ChannelEventTests::test_eventsub_chat_notification_shadow_mode_records_dedupe tests/test_channel_events.py::ChannelEventTests::test_eventsub_conduit_chat_notification_missing_shard_secret_returns_503` and both tests passed (`2 passed`).
- Added/updated unit tests in `tests/test_channel_events.py` covering conduit chat verification with shard secret and missing-shard-secret -> 503 diagnostic behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc2861d908832880cb1e9baf2a9490)