### PR TITLE
Harden EventSub chat reply preflight to avoid deterministic 400s

### DIFF
--- a/backend_app.py
+++ b/backend_app.py
@@ -192,6 +192,7 @@ BOT_MESSAGE_DEFAULT_TEMPLATES: dict[str, str] = {
     "failed": "Failed: {error}",
 }
 BOT_MESSAGE_LEVEL_RANK: dict[str, int] = {"mute": 0, "normal": 1, "verbose": 2, "debug": 3}
+TWITCH_SEND_CHAT_MESSAGE_MAX_LENGTH = 500
 
 _bot_log_listeners: set[asyncio.Queue[str]] = set()
 _bot_oauth_states: dict[str, Dict[str, Any]] = {}
@@ -1513,11 +1514,112 @@ def _should_send_eventsub_reply(channel: ActiveChannel, visibility: str) -> bool
     return threshold_name != "mute" and message_rank <= threshold_rank
 
 
+def _resolve_twitch_token_subject_id(access_token: str, *, timeout: float = 6.0) -> Optional[str]:
+    """Resolve Twitch OAuth token subject user id via validation endpoint.
+
+    Dependencies: Performs an HTTPS GET to Twitch ``/oauth2/validate``.
+    Code customers: ``_preflight_eventsub_chat_reply_payload`` sender parity.
+    Used variables/origin: ``access_token`` comes from persisted bot OAuth
+    credentials and maps to validation response field ``user_id``.
+    """
+
+    token = (access_token or "").strip()
+    if not token:
+        return None
+    response = requests.get(
+        "https://id.twitch.tv/oauth2/validate",
+        headers={"Authorization": f"OAuth {token}"},
+        timeout=timeout,
+    )
+    if response.status_code != 200:
+        return None
+    payload = response.json()
+    subject_id = str(payload.get("user_id") or "").strip()
+    return subject_id or None
+
+
+def _build_eventsub_chat_reply_payload(
+    *,
+    broadcaster_id: str,
+    sender_id: str,
+    message: str,
+    reply_parent_message_id: Optional[str],
+) -> dict[str, Any]:
+    """Build Twitch send-chat payload with optional reply parent message id.
+
+    Dependencies: Pure builder with no external runtime dependencies.
+    Code customers: ``_preflight_eventsub_chat_reply_payload`` and send API call
+    path inside ``_send_eventsub_chat_reply``.
+    Used variables/origin: values originate from active channel identity, bot
+    OAuth identity, rendered reply text, and EventSub payload ``message_id``.
+    """
+
+    payload: dict[str, Any] = {
+        "broadcaster_id": broadcaster_id,
+        "sender_id": sender_id,
+        "message": message,
+    }
+    if reply_parent_message_id:
+        payload["reply_parent_message_id"] = reply_parent_message_id
+    return payload
+
+
+def _preflight_eventsub_chat_reply_payload(
+    db: Session,
+    *,
+    channel: ActiveChannel,
+    sender_id: str,
+    message: str,
+    reply_parent_message_id: Optional[str],
+) -> tuple[Optional[dict[str, Any]], Optional[str], Optional[dict[str, str]]]:
+    """Validate deterministic Twitch send-chat inputs before HTTP requests.
+
+    Dependencies: Reads ``BotConfig`` for bot access token, validates token
+    subject via Twitch ``/oauth2/validate``, and assembles Helix headers.
+    Code customers: ``_send_eventsub_chat_reply`` deterministic preflight guard.
+    Used variables/origin: broadcaster id from ``channel.channel_id``,
+    ``sender_id`` from bot identity resolution, ``message`` from rendered reply,
+    and ``reply_parent_message_id`` from EventSub ``event.message_id``.
+    """
+
+    broadcaster_id = str(channel.channel_id or "").strip()
+    normalized_sender_id = str(sender_id or "").strip()
+    normalized_message = str(message or "")
+    if not broadcaster_id:
+        return None, "preflight_missing_broadcaster_id", None
+    if not normalized_sender_id:
+        return None, "preflight_missing_sender_id", None
+    message_len = len(normalized_message)
+    if message_len < 1 or message_len > TWITCH_SEND_CHAT_MESSAGE_MAX_LENGTH:
+        return None, "preflight_invalid_message_length", None
+
+    cfg = db.query(BotConfig).order_by(BotConfig.id.asc()).first()
+    access_token = (cfg.access_token if cfg and cfg.access_token else "").strip()
+    if not access_token:
+        return None, "preflight_missing_bot_access_token", None
+    token_subject_id = _resolve_twitch_token_subject_id(access_token)
+    if not token_subject_id:
+        return None, "preflight_token_subject_unresolved", None
+    if token_subject_id != normalized_sender_id:
+        return None, "preflight_sender_token_subject_mismatch", None
+
+    headers = _eventsub_headers(access_token)
+    payload = _build_eventsub_chat_reply_payload(
+        broadcaster_id=broadcaster_id,
+        sender_id=normalized_sender_id,
+        message=normalized_message,
+        reply_parent_message_id=(reply_parent_message_id or "").strip() or None,
+    )
+    return payload, None, headers
+
+
 def _send_eventsub_chat_reply(db: Session, channel: ActiveChannel, reply: dict[str, Any], *, reply_parent_message_id: Optional[str]) -> bool:
     """Send webhook reply text through Twitch Send Chat Message API with retries.
 
-    Dependencies: Uses ``_eventsub_bot_headers`` for bot OAuth context and
-    ``get_bot_user_id`` for sender id, then POSTs ``/helix/chat/messages``.
+    Dependencies: Resolves sender identity via ``get_bot_user_id``, validates
+    deterministic payload constraints through
+    ``_preflight_eventsub_chat_reply_payload``, then POSTs
+    ``/helix/chat/messages``.
     Code customers: ``_process_eventsub_chat_notification`` authoritative path.
     Used variables/origin: ``reply`` contract is emitted by command executors;
     ``reply_parent_message_id`` comes from the inbound EventSub message id.
@@ -1531,24 +1633,23 @@ def _send_eventsub_chat_reply(db: Session, channel: ActiveChannel, reply: dict[s
     if not text:
         _record_ingress_metric("reply_suppressed")
         return False
-    sender_id = get_bot_user_id()
-    if not sender_id:
+    sender_id = str(get_bot_user_id() or "").strip()
+    payload, preflight_reason_code, headers = _preflight_eventsub_chat_reply_payload(
+        db,
+        channel=channel,
+        sender_id=sender_id,
+        message=text,
+        reply_parent_message_id=reply_parent_message_id,
+    )
+    if preflight_reason_code or not payload or not headers:
         _record_ingress_metric("send_api_failure")
-        logger.warning("Webhook reply send skipped: bot_user_id unavailable")
+        logger.warning(
+            "Webhook reply send skipped by preflight: reason_code=%s channel=%s template_key=%s",
+            preflight_reason_code or "preflight_unknown_failure",
+            channel.channel_name,
+            reply.get("template_key"),
+        )
         return False
-    try:
-        headers = _eventsub_bot_headers(db)
-    except Exception:
-        _record_ingress_metric("send_api_failure")
-        logger.exception("Webhook reply send skipped: bot oauth credentials unavailable")
-        return False
-    payload: dict[str, Any] = {
-        "broadcaster_id": channel.channel_id,
-        "sender_id": sender_id,
-        "message": text,
-    }
-    if reply_parent_message_id:
-        payload["reply_parent_message_id"] = reply_parent_message_id
     delay_seconds = 0.3
     for attempt in range(3):
         try:
@@ -1561,6 +1662,25 @@ def _send_eventsub_chat_reply(db: Session, channel: ActiveChannel, reply: dict[s
             response.raise_for_status()
             _record_ingress_metric("reply_sent")
             return True
+        except requests.HTTPError as exc:
+            _record_ingress_metric("send_api_failure")
+            status_code = exc.response.status_code if exc.response is not None else None
+            if status_code is not None and 400 <= status_code < 500:
+                logger.warning(
+                    "Webhook reply send failed without retry: reason_code=api_4xx_response status_code=%s channel=%s template_key=%s",
+                    status_code,
+                    channel.channel_name,
+                    reply.get("template_key"),
+                )
+                return False
+            if attempt == 2:
+                logger.exception(
+                    "Webhook reply send failed after retries",
+                    extra={"channel": channel.channel_name, "template_key": reply.get("template_key")},
+                )
+                return False
+            time.sleep(delay_seconds)
+            delay_seconds *= 2
         except requests.RequestException:
             _record_ingress_metric("send_api_failure")
             if attempt == 2:
@@ -2184,11 +2304,12 @@ def _process_eventsub_chat_notification(
             reply_contract = ((outcome.get("metadata") or {}).get("response") if isinstance(outcome.get("metadata"), dict) else None)
             reply_sent = False
             if isinstance(reply_contract, dict) and not shadow_mode:
+                reply_parent_message_id = str(event_payload.get("message_id") or "").strip() or None
                 reply_sent = _send_eventsub_chat_reply(
                     db,
                     channel,
                     reply_contract,
-                    reply_parent_message_id=message_id,
+                    reply_parent_message_id=reply_parent_message_id,
                 )
             mutated = bool((outcome.get("metadata") or {}).get("mutated")) if isinstance(outcome.get("metadata"), dict) else False
             executed_authoritative = outcome.get("status") == "executed" and (mutated or reply_sent)

--- a/docs/README.md
+++ b/docs/README.md
@@ -182,6 +182,14 @@ unlocks the API for the bot, queue manager, and public web frontend.
     replies through Twitch `POST /helix/chat/messages` using a stable reply
     contract (`status`, `template_key`, `template_vars`, `visibility`) so
     webhook responses match websocket/bot catalog semantics.
+  - Reply threading now uses chat event payload `event.message_id` only (never
+    the EventSub transport header message id). If `event.message_id` is
+    missing, the send payload omits `reply_parent_message_id`.
+  - Deterministic Send Chat 400 guards now run before HTTP requests:
+    `broadcaster_id` and `sender_id` must be non-empty, message length must be
+    within Twitch Send Chat limits (`1-500` chars), and `sender_id` must match
+    the bot token subject (`/oauth2/validate user_id`). Failed preflight emits
+    explicit reason codes and skips request/retry.
   - Reply visibility still honors per-channel `bot_message_level` thresholds,
     so muted/normal/verbose/debug suppression behavior is unchanged.
   - Shadow mode remains non-sending and non-mutating for webhook commands even

--- a/docs/backend_api.md
+++ b/docs/backend_api.md
@@ -461,6 +461,9 @@ Certain events award priority points and are fed by EventSub subscriptions creat
   - Canonical webhook execution now covers `request`, `playlist_request`, `prioritize`, `remove`, and `points` with queue mutation and reply semantics aligned to the prior websocket flow.
   - Explicit no-op buckets are tracked for non-command chat lines, unknown aliases, policy-suppressed replies, and shadow-mode observe-only dispatch.
   - Authoritative webhook execution now produces chat replies through Twitch Send Chat Message API (`POST /helix/chat/messages`) with a stable reply contract (`status=success|error`, `template_key`, `template_vars`, optional `visibility` level).
+  - Reply threading uses EventSub chat payload `event.message_id` only. The EventSub transport header message id is not used for `reply_parent_message_id`; when `event.message_id` is absent, reply threading is omitted.
+  - Deterministic preflight validation now runs before Send Chat API calls to prevent guaranteed 400 retries: non-empty `broadcaster_id`, non-empty `sender_id`, message length `1-500`, and `sender_id` equality with bot token subject (`/oauth2/validate` `user_id`).
+  - Preflight failures emit explicit reason codes and skip HTTP requests/retries.
   - Reply rendering uses the same message-catalog template semantics as websocket bot command responses.
   - Channel `bot_message_level` thresholds still gate webhook replies exactly like bot/websocket mode (`mute` suppresses all, `normal`/`verbose`/`debug` thresholds allow <= level).
   - In `chat_ingress_shadow_mode=true`, webhook command notifications stay observe-only and do not send chat replies or mutate queue state.

--- a/tests/test_channel_events.py
+++ b/tests/test_channel_events.py
@@ -897,7 +897,7 @@ class ChannelEventTests(unittest.TestCase):
         timestamp = "2023-01-01T00:00:00Z"
         signature = hmac.new(secret.encode(), msg=(message_id + timestamp).encode() + raw, digestmod=hashlib.sha256)
         with mock.patch.object(backend_app, "get_bot_user_id", return_value="bot-user-1"), mock.patch.object(
-            backend_app, "_eventsub_bot_headers", return_value={"Authorization": "Bearer token", "Client-Id": "cid"}
+            backend_app, "_resolve_twitch_token_subject_id", return_value="bot-user-1"
         ), mock.patch("backend_app.requests.post") as mock_send:
             mock_send.return_value.raise_for_status.return_value = None
             response = self.client.post(
@@ -925,6 +925,209 @@ class ChannelEventTests(unittest.TestCase):
             self.assertIsNotNone(song)
             self.assertEqual(song.artist, "Artist C")
             self.assertEqual(song.title, "Song Three")
+        finally:
+            db.close()
+
+    def test_eventsub_chat_notification_reply_parent_uses_event_message_id(self) -> None:
+        """Send replies threaded to ``event.message_id`` instead of header message id."""
+
+        details = _setup_channel()
+        secret = "chatsecret-event-message-id"
+        conduit_id = "conduit-chat-event-message-id"
+        shard_id = "13"
+        subscription_id = "sub-chat-event-message-id"
+        db = backend_app.SessionLocal()
+        try:
+            backend_app.set_settings(db, {"chat_ingress_mode": "webhook_conduit", "chat_ingress_shadow_mode": "0"})
+        finally:
+            db.close()
+        _create_chat_conduit_subscription(
+            details["channel_pk"],
+            subscription_id=subscription_id,
+            conduit_id=conduit_id,
+            shard_id=shard_id,
+            secret=secret,
+        )
+
+        body = {
+            "subscription": {
+                "id": subscription_id,
+                "type": "channel.chat.message",
+                "status": "enabled",
+                "version": "1",
+                "condition": {"broadcaster_user_id": "cid"},
+                "transport": {"method": "conduit", "conduit_id": conduit_id},
+            },
+            "event": {
+                "message_id": "event-message-id-123",
+                "chatter_user_id": "webhook-user-2",
+                "chatter_user_login": "webhookuser2",
+                "message": {"text": "!request Artist E - Song Five"},
+            },
+        }
+        raw = json.dumps(body).encode()
+        header_message_id = "header-message-id-999"
+        timestamp = "2023-01-01T00:00:00Z"
+        signature = hmac.new(secret.encode(), msg=(header_message_id + timestamp).encode() + raw, digestmod=hashlib.sha256)
+        with mock.patch.object(backend_app, "get_bot_user_id", return_value="bot-user-1"), mock.patch.object(
+            backend_app, "_resolve_twitch_token_subject_id", return_value="bot-user-1"
+        ), mock.patch("backend_app.requests.post") as mock_send:
+            mock_send.return_value.raise_for_status.return_value = None
+            response = self.client.post(
+                "/twitch/eventsub/callback",
+                data=raw,
+                headers={
+                    "Twitch-Eventsub-Message-Id": header_message_id,
+                    "Twitch-Eventsub-Message-Timestamp": timestamp,
+                    "Twitch-Eventsub-Message-Signature": f"sha256={signature.hexdigest()}",
+                    "Twitch-Eventsub-Message-Type": "notification",
+                },
+            )
+            payload = mock_send.call_args.kwargs["json"]
+            self.assertEqual(payload["reply_parent_message_id"], "event-message-id-123")
+        self.assertEqual(response.status_code, 200, response.text)
+
+    def test_eventsub_chat_notification_reply_parent_omitted_when_event_message_id_missing(self) -> None:
+        """Omit reply threading when ``event.message_id`` is absent."""
+
+        details = _setup_channel()
+        secret = "chatsecret-no-event-message-id"
+        conduit_id = "conduit-chat-no-event-message-id"
+        shard_id = "14"
+        subscription_id = "sub-chat-no-event-message-id"
+        db = backend_app.SessionLocal()
+        try:
+            backend_app.set_settings(db, {"chat_ingress_mode": "webhook_conduit", "chat_ingress_shadow_mode": "0"})
+        finally:
+            db.close()
+        _create_chat_conduit_subscription(
+            details["channel_pk"],
+            subscription_id=subscription_id,
+            conduit_id=conduit_id,
+            shard_id=shard_id,
+            secret=secret,
+        )
+
+        body = {
+            "subscription": {
+                "id": subscription_id,
+                "type": "channel.chat.message",
+                "status": "enabled",
+                "version": "1",
+                "condition": {"broadcaster_user_id": "cid"},
+                "transport": {"method": "conduit", "conduit_id": conduit_id},
+            },
+            "event": {
+                "chatter_user_id": "webhook-user-3",
+                "chatter_user_login": "webhookuser3",
+                "message": {"text": "!request Artist F - Song Six"},
+            },
+        }
+        raw = json.dumps(body).encode()
+        header_message_id = "header-message-id-omit-reply-parent"
+        timestamp = "2023-01-01T00:00:00Z"
+        signature = hmac.new(secret.encode(), msg=(header_message_id + timestamp).encode() + raw, digestmod=hashlib.sha256)
+        with mock.patch.object(backend_app, "get_bot_user_id", return_value="bot-user-1"), mock.patch.object(
+            backend_app, "_resolve_twitch_token_subject_id", return_value="bot-user-1"
+        ), mock.patch("backend_app.requests.post") as mock_send:
+            mock_send.return_value.raise_for_status.return_value = None
+            response = self.client.post(
+                "/twitch/eventsub/callback",
+                data=raw,
+                headers={
+                    "Twitch-Eventsub-Message-Id": header_message_id,
+                    "Twitch-Eventsub-Message-Timestamp": timestamp,
+                    "Twitch-Eventsub-Message-Signature": f"sha256={signature.hexdigest()}",
+                    "Twitch-Eventsub-Message-Type": "notification",
+                },
+            )
+            payload = mock_send.call_args.kwargs["json"]
+            self.assertNotIn("reply_parent_message_id", payload)
+        self.assertEqual(response.status_code, 200, response.text)
+
+    def test_eventsub_chat_notification_preflight_sender_subject_mismatch_skips_send(self) -> None:
+        """Skip deterministic bad payload sends when sender and token subject mismatch."""
+
+        details = _setup_channel()
+        secret = "chatsecret-sender-mismatch"
+        conduit_id = "conduit-chat-sender-mismatch"
+        shard_id = "15"
+        subscription_id = "sub-chat-sender-mismatch"
+        db = backend_app.SessionLocal()
+        try:
+            backend_app.set_settings(db, {"chat_ingress_mode": "webhook_conduit", "chat_ingress_shadow_mode": "0"})
+        finally:
+            db.close()
+        _create_chat_conduit_subscription(
+            details["channel_pk"],
+            subscription_id=subscription_id,
+            conduit_id=conduit_id,
+            shard_id=shard_id,
+            secret=secret,
+        )
+
+        body = {
+            "subscription": {
+                "id": subscription_id,
+                "type": "channel.chat.message",
+                "status": "enabled",
+                "version": "1",
+                "condition": {"broadcaster_user_id": "cid"},
+                "transport": {"method": "conduit", "conduit_id": conduit_id},
+            },
+            "event": {
+                "message_id": "event-message-id-sender-mismatch",
+                "chatter_user_id": "webhook-user-4",
+                "chatter_user_login": "webhookuser4",
+                "message": {"text": "!request Artist G - Song Seven"},
+            },
+        }
+        raw = json.dumps(body).encode()
+        header_message_id = "header-message-id-sender-mismatch"
+        timestamp = "2023-01-01T00:00:00Z"
+        signature = hmac.new(secret.encode(), msg=(header_message_id + timestamp).encode() + raw, digestmod=hashlib.sha256)
+        with mock.patch.object(backend_app, "get_bot_user_id", return_value="bot-user-1"), mock.patch.object(
+            backend_app, "_resolve_twitch_token_subject_id", return_value="bot-user-2"
+        ), mock.patch("backend_app.requests.post") as mock_send:
+            response = self.client.post(
+                "/twitch/eventsub/callback",
+                data=raw,
+                headers={
+                    "Twitch-Eventsub-Message-Id": header_message_id,
+                    "Twitch-Eventsub-Message-Timestamp": timestamp,
+                    "Twitch-Eventsub-Message-Signature": f"sha256={signature.hexdigest()}",
+                    "Twitch-Eventsub-Message-Type": "notification",
+                },
+            )
+            self.assertEqual(mock_send.call_count, 0)
+        self.assertEqual(response.status_code, 200, response.text)
+
+    def test_send_eventsub_chat_reply_preflight_invalid_message_length_skips_request(self) -> None:
+        """Skip Send Chat API call when rendered message violates Twitch length limits."""
+
+        details = _setup_channel()
+        db = backend_app.SessionLocal()
+        try:
+            channel = db.get(backend_app.ActiveChannel, details["channel_pk"])
+            self.assertIsNotNone(channel)
+            over_limit_message = "x" * (backend_app.TWITCH_SEND_CHAT_MESSAGE_MAX_LENGTH + 1)
+            reply = {
+                "status": "success",
+                "template_key": over_limit_message,
+                "template_vars": {},
+                "visibility": "normal",
+            }
+            with mock.patch.object(backend_app, "get_bot_user_id", return_value="bot-user-1"), mock.patch.object(
+                backend_app, "_resolve_twitch_token_subject_id", return_value="bot-user-1"
+            ), mock.patch("backend_app.requests.post") as mock_send:
+                sent = backend_app._send_eventsub_chat_reply(
+                    db,
+                    channel,
+                    reply,
+                    reply_parent_message_id="event-message-id-over-limit",
+                )
+                self.assertFalse(sent)
+                self.assertEqual(mock_send.call_count, 0)
         finally:
             db.close()
 


### PR DESCRIPTION
### Motivation
- Prevent guaranteed-400 retries when sending webhook-initiated chat replies by validating inputs and token subject before calling Twitch `POST /helix/chat/messages`.
- Ensure replies are threaded to the authoritative chat event `event.message_id` (when present) rather than the EventSub transport header id.
- Fail-fast on deterministic payload issues (missing fields, message length, token mismatches) and emit explicit reason codes so callers/operators can triage without retry storms.

### Description
- Added `TWITCH_SEND_CHAT_MESSAGE_MAX_LENGTH = 500` constant and three helpers: `_resolve_twitch_token_subject_id`, `_build_eventsub_chat_reply_payload`, and `_preflight_eventsub_chat_reply_payload` to perform deterministic input checks and token-subject validation.
- Updated `_send_eventsub_chat_reply` to run the preflight, skip the HTTP call on preflight failures (emitting metrics/logs), and to stop retrying on Twitch 4xx responses while preserving retries for transient network errors.
- Switched reply threading to prefer `event.message_id` from the EventSub chat payload and omit `reply_parent_message_id` when that field is missing inside `_process_eventsub_chat_notification`.
- Updated documentation in `docs/README.md` and `docs/backend_api.md` to describe the new preflight guards, reply-threading source, and emitted failure reason codes.
- Added unit tests in `tests/test_channel_events.py` to cover: event payload message id threading, omission when `event.message_id` is missing, sender/token-subject mismatch skipping sends, and invalid message length skipping sends; and adjusted an existing authoritative-path test to mock the new token-subject resolver.

### Testing
- `python -m py_compile backend_app.py tests/test_channel_events.py` succeeded (syntax/compile check passed).
- A targeted `pytest` run was attempted but test collection failed in this environment due to SQLite access (`sqlite3.OperationalError: unable to open database file`), so full test execution could not be completed here.
- Static/quick checks (file diffs, commits) were performed and the changes were committed to the branch (commit id `1242263`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cd430aee848328b41a2b2ddc1ed5f4)