### PR TITLE
Production hardening: authoritative webhook-conduit ingress guardrails, metrics, and fallback controls

### DIFF
--- a/backend_app.py
+++ b/backend_app.py
@@ -80,8 +80,13 @@ SETTINGS_ENV_MAP: Dict[str, str] = {
 SETTINGS_DEFAULTS: Dict[str, Optional[str]] = {
     "twitch_scopes": "channel:bot channel:read:subscriptions channel:read:vips bits:read moderator:read:followers",
     "bot_app_scopes": "user:read:chat user:write:chat user:bot",
-    "chat_ingress_mode": "websocket",
+    "chat_ingress_mode": "webhook_conduit",
     "chat_ingress_shadow_mode": "0",
+    "chat_websocket_fallback_legacy_enabled": "0",
+    "chat_ingress_guard_auto_fallback_enabled": "0",
+    "chat_ingress_guard_callback_error_threshold": "5",
+    "chat_ingress_guard_window_seconds": "300",
+    "chat_ingress_guard_min_healthy_shards": "1",
 }
 
 SETUP_REQUIRED_KEYS = ("twitch_client_id", "twitch_client_secret")
@@ -172,6 +177,22 @@ _bot_log_listeners: set[asyncio.Queue[str]] = set()
 _bot_oauth_states: dict[str, Dict[str, Any]] = {}
 
 logger = logging.getLogger(__name__)
+
+_INGRESS_METRICS_LOCK = Lock()
+_INGRESS_METRICS: dict[str, Any] = {
+    "callback_status": {"2xx": 0, "4xx": 0, "5xx": 0},
+    "signature_failures": 0,
+    "dedupe_hits": 0,
+    "command_dispatch_outcomes": {},
+    "shard_status_transitions": {},
+    "last_errors": {
+        "signature_failure_at": None,
+        "callback_4xx_at": None,
+        "callback_5xx_at": None,
+        "guard_degraded_at": None,
+    },
+    "callback_events": [],
+}
 
 engine = create_engine(DB_URL, connect_args={"check_same_thread": False} if DB_URL.startswith("sqlite") else {})
 SessionLocal = sessionmaker(bind=engine, autoflush=False, autocommit=False)
@@ -385,6 +406,39 @@ def backfill_missing_channel_keys() -> None:
             db.commit()
     finally:
         db.close()
+
+
+def cleanup_conduit_subscription_secret_semantics() -> None:
+    """Normalize conduit EventSub rows to non-authoritative secret placeholders.
+
+    Dependencies: Uses ``SessionLocal`` and updates ``EventSubscription`` rows.
+    Code customers: Startup migration/cleanup for post-cutover conduit ingress.
+    Used variables/origin: Targets rows where ``transport='conduit'`` and chat
+    ingress type is ``channel.chat.message`` so signature validation depends only
+    on ``twitch_conduit_shards.transport_secret``.
+    """
+
+    db = SessionLocal()
+    try:
+        rows = (
+            db.query(EventSubscription)
+            .filter(
+                EventSubscription.transport == "conduit",
+                EventSubscription.type == EVENTSUB_CONDUIT_CHAT_TYPE,
+                EventSubscription.secret != EVENTSUB_CONDUIT_SECRET_PLACEHOLDER,
+            )
+            .all()
+        )
+        for row in rows:
+            row.secret = EVENTSUB_CONDUIT_SECRET_PLACEHOLDER
+            row.updated_at = datetime.utcnow()
+        if rows:
+            db.commit()
+            logger.info("Normalized %s conduit chat subscription secrets to placeholder semantics", len(rows))
+    finally:
+        db.close()
+
+
 def _load_settings_from_db() -> Dict[str, Optional[str]]:
     db = SessionLocal()
     try:
@@ -785,6 +839,144 @@ def get_chat_ingress_shadow_mode() -> bool:
     return _env_flag(get_setting("chat_ingress_shadow_mode", "0"))
 
 
+def get_chat_websocket_fallback_legacy_enabled() -> bool:
+    """Return whether legacy websocket ingress fallback is explicitly enabled.
+
+    Dependencies: Uses ``get_setting`` and ``_env_flag``.
+    Code customers: Bot runtime subscription gating and ``/system/config``.
+    Used variables/origin: Reads ``chat_websocket_fallback_legacy_enabled`` from
+    app settings to keep rollback explicit and operator-controlled.
+    """
+
+    return _env_flag(get_setting("chat_websocket_fallback_legacy_enabled", "0"))
+
+
+def _ingress_guard_thresholds() -> dict[str, float]:
+    """Return normalized ingress guard thresholds from persisted settings."""
+
+    callback_error_threshold = max(_coerce_int(get_setting("chat_ingress_guard_callback_error_threshold", "5"), default=5), 1)
+    window_seconds = max(_coerce_int(get_setting("chat_ingress_guard_window_seconds", "300"), default=300), 60)
+    min_healthy_shards = max(_coerce_int(get_setting("chat_ingress_guard_min_healthy_shards", "1"), default=1), 1)
+    return {
+        "callback_error_threshold": float(callback_error_threshold),
+        "window_seconds": float(window_seconds),
+        "min_healthy_shards": float(min_healthy_shards),
+    }
+
+
+def _record_ingress_metric(metric: str, *, key: Optional[str] = None, timestamp: Optional[datetime] = None) -> None:
+    """Update in-memory ingress telemetry counters used by health diagnostics."""
+
+    now = timestamp or datetime.utcnow()
+    with _INGRESS_METRICS_LOCK:
+        if metric == "callback_status" and key in {"2xx", "4xx", "5xx"}:
+            _INGRESS_METRICS["callback_status"][key] = int(_INGRESS_METRICS["callback_status"].get(key, 0)) + 1
+            _INGRESS_METRICS["callback_events"].append({"timestamp": now, "class": key})
+            if key == "4xx":
+                _INGRESS_METRICS["last_errors"]["callback_4xx_at"] = now
+            if key == "5xx":
+                _INGRESS_METRICS["last_errors"]["callback_5xx_at"] = now
+        elif metric == "signature_failure":
+            _INGRESS_METRICS["signature_failures"] = int(_INGRESS_METRICS.get("signature_failures", 0)) + 1
+            _INGRESS_METRICS["last_errors"]["signature_failure_at"] = now
+        elif metric == "dedupe_hit":
+            _INGRESS_METRICS["dedupe_hits"] = int(_INGRESS_METRICS.get("dedupe_hits", 0)) + 1
+        elif metric == "command_dispatch_outcome" and key:
+            outcomes = _INGRESS_METRICS["command_dispatch_outcomes"]
+            outcomes[key] = int(outcomes.get(key, 0)) + 1
+        elif metric == "shard_status_transition" and key:
+            transitions = _INGRESS_METRICS["shard_status_transitions"]
+            transitions[key] = int(transitions.get(key, 0)) + 1
+        elif metric == "guard_degraded":
+            _INGRESS_METRICS["last_errors"]["guard_degraded_at"] = now
+        cutoff = now - timedelta(hours=1)
+        _INGRESS_METRICS["callback_events"] = [
+            event for event in _INGRESS_METRICS["callback_events"] if event.get("timestamp") and event["timestamp"] >= cutoff
+        ]
+
+
+def _ingress_metrics_snapshot(now: datetime) -> dict[str, Any]:
+    """Return compact ingress telemetry for ``/system/health`` diagnostics."""
+
+    with _INGRESS_METRICS_LOCK:
+        thresholds = _ingress_guard_thresholds()
+        window = timedelta(seconds=int(thresholds["window_seconds"]))
+        cutoff = now - window
+        recent = [event for event in _INGRESS_METRICS["callback_events"] if event["timestamp"] >= cutoff]
+        recent_total = len(recent)
+        recent_4xx = sum(1 for event in recent if event["class"] == "4xx")
+        recent_5xx = sum(1 for event in recent if event["class"] == "5xx")
+        return {
+            "callback_status": dict(_INGRESS_METRICS["callback_status"]),
+            "signature_failures": int(_INGRESS_METRICS["signature_failures"]),
+            "dedupe_hits": int(_INGRESS_METRICS["dedupe_hits"]),
+            "command_dispatch_outcomes": dict(_INGRESS_METRICS["command_dispatch_outcomes"]),
+            "shard_status_transitions": dict(_INGRESS_METRICS["shard_status_transitions"]),
+            "last_errors": dict(_INGRESS_METRICS["last_errors"]),
+            "recent_callback_throughput": {
+                "window_seconds": int(thresholds["window_seconds"]),
+                "callbacks_total": recent_total,
+                "callbacks_4xx": recent_4xx,
+                "callbacks_5xx": recent_5xx,
+                "callbacks_per_minute": round(recent_total / max(thresholds["window_seconds"] / 60.0, 1.0), 2),
+            },
+        }
+
+
+def _evaluate_ingress_guard(db: Session, now: datetime, *, apply_fallback: bool) -> dict[str, Any]:
+    """Evaluate authoritative webhook-conduit health and optional fallback policy."""
+
+    thresholds = _ingress_guard_thresholds()
+    summary = _ingress_metrics_snapshot(now)
+    shard_rows = db.query(TwitchConduitShard).all()
+    healthy_shards = sum(1 for shard in shard_rows if (shard.status or "").lower() == "enabled")
+    degraded_reasons: list[str] = []
+    if healthy_shards < int(thresholds["min_healthy_shards"]):
+        degraded_reasons.append("missing_healthy_shards")
+    recent = summary["recent_callback_throughput"]
+    callback_errors = int(recent["callbacks_4xx"]) + int(recent["callbacks_5xx"])
+    if callback_errors >= int(thresholds["callback_error_threshold"]):
+        degraded_reasons.append("callback_errors_spike")
+    degraded = bool(degraded_reasons)
+    auto_fallback_enabled = _env_flag(get_setting("chat_ingress_guard_auto_fallback_enabled", "0"))
+    fallback_applied = False
+    if degraded:
+        _record_ingress_metric("guard_degraded", timestamp=now)
+        logger.error(
+            "INGRESS_GUARD_DEGRADED reasons=%s healthy_shards=%s callback_errors=%s",
+            ",".join(degraded_reasons),
+            healthy_shards,
+            callback_errors,
+        )
+        if apply_fallback and auto_fallback_enabled and get_chat_ingress_mode() == "webhook_conduit":
+            set_settings(db, {"chat_ingress_mode": "websocket"})
+            fallback_applied = True
+            logger.error("INGRESS_GUARD_AUTO_FALLBACK applied chat_ingress_mode=websocket")
+    return {
+        "degraded": degraded,
+        "reasons": degraded_reasons,
+        "healthy_shards": healthy_shards,
+        "thresholds": {k: int(v) for k, v in thresholds.items()},
+        "auto_fallback_enabled": auto_fallback_enabled,
+        "auto_fallback_applied": fallback_applied,
+        "legacy_websocket_fallback_enabled": get_chat_websocket_fallback_legacy_enabled(),
+    }
+
+
+def run_ingress_guard_startup_check() -> None:
+    """Run a startup ingress guard check and emit high-severity alerts when degraded."""
+
+    db = SessionLocal()
+    try:
+        if get_chat_ingress_mode() != "webhook_conduit":
+            return
+        _evaluate_ingress_guard(db, datetime.utcnow(), apply_fallback=True)
+    except Exception:
+        logger.exception("Ingress guard startup check failed")
+    finally:
+        db.close()
+
+
 def _system_config_payload() -> Dict[str, Any]:
     return {
         "setup_complete": is_setup_complete(),
@@ -798,6 +990,8 @@ def _system_config_payload() -> Dict[str, Any]:
         "bot_app_scopes": get_bot_app_scopes(),
         "chat_ingress_mode": get_chat_ingress_mode(),
         "chat_ingress_shadow_mode": get_chat_ingress_shadow_mode(),
+        "chat_websocket_fallback_legacy_enabled": get_chat_websocket_fallback_legacy_enabled(),
+        "chat_ingress_guard_auto_fallback_enabled": _env_flag(get_setting("chat_ingress_guard_auto_fallback_enabled", "0")),
     }
 
 
@@ -1105,6 +1299,7 @@ def _record_eventsub_notification_dedupe(db: Session, message_id: str) -> bool:
         return True
     except IntegrityError:
         db.rollback()
+        _record_ingress_metric("dedupe_hit")
         logger.info("Ignoring duplicate EventSub notification retry", extra={"eventsub_message_id": message_id})
         return False
 
@@ -1180,7 +1375,16 @@ def _process_eventsub_chat_notification(
     ingress_mode = get_chat_ingress_mode()
     shadow_mode = get_chat_ingress_shadow_mode()
     webhook_authoritative = ingress_mode == "webhook_conduit" and not shadow_mode
-    webhook_result = "executed_authoritative" if webhook_authoritative else "shadow_observe_only"
+    if not parsed.get("canonical"):
+        webhook_result = "ignored_non_command"
+    elif webhook_authoritative:
+        webhook_result = "executed_authoritative"
+    else:
+        webhook_result = "shadow_observe_only"
+    _record_ingress_metric(
+        "command_dispatch_outcome",
+        key=f"{channel.channel_name}:{webhook_result}",
+    )
 
     logger.info(
         "EventSub chat ingress comparison",
@@ -1458,7 +1662,11 @@ def _reconcile_twitch_conduit_shards(
         transport = shard.get("transport") or {}
         row.transport_callback = transport.get("callback") or callback
         row.transport_secret = secret_by_shard.get(shard_id) or row.transport_secret
-        row.status = shard.get("status") or "enabled"
+        next_status = shard.get("status") or "enabled"
+        prev_status = row.status or "pending"
+        if prev_status != next_status:
+            _record_ingress_metric("shard_status_transition", key=f"{prev_status}->{next_status}")
+        row.status = next_status
         row.last_sync_at = now
 
     for shard_id in desired_ids:
@@ -1478,6 +1686,8 @@ def _reconcile_twitch_conduit_shards(
             db.add(row)
         row.transport_callback = callback
         row.transport_secret = secret_by_shard.get(shard_id) or row.transport_secret
+        if (row.status or "pending") != "pending":
+            _record_ingress_metric("shard_status_transition", key=f"{row.status}->pending")
         row.status = "pending"
         row.last_sync_at = now
     return assignment, errors
@@ -1549,7 +1759,11 @@ def _refresh_conduit_shard_status_from_twitch(
             db.add(row)
         transport = remote.get("transport") or {}
         row.transport_callback = transport.get("callback") or row.transport_callback
-        row.status = remote.get("status") or row.status or "pending"
+        next_status = remote.get("status") or row.status or "pending"
+        prev_status = row.status or "pending"
+        if prev_status != next_status:
+            _record_ingress_metric("shard_status_transition", key=f"{prev_status}->{next_status}")
+        row.status = next_status
         row.last_sync_at = now
         updated = True
     if updated:
@@ -2345,6 +2559,8 @@ ensure_channel_settings_schema()
 _ensure_playlist_schema()
 ensure_eventsub_conduit_schema()
 bootstrap_settings_from_env()
+cleanup_conduit_subscription_secret_semantics()
+run_ingress_guard_startup_check()
 
 # =====================================
 # Schemas
@@ -2548,6 +2764,8 @@ class SystemConfigOut(BaseModel):
     bot_app_scopes: List[str]
     chat_ingress_mode: Literal["websocket", "webhook_conduit"]
     chat_ingress_shadow_mode: bool
+    chat_websocket_fallback_legacy_enabled: bool
+    chat_ingress_guard_auto_fallback_enabled: bool
 
 
 class SystemConfigUpdate(BaseModel):
@@ -2561,6 +2779,8 @@ class SystemConfigUpdate(BaseModel):
     bot_app_scopes: Optional[List[str]] = None
     chat_ingress_mode: Optional[Literal["websocket", "webhook_conduit"]] = None
     chat_ingress_shadow_mode: Optional[bool] = None
+    chat_websocket_fallback_legacy_enabled: Optional[bool] = None
+    chat_ingress_guard_auto_fallback_enabled: Optional[bool] = None
     setup_complete: Optional[bool] = None
 
 
@@ -2958,6 +3178,22 @@ async def enforce_initial_setup(request: FastAPIRequest, call_next):
         return await call_next(request)
 
     return JSONResponse({"detail": "setup incomplete"}, status_code=503)
+
+
+@app.middleware("http")
+async def capture_eventsub_callback_metrics(request: FastAPIRequest, call_next):
+    """Track callback response classes and recent throughput for ingress guarding."""
+
+    response = await call_next(request)
+    if request.url.path == "/twitch/eventsub/callback":
+        status_code = int(getattr(response, "status_code", 0) or 0)
+        if 200 <= status_code < 300:
+            _record_ingress_metric("callback_status", key="2xx")
+        elif 400 <= status_code < 500:
+            _record_ingress_metric("callback_status", key="4xx")
+        elif status_code >= 500:
+            _record_ingress_metric("callback_status", key="5xx")
+    return response
 
 class _ChannelBroker:
     __slots__ = ("channel_pk", "listeners")
@@ -5514,6 +5750,10 @@ def update_system_config(
         updates["chat_ingress_mode"] = payload.chat_ingress_mode
     if payload.chat_ingress_shadow_mode is not None:
         updates["chat_ingress_shadow_mode"] = "1" if payload.chat_ingress_shadow_mode else "0"
+    if payload.chat_websocket_fallback_legacy_enabled is not None:
+        updates["chat_websocket_fallback_legacy_enabled"] = "1" if payload.chat_websocket_fallback_legacy_enabled else "0"
+    if payload.chat_ingress_guard_auto_fallback_enabled is not None:
+        updates["chat_ingress_guard_auto_fallback_enabled"] = "1" if payload.chat_ingress_guard_auto_fallback_enabled else "0"
 
     current = settings_store.snapshot()
     merged: Dict[str, Optional[str]] = dict(current)
@@ -5580,6 +5820,9 @@ def health(request: FastAPIRequest, db: Session = Depends(get_db)):
             else []
         )
         coverage = (conduit_channels / channels_total) if channels_total else 1.0
+        now = datetime.utcnow()
+        ingress_summary = _ingress_metrics_snapshot(now)
+        ingress_guard = _evaluate_ingress_guard(db, now, apply_fallback=False)
         return {
             "status": "ok",
             "eventsub": {
@@ -5602,6 +5845,8 @@ def health(request: FastAPIRequest, db: Session = Depends(get_db)):
                     }
                     for shard in shard_rows
                 ],
+                "ingress_summary": ingress_summary,
+                "authoritative_guard": ingress_guard,
             },
         }
     except Exception as e:
@@ -8244,6 +8489,7 @@ async def eventsub_callback(request: FastAPIRequest, db: Session = Depends(get_d
                 return JSONResponse(status_code=202, content={"detail": "unknown subscription"})
             secret = subscription.secret
             if not _verify_eventsub_signature(secret, message_id, timestamp, body, signature):
+                _record_ingress_metric("signature_failure")
                 logger.warning(
                     "EventSub callback rejected: reason_code=invalid_signature message_id=%s message_type=%s verification_shape=%s",
                     message_id,
@@ -8276,6 +8522,7 @@ async def eventsub_callback(request: FastAPIRequest, db: Session = Depends(get_d
                 )
                 raise HTTPException(status_code=400, detail=resolve_error or "conduit_shard_secret_unavailable")
             if not _verify_eventsub_signature(secret, message_id, timestamp, body, signature):
+                _record_ingress_metric("signature_failure")
                 logger.warning(
                     "EventSub callback rejected: reason_code=invalid_signature message_id=%s message_type=%s verification_shape=%s conduit_id=%s shard_id=%s",
                     message_id,
@@ -8371,6 +8618,7 @@ async def eventsub_callback(request: FastAPIRequest, db: Session = Depends(get_d
             )
 
     if not _verify_eventsub_signature(verification_secret, message_id, timestamp, body, signature):
+        _record_ingress_metric("signature_failure")
         if is_conduit_chat_notification:
             logger.warning(
                 "EventSub callback rejected: reason_code=invalid_signature message_id=%s message_type=%s subscription_id=%s conduit_id=%s shard_id=%s signature_mode=conduit_shard_secret",
@@ -8400,9 +8648,13 @@ async def eventsub_callback(request: FastAPIRequest, db: Session = Depends(get_d
         if is_conduit_chat_notification:
             _refresh_conduit_shard_status_from_twitch(conduit_id, db, datetime.utcnow())
             db.commit()
+        if get_chat_ingress_mode() == "webhook_conduit":
+            _evaluate_ingress_guard(db, datetime.utcnow(), apply_fallback=True)
         return JSONResponse({"success": True})
 
     db.commit()
+    if get_chat_ingress_mode() == "webhook_conduit":
+        _evaluate_ingress_guard(db, datetime.utcnow(), apply_fallback=True)
     return JSONResponse({"detail": "ignored"})
 
 # =====================================

--- a/bot/bot_app.py
+++ b/bot/bot_app.py
@@ -171,6 +171,18 @@ class Backend:
     async def get_channels(self):
         return await self._req('GET', "/channels")
 
+    async def get_system_config(self) -> dict:
+        """Return backend system config used for ingress runtime gating.
+
+        Dependencies: calls the backend ``/system/config`` endpoint.
+        Code customers: ``SongBot.sync_channels`` websocket fallback decisions.
+        Used variables/origin: uses admin-authenticated API response fields such
+        as ``chat_ingress_mode`` and ``chat_websocket_fallback_legacy_enabled``.
+        """
+
+        payload = await self._req('GET', "/system/config")
+        return payload if isinstance(payload, dict) else {}
+
     async def add_channel(self, channel_name: str, channel_id: str, join_active: int = 1):
         return await self._req('POST', "/channels", {
             'channel_name': channel_name,
@@ -535,6 +547,7 @@ class SongBot(commands.Bot):
         self._subscription_ids: Dict[str, str] = {}
         self._update_locks: Dict[str, asyncio.Lock] = {}
         self._refresher_task: Optional[asyncio.Task] = None
+        self._websocket_ingress_enabled = True
 
     @property
     def configured_login(self) -> Optional[str]:
@@ -647,6 +660,12 @@ class SongBot(commands.Bot):
             await self._disable_all_channels()
             return
         async with self._sync_lock:
+            config = await backend.get_system_config()
+            ingress_mode = str(config.get("chat_ingress_mode") or "").strip().lower()
+            rollback_enabled = bool(config.get("chat_websocket_fallback_legacy_enabled"))
+            self._websocket_ingress_enabled = ingress_mode != "webhook_conduit" or rollback_enabled
+            if ingress_mode == "webhook_conduit" and not rollback_enabled:
+                logger.info("Websocket EventSub chat subscription is disabled by authoritative webhook_conduit mode")
             rows = await backend.get_channels()
             allowed: Dict[str, Dict] = {}
             for row in rows:
@@ -758,6 +777,8 @@ class SongBot(commands.Bot):
         return None
 
     async def _find_existing_subscription_id(self, broadcaster_id: str) -> Optional[str]:
+        # TODO(cleanup): This websocket helper is a legacy fallback path once
+        # webhook-conduit ingress has passed the stabilization window.
         for existing_id, details in self.websocket_subscriptions().items():
             condition = getattr(details, 'condition', {}) or {}
             sub_type = getattr(details, 'type', None)
@@ -788,8 +809,22 @@ class SongBot(commands.Bot):
         return None
 
     async def _subscribe_for_channel(self, broadcaster_id: str) -> None:
+        """Create/reuse websocket chat subscriptions unless authoritative mode disables them.
+
+        Dependencies: uses backend-provided ingress policy computed in
+        ``sync_channels`` and TwitchIO websocket EventSub APIs.
+        Code customers: channel-sync subscription lifecycle.
+        Used variables/origin: ``self._websocket_ingress_enabled`` reflects
+        ``chat_ingress_mode`` plus rollback flag from backend system config.
+        """
+
         if not broadcaster_id:
             raise RuntimeError('Channel missing broadcaster id')
+        if not self._websocket_ingress_enabled:
+            # Deprecated fallback note:
+            # websocket chat subscriptions remain available only when explicit
+            # rollback flag ``chat_websocket_fallback_legacy_enabled`` is true.
+            return
         if broadcaster_id in self._subscription_ids:
             return
         existing_id = await self._find_existing_subscription_id(broadcaster_id)

--- a/docs/README.md
+++ b/docs/README.md
@@ -71,10 +71,19 @@ unlocks the API for the bot, queue manager, and public web frontend.
 
 ### Chat ingress defaults and staged rollout flags
 - `/system/config` now exposes `chat_ingress_mode` with:
-  - `websocket` (default)
-  - `webhook_conduit`
+  - `webhook_conduit` (default, authoritative)
+  - `websocket` (legacy fallback only)
 - `/system/config` also exposes `chat_ingress_shadow_mode` (default `false`) so
   operators can run dual-path validation before a full ingress cutover.
+- Legacy rollback is explicit through `chat_websocket_fallback_legacy_enabled`.
+  Websocket EventSub chat subscriptions are suppressed in bot runtime when
+  `chat_ingress_mode=webhook_conduit` and this rollback flag is `false`.
+- Startup/runtime ingress guard now evaluates conduit health with high-severity
+  alerts and optional auto-fallback (`chat_ingress_guard_auto_fallback_enabled`)
+  when:
+  - healthy conduit shards drop below `chat_ingress_guard_min_healthy_shards`,
+  - callback 4xx/5xx volume in `chat_ingress_guard_window_seconds` exceeds
+    `chat_ingress_guard_callback_error_threshold`.
 - Migration `migrations/20260330_eventsub_conduits.sql` adds additive EventSub
   replay/conduit tables (`eventsub_message_dedupe`, `twitch_conduits`,
   `twitch_conduit_shards`) plus conduit linkage columns on
@@ -86,6 +95,11 @@ unlocks the API for the bot, queue manager, and public web frontend.
   staggered deploys on legacy SQLite/prod databases continue booting safely.
 - EventSub health endpoints now include conduit + shard coverage summaries:
   - `GET /system/health` reports global conduit assignment coverage.
+  - `GET /system/health.eventsub.ingress_summary` adds compact runtime counters:
+    callback 2xx/4xx/5xx, signature failures, dedupe hits, per-channel command
+    dispatch outcomes, shard status transitions, and last error timestamps.
+  - `GET /system/health.eventsub.authoritative_guard` reports degradation
+    reasons and whether auto-fallback was applied.
   - `GET /channels/{channel}/eventsub/health` reports per-channel shard
     assignment state and can trigger reconcile with `?reconcile=true`, which
     refreshes local/conduit/shard/coverage fields after reconciliation.
@@ -176,6 +190,30 @@ Expected:
 - `public_backend_origin` is an `https://` origin.
 - Derived EventSub callback format is:
   `https://<public-backend-origin>/twitch/eventsub/callback`.
+
+### Rollback + triage playbook
+1. Confirm current mode and guard state:
+   - `GET /system/config`
+   - `GET /system/health` and inspect `eventsub.ingress_summary` +
+     `eventsub.authoritative_guard`.
+2. If degraded (`missing_healthy_shards` / `callback_errors_spike`), run:
+   - `GET /channels/{channel}/eventsub/health?reconcile=true`
+   - validate callback URL config + shard statuses.
+3. Emergency rollback:
+   - set `chat_websocket_fallback_legacy_enabled=true`,
+   - optionally switch `chat_ingress_mode=websocket` if operator policy
+     requires immediate handoff.
+4. After stabilization, disable rollback flag again and restore
+   `chat_ingress_mode=webhook_conduit`.
+
+### Maintenance checklist
+- Verify bot/app token refreshes complete successfully each day.
+- Reconcile conduit shards on a fixed cadence (recommended: every 15 minutes or
+  after channel topology changes).
+- Validate callback URL remains public HTTPS with exact
+  `/twitch/eventsub/callback` path.
+- Review `ingress_summary` counters for signature failures, dedupe spikes, and
+  shard status churn.
 
 ## Running with Docker
 1. Copy `example.env` to `stack.env` and adjust values such as `ADMIN_TOKEN`,

--- a/docs/backend_api.md
+++ b/docs/backend_api.md
@@ -5,7 +5,7 @@ This document summarizes the REST endpoints exposed by `backend_app.py`.
 ## System
 | Method | Path | Description |
 |--------|------|-------------|
-| GET | `/system/health` | Health check that verifies database connectivity plus global EventSub webhook/conduit coverage and shard state. |
+| GET | `/system/health` | Health check that verifies database connectivity plus global EventSub webhook/conduit coverage, shard state, and ingress guard telemetry. |
 | GET | `/system/config` | Read deployment configuration defaults and ingress mode toggles. |
 | PUT | `/system/config` | Update deployment configuration, scopes, and ingress mode toggles (admin token required). |
 
@@ -14,14 +14,31 @@ This document summarizes the REST endpoints exposed by `backend_app.py`.
   - Existing setup/OAuth fields (`setup_complete`, client IDs/secrets, redirect URIs, scopes).
   - `eventsub_callback_override`: optional admin-managed full callback override URL (example: `https://api.example.com/twitch/eventsub/callback`).
   - `public_backend_origin`: canonical public backend origin used for EventSub callback URL generation (example: `https://api.example.com`).
-  - `chat_ingress_mode`: `websocket` (default) or `webhook_conduit`.
+  - `chat_ingress_mode`: `webhook_conduit` (default authoritative) or `websocket` (legacy fallback).
   - `chat_ingress_shadow_mode`: boolean dual-run switch for validation mode (default `false`).
+  - `chat_websocket_fallback_legacy_enabled`: explicit rollback flag for websocket EventSub chat subscriptions in bot runtime.
+  - `chat_ingress_guard_auto_fallback_enabled`: if `true`, degraded authoritative ingress can auto-switch mode to `websocket`.
 - **PUT payload additions**
   - `eventsub_callback_override?: string`
   - `public_backend_origin?: string`
   - `chat_ingress_mode?: "websocket" | "webhook_conduit"`
   - `chat_ingress_shadow_mode?: boolean`
+  - `chat_websocket_fallback_legacy_enabled?: boolean`
+  - `chat_ingress_guard_auto_fallback_enabled?: boolean`
 - **Compatibility note**: Startup includes additive schema patching for staggered deployments so older SQLite/prod DBs can run until the dedicated migration is applied.
+
+### `/system/health` ingress summary
+- `eventsub.ingress_summary` includes compact operational counters:
+  - callback status buckets (`2xx/4xx/5xx`),
+  - signature failures,
+  - dedupe hits,
+  - per-channel webhook command dispatch outcomes,
+  - conduit shard status transitions,
+  - recent callback throughput + last error timestamps.
+- `eventsub.authoritative_guard` includes degradation reasons (`missing_healthy_shards`, `callback_errors_spike`) and whether fallback was applied.
+- Recommended operator thresholds:
+  - callback error threshold: 5 errors / 5 minutes,
+  - minimum healthy shards: 1 (or expected shard count for larger deployments).
 
 ### EventSub callback URL reliability requirements
 - Twitch EventSub webhook registration must use a **publicly reachable HTTPS callback URL**.
@@ -55,6 +72,10 @@ This document summarizes the REST endpoints exposed by `backend_app.py`.
    ```
 2. Confirm expected callback URL format before enabling conduit ingress:
    - `https://<public-backend-origin>/twitch/eventsub/callback`
+3. Rollback playbook:
+   - Enable `chat_websocket_fallback_legacy_enabled=true` for immediate websocket subscription restore.
+   - If required, switch `chat_ingress_mode=websocket`.
+   - Re-run conduit reconcile + callback validation before returning to authoritative mode.
 
 ## Authentication
 | Method | Path | Description |

--- a/tests/test_bot_service.py
+++ b/tests/test_bot_service.py
@@ -17,6 +17,7 @@ class BotServiceTests(unittest.IsolatedAsyncioTestCase):
         self.backend.push_bot_log = AsyncMock()
         self.backend.get_bot_config = AsyncMock()
         self.backend.set_bot_status = AsyncMock()
+        self.backend.get_system_config = AsyncMock(return_value={"chat_ingress_mode": "websocket"})
         self.backend.list_playlists = AsyncMock()
         self.backend.playlist_request = AsyncMock()
         bot_app.backend = self.backend
@@ -284,6 +285,38 @@ class BotServiceTests(unittest.IsolatedAsyncioTestCase):
         self.assertNotIn("foo", song_bot.joined)
         self.backend.set_bot_status.assert_awaited_once_with("Foo", False, "boom")
         song_bot._announce_joined.assert_not_called()
+
+    async def test_sync_channels_disables_websocket_subscriptions_in_authoritative_mode(self) -> None:
+        song_bot = bot_app.SongBot.__new__(bot_app.SongBot)
+        song_bot.channel_map = {}
+        song_bot.state = {}
+        song_bot.listeners = {}
+        song_bot.joined = set()
+        song_bot._sync_lock = asyncio.Lock()
+        song_bot.enabled = True
+        song_bot._announce_joined = AsyncMock()
+        song_bot._announce_left = AsyncMock()
+        song_bot.listen_backend = AsyncMock(return_value=None)
+        song_bot._subscribe_for_channel = AsyncMock()
+        song_bot._unsubscribe_channel = AsyncMock()
+        song_bot._send_message = AsyncMock()
+
+        self.backend.get_system_config = AsyncMock(
+            return_value={"chat_ingress_mode": "webhook_conduit", "chat_websocket_fallback_legacy_enabled": False}
+        )
+        self.backend.get_channels = AsyncMock(
+            return_value=[{"channel_name": "Foo", "channel_id": "1", "authorized": True, "join_active": 1}]
+        )
+        self.backend.get_queue = AsyncMock(return_value=[])
+
+        def fake_create_task(coro):
+            coro.close()
+            return MagicMock()
+
+        with patch.object(bot_app.asyncio, "create_task", fake_create_task), patch.object(bot_app, "push_console_event", AsyncMock()):
+            await song_bot.sync_channels()
+
+        self.assertFalse(song_bot._websocket_ingress_enabled)
 
     async def test_songbot_does_not_assign_readonly_nick(self) -> None:
         commands_map = {k: ([v] if not isinstance(v, list) else v) for k, v in bot_app.DEFAULT_COMMANDS.items()}

--- a/tests/test_channel_events.py
+++ b/tests/test_channel_events.py
@@ -862,6 +862,85 @@ class ChannelEventTests(unittest.TestCase):
         self.assertEqual(payload.get("conduit_id"), conduit_id)
         self.assertEqual(payload.get("shard_id"), shard_id)
 
+    def test_system_health_reports_ingress_summary_metrics(self) -> None:
+        """Expose compact ingress summary with callback throughput and counters."""
+
+        _setup_channel()
+        db = backend_app.SessionLocal()
+        try:
+            backend_app._record_ingress_metric("callback_status", key="2xx")
+            backend_app._record_ingress_metric("callback_status", key="4xx")
+            backend_app._record_ingress_metric("signature_failure")
+        finally:
+            db.close()
+
+        response = self.client.get("/system/health")
+        self.assertEqual(response.status_code, 200, response.text)
+        payload = response.json().get("eventsub") or {}
+        summary = payload.get("ingress_summary") or {}
+        self.assertIn("recent_callback_throughput", summary)
+        self.assertGreaterEqual((summary.get("callback_status") or {}).get("2xx", 0), 1)
+        self.assertGreaterEqual((summary.get("callback_status") or {}).get("4xx", 0), 1)
+        self.assertGreaterEqual(summary.get("signature_failures", 0), 1)
+
+    def test_ingress_guard_degradation_can_auto_fallback_websocket_mode(self) -> None:
+        """Auto-fallback to websocket mode when authoritative ingress is degraded."""
+
+        _setup_channel()
+        db = backend_app.SessionLocal()
+        try:
+            backend_app.set_settings(
+                db,
+                {
+                    "chat_ingress_mode": "webhook_conduit",
+                    "chat_ingress_guard_auto_fallback_enabled": "1",
+                    "chat_ingress_guard_callback_error_threshold": "1",
+                    "chat_ingress_guard_min_healthy_shards": "1",
+                },
+            )
+            backend_app._record_ingress_metric("callback_status", key="5xx")
+            guard = backend_app._evaluate_ingress_guard(db, backend_app.datetime.utcnow(), apply_fallback=True)
+            self.assertTrue(guard["degraded"])
+            self.assertTrue(guard["auto_fallback_applied"])
+            self.assertEqual(backend_app.get_chat_ingress_mode(), "websocket")
+        finally:
+            db.close()
+
+    def test_cleanup_conduit_subscription_secret_semantics_sets_placeholder(self) -> None:
+        """Normalize conduit chat subscription secrets to non-authoritative placeholder."""
+
+        details = _setup_channel()
+        db = backend_app.SessionLocal()
+        try:
+            db.add(
+                backend_app.EventSubscription(
+                    channel_id=details["channel_pk"],
+                    twitch_subscription_id="sub-conduit-cleanup",
+                    type="channel.chat.message",
+                    status="enabled",
+                    secret="legacy-secret",
+                    callback="https://example/callback",
+                    transport="conduit",
+                    conduit_id="conduit-cleanup",
+                    shard_id="0",
+                )
+            )
+            db.commit()
+        finally:
+            db.close()
+
+        backend_app.cleanup_conduit_subscription_secret_semantics()
+        db = backend_app.SessionLocal()
+        try:
+            row = (
+                db.query(backend_app.EventSubscription)
+                .filter(backend_app.EventSubscription.twitch_subscription_id == "sub-conduit-cleanup")
+                .one()
+            )
+            self.assertEqual(row.secret, backend_app.EVENTSUB_CONDUIT_SECRET_PLACEHOLDER)
+        finally:
+            db.close()
+
     def test_get_or_create_settings_backfills_queue_caps(self) -> None:
         """Ensure legacy channel settings rows gain default queue caps.
 


### PR DESCRIPTION
### Motivation
- Harden rollout to authoritative `webhook_conduit` ingress with operator-safe rollback and automated guardrails to avoid silent degradations.
- Improve operational observability and triage for EventSub callback flows (signatures, dedupe, callback errors, shard health) so operators can act quickly during cutover. 
- Reduce websocket fallback surface in runtime while keeping an explicit, operator-controlled rollback path and migration-safe data semantics for conduit subscriptions.

### Description
- Switched default ingress to authoritative `chat_ingress_mode=webhook_conduit` and added new settings: `chat_websocket_fallback_legacy_enabled`, `chat_ingress_guard_auto_fallback_enabled`, `chat_ingress_guard_callback_error_threshold`, `chat_ingress_guard_window_seconds`, and `chat_ingress_guard_min_healthy_shards`, and exposed them via `SystemConfig` models and updates (`backend_app.py`).
- Added in-memory ingress telemetry and counters plus helper functions: `_record_ingress_metric`, `_ingress_metrics_snapshot`, `_ingress_guard_thresholds`, and `_evaluate_ingress_guard`, and a startup check `run_ingress_guard_startup_check` that can optionally auto-apply fallback (`backend_app.py`).
- Captured callback response classes via new HTTP middleware `capture_eventsub_callback_metrics`, instrumented signature failures, dedupe hits, per-channel command dispatch outcomes, and shard status transitions across callback and reconciliation paths, and surfaced a compact `eventsub.ingress_summary` and `authoritative_guard` block in `GET /system/health` (backend telemetry and health diagnostics). 
- Introduced `cleanup_conduit_subscription_secret_semantics()` run at startup to normalize legacy `event_subscriptions.secret` on conduit chat rows to a non-authoritative placeholder while leaving `twitch_conduit_shards.transport_secret` authoritative. 
- Minimized websocket fallback in bot runtime by adding a backend `get_system_config` client call and gating websocket EventSub subscription creation when `chat_ingress_mode=webhook_conduit` unless `chat_websocket_fallback_legacy_enabled` is explicitly set; marked websocket helper paths as legacy candidates for later removal (`bot/bot_app.py`).
- Added/updated docs and runbook content in `docs/README.md` and `docs/backend_api.md` to describe final ingress architecture, rollback playbook, recommended thresholds, and maintenance checklist. 
- Tests: added/extended tests for ingress summary metrics, degraded-guard auto-fallback, conduit secret cleanup migration, and authoritative-mode websocket subscription gating (`tests/test_channel_events.py`, `tests/test_bot_service.py`).

### Testing
- Unit tests run: `mkdir -p /data && PYTHONPATH=. pytest -q tests/test_bot_service.py::BotServiceTests::test_sync_channels_subscribes_backend_channels tests/test_bot_service.py::BotServiceTests::test_sync_channels_disables_websocket_subscriptions_in_authoritative_mode` — both tests passed (2 passed, warnings reported). 
- Unit tests run: `PYTHONPATH=. pytest -q tests/test_channel_events.py::ChannelEventTests::test_system_health_reports_ingress_summary_metrics tests/test_channel_events.py::ChannelEventTests::test_ingress_guard_degradation_can_auto_fallback_websocket_mode tests/test_channel_events.py::ChannelEventTests::test_cleanup_conduit_subscription_secret_semantics_sets_placeholder` — all three tests passed (3 passed, warnings reported). 
- Overall: new guard, metrics, middleware, migration, runtime gating, docs, and tests committed and verified locally.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc3165a4dc8328a95b48954bffe1e4)