### PR TITLE
Refresh conduit shard status after verified EventSub callbacks

### DIFF
--- a/backend_app.py
+++ b/backend_app.py
@@ -1483,6 +1483,80 @@ def _reconcile_twitch_conduit_shards(
     return assignment, errors
 
 
+def _refresh_conduit_shard_status_from_twitch(
+    conduit_id: Optional[str],
+    db: Session,
+    now: datetime,
+) -> bool:
+    """Refresh persisted conduit shard status/callback fields from Twitch.
+
+    Dependencies: Uses ``_eventsub_app_headers`` for app-auth Helix access and
+    reads/writes ``TwitchConduit`` + ``TwitchConduitShard`` rows through the
+    provided SQLAlchemy ``Session``.
+    Code customers: EventSub callback verification/notification flows call this
+    after successful signature validation so health output reflects current
+    shard states without waiting for a full reconciliation cycle.
+    Used variables/origin: ``conduit_id`` is sourced from EventSub payload
+    transport metadata; ``now`` originates from the caller for coherent
+    timestamping across callback-side state updates.
+    """
+
+    if not conduit_id:
+        return False
+    conduit_row = db.query(TwitchConduit).filter(TwitchConduit.conduit_id == conduit_id).one_or_none()
+    if not conduit_row:
+        return False
+    try:
+        headers = _eventsub_app_headers()
+    except RuntimeError:
+        logger.debug(
+            "Skipping conduit shard status refresh; app headers unavailable",
+            extra={"conduit_id": conduit_id},
+        )
+        return False
+    try:
+        resp = requests.get(
+            "https://api.twitch.tv/helix/eventsub/conduits/shards",
+            params={"conduit_id": conduit_id},
+            headers=headers,
+            timeout=8,
+        )
+        resp.raise_for_status()
+        remote_shards = resp.json().get("data") or []
+    except Exception:
+        logger.warning(
+            "Failed to refresh conduit shard status from Twitch",
+            extra={"conduit_id": conduit_id},
+            exc_info=True,
+        )
+        return False
+
+    updated = False
+    for remote in remote_shards:
+        shard_id = str(remote.get("id")) if remote.get("id") is not None else None
+        if not shard_id:
+            continue
+        row = (
+            db.query(TwitchConduitShard)
+            .filter(
+                TwitchConduitShard.conduit_fk == conduit_row.id,
+                TwitchConduitShard.shard_id == shard_id,
+            )
+            .one_or_none()
+        )
+        if not row:
+            row = TwitchConduitShard(conduit_fk=conduit_row.id, shard_id=shard_id)
+            db.add(row)
+        transport = remote.get("transport") or {}
+        row.transport_callback = transport.get("callback") or row.transport_callback
+        row.status = remote.get("status") or row.status or "pending"
+        row.last_sync_at = now
+        updated = True
+    if updated:
+        conduit_row.last_sync_at = now
+    return updated
+
+
 def _resolve_conduit_verification_secret(
     payload: Mapping[str, Any],
     db: Session,
@@ -8218,6 +8292,8 @@ async def eventsub_callback(request: FastAPIRequest, db: Session = Depends(get_d
                 shard_id,
                 message_id,
             )
+            _refresh_conduit_shard_status_from_twitch(conduit_id, db, datetime.utcnow())
+            db.commit()
         else:
             logger.warning(
                 "EventSub callback rejected: reason_code=unsupported_verification_shape message_id=%s message_type=%s",
@@ -8321,6 +8397,9 @@ async def eventsub_callback(request: FastAPIRequest, db: Session = Depends(get_d
         if not _record_eventsub_notification_dedupe(db, message_id):
             return JSONResponse({"success": True, "deduped": True})
         _process_eventsub_notification(db, subscription, payload, message_id=message_id)
+        if is_conduit_chat_notification:
+            _refresh_conduit_shard_status_from_twitch(conduit_id, db, datetime.utcnow())
+            db.commit()
         return JSONResponse({"success": True})
 
     db.commit()

--- a/docs/backend_api.md
+++ b/docs/backend_api.md
@@ -429,6 +429,7 @@ Certain events award priority points and are fed by EventSub subscriptions creat
   - Conduit shard verification payloads with `conduit_shard` and no `subscription` are supported.
   - Conduit payload validation requires both `conduit_shard.conduit_id` and `conduit_shard.shard`; missing fields are rejected with explicit reason codes (`missing_conduit_shard_field_conduit_id`, `missing_conduit_shard_field_shard`).
   - Legacy behavior that globally required `subscription.id` has been removed for verification callbacks.
+  - After successful conduit verification or valid conduit chat notifications, the backend immediately re-queries Helix conduit shard status and updates persisted shard rows so health endpoints do not stay stuck in `webhook_callback_verification_pending`.
 - **Idempotency / retries**:
   - `notification` deliveries are inserted into `eventsub_message_dedupe` keyed by `message_id` before processing.
   - Duplicate retries are acknowledged with success and skipped to prevent duplicate command/event execution.

--- a/tests/test_channel_events.py
+++ b/tests/test_channel_events.py
@@ -1,4 +1,5 @@
 import unittest
+from unittest import mock
 from typing import Dict
 
 from fastapi.testclient import TestClient
@@ -479,6 +480,86 @@ class ChannelEventTests(unittest.TestCase):
         )
         self.assertEqual(response.status_code, 200, response.text)
         self.assertEqual(response.text, "challenge-conduit")
+
+    def test_eventsub_conduit_verification_refreshes_shard_status_from_twitch(self) -> None:
+        """Refresh shard status after successful conduit verification callbacks.
+
+        Dependencies: Uses callback signature verification plus mocked
+        ``_eventsub_app_headers`` and Twitch shard list HTTP response.
+        Code customers: EventSub health diagnostics that should stop showing
+        stale ``webhook_callback_verification_pending`` shard status.
+        Used variables/origin: Starts local shard status as pending and uses
+        mocked Helix response data to transition it to enabled.
+        """
+
+        shard_secret = "verify-refresh-secret"
+        db = backend_app.SessionLocal()
+        try:
+            conduit = backend_app.TwitchConduit(conduit_id="conduit-refresh", status="enabled")
+            db.add(conduit)
+            db.commit()
+            db.refresh(conduit)
+            db.add(
+                backend_app.TwitchConduitShard(
+                    conduit_fk=conduit.id,
+                    shard_id="0",
+                    transport_callback="https://example/callback",
+                    transport_secret=shard_secret,
+                    status="webhook_callback_verification_pending",
+                )
+            )
+            db.commit()
+        finally:
+            db.close()
+
+        body = {
+            "conduit_shard": {"shard": "0", "conduit_id": "conduit-refresh"},
+            "challenge": "challenge-refresh",
+        }
+        raw = json.dumps(body).encode()
+        message_id = "msg-verify-refresh"
+        timestamp = "2023-01-01T00:00:00Z"
+        digest = hmac.new(shard_secret.encode(), msg=(message_id + timestamp).encode() + raw, digestmod=hashlib.sha256)
+        with mock.patch.object(backend_app, "_eventsub_app_headers", return_value={"Client-Id": "cid"}):
+            fake_response = mock.Mock()
+            fake_response.raise_for_status.return_value = None
+            fake_response.json.return_value = {
+                "data": [
+                    {
+                        "id": "0",
+                        "status": "enabled",
+                        "transport": {"method": "webhook", "callback": "https://example/callback"},
+                    }
+                ]
+            }
+            with mock.patch("backend_app.requests.get", return_value=fake_response):
+                response = self.client.post(
+                    "/twitch/eventsub/callback",
+                    data=raw,
+                    headers={
+                        "Twitch-Eventsub-Message-Id": message_id,
+                        "Twitch-Eventsub-Message-Timestamp": timestamp,
+                        "Twitch-Eventsub-Message-Signature": f"sha256={digest.hexdigest()}",
+                        "Twitch-Eventsub-Message-Type": "webhook_callback_verification",
+                    },
+                )
+        self.assertEqual(response.status_code, 200, response.text)
+
+        db = backend_app.SessionLocal()
+        try:
+            shard_row = (
+                db.query(backend_app.TwitchConduitShard)
+                .join(backend_app.TwitchConduit, backend_app.TwitchConduitShard.conduit_fk == backend_app.TwitchConduit.id)
+                .filter(
+                    backend_app.TwitchConduit.conduit_id == "conduit-refresh",
+                    backend_app.TwitchConduitShard.shard_id == "0",
+                )
+                .one()
+            )
+            self.assertEqual(shard_row.status, "enabled")
+            self.assertIsNotNone(shard_row.last_sync_at)
+        finally:
+            db.close()
 
     def test_eventsub_verification_rejects_missing_conduit_shard_field_shard(self) -> None:
         """Reject conduit verification payloads that omit ``conduit_shard.shard``.


### PR DESCRIPTION
### Motivation

- Health endpoints showed shards stuck in `webhook_callback_verification_pending` after Twitch verification cycles or valid conduit notifications, so the goal is to make those transitions visible immediately. 
- Operators need per-channel EventSub health to reflect correct shard state without waiting for a full reconciliation run.

### Description

- Add helper ` _refresh_conduit_shard_status_from_twitch` to re-query Helix `conduits/shards` and persist `TwitchConduit`/`TwitchConduitShard` fields (`transport_callback`, `status`, `last_sync_at`) using the provided `db` session and caller-supplied `now` timestamp, with a docstring describing dependencies, code customers, and used variables. 
- Invoke the refresh helper from the EventSub callback flow after successful `verification_shape=conduit_shard` verification and after valid conduit chat `notification` processing, and call `db.commit()` so updates are persisted immediately. 
- Add a regression test `test_eventsub_conduit_verification_refreshes_shard_status_from_twitch` that seeds a `webhook_callback_verification_pending` shard, simulates a valid conduit verification, mocks `_eventsub_app_headers` and Twitch `requests.get` shard response returning `enabled`, and asserts persisted shard status and `last_sync_at` are updated. 
- Update `docs/backend_api.md` to document the callback-side shard refresh behavior so health endpoints avoid stale pending states. 

### Testing

- `python -m py_compile backend_app.py tests/test_channel_events.py` ran successfully to validate syntax. 
- Attempted `PYTHONPATH=. pytest -q tests/test_channel_events.py -k "conduit_verification_refreshes_shard_status_from_twitch or verification_accepts_conduit_shard_shape_without_subscription"` but collection failed in this environment due to SQLite unable to open database file (environment import/DB path limitation), so the new test could not be executed here. 
- Files modified: `backend_app.py`, `tests/test_channel_events.py`, and `docs/backend_api.md`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc2adb2d3083288b2f16f5737f7fa5)