### PR TITLE
Use conduit shard secrets as authoritative EventSub secret source

### DIFF
--- a/backend_app.py
+++ b/backend_app.py
@@ -114,6 +114,7 @@ EVENTSUB_EVENT_MAP: dict[str, str] = {
     "channel.subscription.gift": "gift_sub",
 }
 EVENTSUB_CONDUIT_CHAT_TYPE = "channel.chat.message"
+EVENTSUB_CONDUIT_SECRET_PLACEHOLDER = "__conduit_secret_unused__"
 
 BOT_MESSAGE_LEVEL_DETAILS: list[dict[str, str]] = [
     {
@@ -1588,6 +1589,21 @@ def _resolve_conduit_notification_secret(
     return shard_row.transport_secret, conduit_id, shard_id, None
 
 
+def _persist_conduit_subscription_secret_placeholder(existing_secret: Optional[str]) -> str:
+    """Return compatibility placeholder for conduit subscription ``secret`` column.
+
+    Dependencies: Uses ``EVENTSUB_CONDUIT_SECRET_PLACEHOLDER`` to satisfy the
+    current non-null schema contract on ``EventSubscription.secret``.
+    Code customers: ``reconcile_eventsub_conduit_subscriptions`` persists this
+    placeholder for conduit rows while ``twitch_conduit_shards.transport_secret``
+    remains authoritative for signature verification.
+    Used variables/origin: ``existing_secret`` is read from prior row state and
+    intentionally ignored so legacy random values are not treated as canonical.
+    """
+
+    return EVENTSUB_CONDUIT_SECRET_PLACEHOLDER
+
+
 def _format_eventsub_http_error(exc: Exception, auth_mode: str) -> str:
     """Build a safe compact EventSub HTTP error summary for operator triage.
 
@@ -1793,12 +1809,13 @@ def reconcile_eventsub_conduit_subscriptions(request: FastAPIRequest, db: Sessio
             result["errors"].append(f"subscriptions.missing_id.{channel.channel_name}")
             result["subscriptions"].append(channel_result)
             continue
-        secret = existing.secret if existing and existing.secret else secrets.token_urlsafe(32)
+        secret = _persist_conduit_subscription_secret_placeholder(existing.secret if existing else None)
         meta_payload = {
             "condition": desired_condition,
             "transport": {"method": "conduit", "conduit_id": conduit_row.conduit_id},
             "conduit_shard": {"conduit_id": conduit_row.conduit_id, "shard_id": shard_id},
             "shard_id": shard_id,
+            "signature_secret_source": "twitch_conduit_shards.transport_secret",
             "reconciled_at": now.isoformat() + "Z",
         }
         if existing:

--- a/docs/README.md
+++ b/docs/README.md
@@ -147,8 +147,13 @@ unlocks the API for the bot, queue manager, and public web frontend.
     (non-HTTPS, wrong path, or internal/private host).
   - `301` redirecting `http://...` to `https://...` is not a supported
     substitute for reliable Twitch callback registration.
-  - Signatures are validated against the persisted per-subscription secret
-    before processing.
+  - Signatures are validated before processing. Classic webhook callbacks use
+    `event_subscriptions.secret`; conduit chat callbacks use
+    `twitch_conduit_shards.transport_secret` resolved via persisted conduit
+    linkage (`conduit_id`, `shard_id`, transport metadata).
+  - For conduit rows, `event_subscriptions.secret` is a non-authoritative
+    compatibility placeholder; legacy/random values on existing rows are
+    ignored for conduit notification verification.
   - `notification` retries are deduplicated via `eventsub_message_dedupe` to
     avoid replaying queue commands/reward logic.
   - `channel.chat.message` webhook notifications now route through a dedicated

--- a/docs/backend_api.md
+++ b/docs/backend_api.md
@@ -420,6 +420,8 @@ Certain events award priority points and are fed by EventSub subscriptions creat
   - The backend computes `HMAC_SHA256(secret, message_id + timestamp + raw_body)` and rejects mismatches with `403`.
   - For classic webhook payloads, the `secret` is taken from `event_subscriptions.secret` via `subscription.id`.
   - For conduit chat notifications (`subscription.type=channel.chat.message` and/or `subscription.transport.method=conduit`), the `secret` is resolved from `twitch_conduit_shards.transport_secret` using the persisted `(conduit_id, shard_id)` linkage from `event_subscriptions` columns/metadata/transport data.
+  - Conduit reconciliation stores linkage metadata (`conduit_id`, `shard_id`, and transport details) on `event_subscriptions`; the `event_subscriptions.secret` field for conduit rows is treated as a schema-compatibility placeholder and is not authoritative.
+  - Migration-safe behavior: existing conduit rows that still contain legacy/random `event_subscriptions.secret` values are ignored during conduit notification signature verification.
   - If a conduit notification cannot resolve shard secret material, the callback returns explicit diagnostics with reason code (for example `missing_conduit_shard_secret`) and uses `503` for missing secret state so operators can distinguish config drift from invalid signatures.
   - For conduit verification payloads (`verification_shape=conduit_shard`), the `secret` is taken from `twitch_conduit_shards.transport_secret` using the persisted `(conduit_shard.conduit_id, conduit_shard.shard)` pair.
 - **Verification payload variants**:


### PR DESCRIPTION
### Motivation
- Stop treating randomly-generated `EventSubscription.secret` values on conduit-mode chat subscriptions as authoritative and instead rely on persisted conduit shard secrets for signature verification.
- Ensure reconciliation persists conduit linkage (`conduit_id`, `shard_id`, transport metadata) so notification verification can resolve shard secret material from `twitch_conduit_shards.transport_secret`.
- Provide migration-safe behavior so legacy/random values in `event_subscriptions.secret` are ignored for conduit notifications rather than accidentally used.

### Description
- Added constant `EVENTSUB_CONDUIT_SECRET_PLACEHOLDER = "__conduit_secret_unused__"` as the canonical non-authoritative sentinel for conduit subscription `secret` values.
- Implemented `_persist_conduit_subscription_secret_placeholder(existing_secret: Optional[str]) -> str` with a docstring describing dependencies, code customers, and used variables/origin, and made it explicitly ignore legacy/random secrets.
- Updated `reconcile_eventsub_conduit_subscriptions` to stop generating/storing `secrets.token_urlsafe(...)` for conduit chat rows and instead call `_persist_conduit_subscription_secret_placeholder(...)` when persisting conduit-mode `EventSubscription` rows; added `

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc2a15b6dc83289536eadd1cf694da)