### PR TITLE
EventSub chat reply diagnostics: map 400 reasons, sanitize Twitch errors, adjust retry policy, and expose counters

### DIFF
--- a/backend_app.py
+++ b/backend_app.py
@@ -209,12 +209,26 @@ _INGRESS_METRICS: dict[str, Any] = {
     "reply_sent_count": 0,
     "reply_suppressed_count": 0,
     "send_api_failure_count": 0,
+    "send_api_failure_reasons": {
+        "invalid_reply_parent_message_id": 0,
+        "sender_token_mismatch": 0,
+        "invalid_sender_broadcaster_relation": 0,
+        "empty_or_invalid_message": 0,
+        "unknown_400": 0,
+        "transient_5xx": 0,
+        "timeout": 0,
+        "request_exception_non_timeout": 0,
+        "preflight_rejected": 0,
+    },
     "shard_status_transitions": {},
     "last_errors": {
         "signature_failure_at": None,
         "callback_4xx_at": None,
         "callback_5xx_at": None,
         "guard_degraded_at": None,
+        "send_api_failure_at": None,
+        "send_api_failure_reason_code": None,
+        "send_api_failure_snippet": None,
     },
     "callback_events": [],
 }
@@ -939,7 +953,15 @@ def _ingress_guard_thresholds() -> dict[str, float]:
 
 
 def _record_ingress_metric(metric: str, *, key: Optional[str] = None, timestamp: Optional[datetime] = None) -> None:
-    """Update in-memory ingress telemetry counters used by health diagnostics."""
+    """Update in-memory ingress telemetry counters used by health diagnostics.
+
+    Dependencies: Uses ``datetime.utcnow`` and guarded shared state
+    ``_INGRESS_METRICS`` protected by ``_INGRESS_METRICS_LOCK``.
+    Code customers: EventSub callback handlers, reply send path diagnostics, and
+    ``/system/health`` ingress summary generation.
+    Used variables/origin: ``metric`` and optional ``key`` come from ingress
+    processing branches (callback classes, reply send outcomes, guard events).
+    """
 
     now = timestamp or datetime.utcnow()
     with _INGRESS_METRICS_LOCK:
@@ -966,6 +988,10 @@ def _record_ingress_metric(metric: str, *, key: Optional[str] = None, timestamp:
             _INGRESS_METRICS["reply_suppressed_count"] = int(_INGRESS_METRICS.get("reply_suppressed_count", 0)) + 1
         elif metric == "send_api_failure":
             _INGRESS_METRICS["send_api_failure_count"] = int(_INGRESS_METRICS.get("send_api_failure_count", 0)) + 1
+            _INGRESS_METRICS["last_errors"]["send_api_failure_at"] = now
+        elif metric == "send_api_failure_reason" and key:
+            reasons = _INGRESS_METRICS["send_api_failure_reasons"]
+            reasons[key] = int(reasons.get(key, 0)) + 1
         elif metric == "shard_status_transition" and key:
             transitions = _INGRESS_METRICS["shard_status_transitions"]
             transitions[key] = int(transitions.get(key, 0)) + 1
@@ -978,7 +1004,14 @@ def _record_ingress_metric(metric: str, *, key: Optional[str] = None, timestamp:
 
 
 def _ingress_metrics_snapshot(now: datetime) -> dict[str, Any]:
-    """Return compact ingress telemetry for ``/system/health`` diagnostics."""
+    """Return compact ingress telemetry for ``/system/health`` diagnostics.
+
+    Dependencies: Reads ``_INGRESS_METRICS`` under lock and ingress guard
+    thresholds from ``_ingress_guard_thresholds``.
+    Code customers: ``/system/health`` endpoint and ingress guard evaluators.
+    Used variables/origin: ``now`` originates from runtime clock and scopes the
+    rolling callback throughput window.
+    """
 
     with _INGRESS_METRICS_LOCK:
         thresholds = _ingress_guard_thresholds()
@@ -997,6 +1030,7 @@ def _ingress_metrics_snapshot(now: datetime) -> dict[str, Any]:
             "reply_sent_count": int(_INGRESS_METRICS["reply_sent_count"]),
             "reply_suppressed_count": int(_INGRESS_METRICS["reply_suppressed_count"]),
             "send_api_failure_count": int(_INGRESS_METRICS["send_api_failure_count"]),
+            "send_api_failure_reasons": dict(_INGRESS_METRICS["send_api_failure_reasons"]),
             "shard_status_transitions": dict(_INGRESS_METRICS["shard_status_transitions"]),
             "last_errors": dict(_INGRESS_METRICS["last_errors"]),
             "recent_callback_throughput": {
@@ -1613,6 +1647,81 @@ def _preflight_eventsub_chat_reply_payload(
     return payload, None, headers
 
 
+def _sanitize_send_api_diagnostic_snippet(value: Any, *, max_len: int = 220) -> str:
+    """Normalize Twitch API diagnostics into a compact log-safe string snippet.
+
+    Dependencies: Pure string manipulation only.
+    Code customers: ``_extract_send_api_error_details`` and reply failure logs.
+    Used variables/origin: ``value`` originates from Twitch error fields
+    (``message``, ``error``, ``status``) or fallback response body text.
+    """
+
+    text = " ".join(str(value or "").split())
+    if len(text) <= max_len:
+        return text
+    return f"{text[:max_len - 3]}..."
+
+
+def _extract_send_api_error_details(response: Optional[requests.Response]) -> tuple[Optional[int], str, str]:
+    """Extract status, reason code, and sanitized diagnostic snippet from Twitch error responses.
+
+    Dependencies: Parses ``requests.Response`` JSON/body best-effort and maps
+    deterministic 400-series validation failures through
+    ``_map_send_api_400_reason_code``.
+    Code customers: ``_send_eventsub_chat_reply`` retry and telemetry logic.
+    Used variables/origin: ``response`` comes from Twitch Send Chat Message API
+    HTTP exceptions.
+    """
+
+    if response is None:
+        return None, "request_exception_non_timeout", ""
+    status_code = response.status_code
+    body_obj: dict[str, Any] = {}
+    try:
+        parsed = response.json()
+        if isinstance(parsed, dict):
+            body_obj = parsed
+    except ValueError:
+        body_obj = {}
+    message = _sanitize_send_api_diagnostic_snippet(body_obj.get("message"))
+    error = _sanitize_send_api_diagnostic_snippet(body_obj.get("error"))
+    body_status = body_obj.get("status")
+    status_text = _sanitize_send_api_diagnostic_snippet(body_status if body_status is not None else status_code)
+    if not any((message, error)):
+        fallback_text = _sanitize_send_api_diagnostic_snippet(response.text)
+        if fallback_text:
+            message = fallback_text
+    snippet = _sanitize_send_api_diagnostic_snippet(" | ".join(part for part in [f"status={status_text}", f"error={error}", f"message={message}"] if part))
+    reason_code = _map_send_api_400_reason_code(status_code=status_code, message=message, error=error) if status_code == 400 else (
+        "transient_5xx" if status_code >= 500 else f"http_{status_code}"
+    )
+    return status_code, reason_code, snippet
+
+
+def _map_send_api_400_reason_code(*, status_code: Optional[int], message: str, error: str) -> str:
+    """Map Twitch Send Chat API 400 diagnostics to stable reason-code classes.
+
+    Dependencies: Pure string matching; no external services.
+    Code customers: ``_extract_send_api_error_details`` and ingress summary
+    counters for deterministic 400 troubleshooting.
+    Used variables/origin: ``message``/``error`` strings originate from Twitch
+    JSON error payload fields.
+    """
+
+    if status_code != 400:
+        return "unknown_400"
+    corpus = f"{message} {error}".lower()
+    if "reply_parent_message_id" in corpus or ("reply" in corpus and "parent" in corpus):
+        return "invalid_reply_parent_message_id"
+    if ("sender_id" in corpus and "token" in corpus) or ("sender" in corpus and "does not match" in corpus):
+        return "sender_token_mismatch"
+    if ("sender_id" in corpus and "broadcaster" in corpus) or ("sender" in corpus and "broadcaster" in corpus):
+        return "invalid_sender_broadcaster_relation"
+    if "message" in corpus and any(term in corpus for term in ("empty", "invalid", "must not", "length", "between")):
+        return "empty_or_invalid_message"
+    return "unknown_400"
+
+
 def _send_eventsub_chat_reply(db: Session, channel: ActiveChannel, reply: dict[str, Any], *, reply_parent_message_id: Optional[str]) -> bool:
     """Send webhook reply text through Twitch Send Chat Message API with retries.
 
@@ -1643,6 +1752,7 @@ def _send_eventsub_chat_reply(db: Session, channel: ActiveChannel, reply: dict[s
     )
     if preflight_reason_code or not payload or not headers:
         _record_ingress_metric("send_api_failure")
+        _record_ingress_metric("send_api_failure_reason", key="preflight_rejected")
         logger.warning(
             "Webhook reply send skipped by preflight: reason_code=%s channel=%s template_key=%s",
             preflight_reason_code or "preflight_unknown_failure",
@@ -1664,15 +1774,35 @@ def _send_eventsub_chat_reply(db: Session, channel: ActiveChannel, reply: dict[s
             return True
         except requests.HTTPError as exc:
             _record_ingress_metric("send_api_failure")
-            status_code = exc.response.status_code if exc.response is not None else None
+            status_code, reason_code, diagnostic_snippet = _extract_send_api_error_details(exc.response)
+            with _INGRESS_METRICS_LOCK:
+                _INGRESS_METRICS["last_errors"]["send_api_failure_reason_code"] = reason_code
+                _INGRESS_METRICS["last_errors"]["send_api_failure_snippet"] = diagnostic_snippet
+            _record_ingress_metric("send_api_failure_reason", key=reason_code)
             if status_code is not None and 400 <= status_code < 500:
                 logger.warning(
-                    "Webhook reply send failed without retry: reason_code=api_4xx_response status_code=%s channel=%s template_key=%s",
+                    "Webhook reply send failed without retry: reason_code=%s status_code=%s channel=%s template_key=%s twitch_error=%s",
+                    reason_code,
                     status_code,
                     channel.channel_name,
                     reply.get("template_key"),
+                    diagnostic_snippet,
                 )
                 return False
+            if attempt == 2:
+                logger.exception(
+                    "Webhook reply send failed after retries: reason_code=%s status_code=%s twitch_error=%s",
+                    reason_code,
+                    status_code,
+                    diagnostic_snippet,
+                    extra={"channel": channel.channel_name, "template_key": reply.get("template_key")},
+                )
+                return False
+            time.sleep(delay_seconds)
+            delay_seconds *= 2
+        except requests.Timeout:
+            _record_ingress_metric("send_api_failure")
+            _record_ingress_metric("send_api_failure_reason", key="timeout")
             if attempt == 2:
                 logger.exception(
                     "Webhook reply send failed after retries",
@@ -1683,14 +1813,13 @@ def _send_eventsub_chat_reply(db: Session, channel: ActiveChannel, reply: dict[s
             delay_seconds *= 2
         except requests.RequestException:
             _record_ingress_metric("send_api_failure")
-            if attempt == 2:
-                logger.exception(
-                    "Webhook reply send failed after retries",
-                    extra={"channel": channel.channel_name, "template_key": reply.get("template_key")},
-                )
-                return False
-            time.sleep(delay_seconds)
-            delay_seconds *= 2
+            _record_ingress_metric("send_api_failure_reason", key="request_exception_non_timeout")
+            logger.warning(
+                "Webhook reply send failed without retry: reason_code=request_exception_non_timeout channel=%s template_key=%s",
+                channel.channel_name,
+                reply.get("template_key"),
+            )
+            return False
     return False
 
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -99,7 +99,8 @@ unlocks the API for the bot, queue manager, and public web frontend.
   - `GET /system/health` reports global conduit assignment coverage.
   - `GET /system/health.eventsub.ingress_summary` adds compact runtime counters:
     callback 2xx/4xx/5xx, signature failures, dedupe hits, per-channel command
-    dispatch outcomes, shard status transitions, and last error timestamps.
+    dispatch outcomes, shard status transitions, Send Chat API failure reasons
+    (including mapped 400 validation classes), and last error timestamps.
   - `GET /system/health.eventsub.authoritative_guard` reports degradation
     reasons and whether auto-fallback was applied.
   - `GET /channels/{channel}/eventsub/health` reports per-channel shard

--- a/docs/backend_api.md
+++ b/docs/backend_api.md
@@ -32,9 +32,12 @@ This document summarizes the REST endpoints exposed by `backend_app.py`.
   - callback status buckets (`2xx/4xx/5xx`),
   - signature failures,
   - dedupe hits,
+  - Send Chat API failure reason counters (`invalid_reply_parent_message_id`,
+    `sender_token_mismatch`, `invalid_sender_broadcaster_relation`,
+    `empty_or_invalid_message`, `unknown_400`, transient classes),
   - per-channel webhook command dispatch outcomes,
   - conduit shard status transitions,
-  - recent callback throughput + last error timestamps.
+  - recent callback throughput + last error timestamps/diagnostic snippets.
 - `eventsub.authoritative_guard` includes degradation reasons (`missing_healthy_shards`, `callback_errors_spike`) and whether fallback was applied.
 - Recommended operator thresholds:
   - callback error threshold: 5 errors / 5 minutes,

--- a/tests/test_channel_events.py
+++ b/tests/test_channel_events.py
@@ -6,6 +6,7 @@ from fastapi.testclient import TestClient
 import hashlib
 import hmac
 import json
+import requests
 
 import backend_app
 
@@ -1131,6 +1132,70 @@ class ChannelEventTests(unittest.TestCase):
         finally:
             db.close()
 
+    def test_send_eventsub_chat_reply_400_maps_reason_and_skips_retry(self) -> None:
+        """Map deterministic Twitch 400 reply diagnostics and avoid retries."""
+
+        details = _setup_channel()
+        db = backend_app.SessionLocal()
+        try:
+            channel = db.get(backend_app.ActiveChannel, details["channel_pk"])
+            self.assertIsNotNone(channel)
+            reply = {"status": "success", "template_key": "queue_open", "template_vars": {}, "visibility": "normal"}
+
+            response = requests.Response()
+            response.status_code = 400
+            response._content = b'{"error":"Bad Request","status":400,"message":"reply_parent_message_id is invalid"}'
+            error = requests.HTTPError(response=response)
+            with mock.patch.object(backend_app, "get_bot_user_id", return_value="bot-user-1"), mock.patch.object(
+                backend_app, "_resolve_twitch_token_subject_id", return_value="bot-user-1"
+            ), mock.patch("backend_app.requests.post", side_effect=error) as mock_send:
+                sent = backend_app._send_eventsub_chat_reply(
+                    db,
+                    channel,
+                    reply,
+                    reply_parent_message_id="bad-parent-id",
+                )
+            self.assertFalse(sent)
+            self.assertEqual(mock_send.call_count, 1)
+            snapshot = backend_app._ingress_metrics_snapshot(backend_app.datetime.utcnow())
+            reasons = snapshot.get("send_api_failure_reasons") or {}
+            self.assertGreaterEqual(reasons.get("invalid_reply_parent_message_id", 0), 1)
+        finally:
+            db.close()
+
+    def test_send_eventsub_chat_reply_5xx_retries_and_tracks_transient_reason(self) -> None:
+        """Retry transient Send Chat API failures and classify reason as transient 5xx."""
+
+        details = _setup_channel()
+        db = backend_app.SessionLocal()
+        try:
+            channel = db.get(backend_app.ActiveChannel, details["channel_pk"])
+            self.assertIsNotNone(channel)
+            reply = {"status": "success", "template_key": "queue_open", "template_vars": {}, "visibility": "normal"}
+
+            response = requests.Response()
+            response.status_code = 503
+            response._content = b'{"error":"Service Unavailable","status":503,"message":"server overloaded"}'
+            error = requests.HTTPError(response=response)
+            with mock.patch.object(backend_app, "get_bot_user_id", return_value="bot-user-1"), mock.patch.object(
+                backend_app, "_resolve_twitch_token_subject_id", return_value="bot-user-1"
+            ), mock.patch("backend_app.requests.post", side_effect=error) as mock_send, mock.patch(
+                "backend_app.time.sleep", return_value=None
+            ):
+                sent = backend_app._send_eventsub_chat_reply(
+                    db,
+                    channel,
+                    reply,
+                    reply_parent_message_id="parent-id",
+                )
+            self.assertFalse(sent)
+            self.assertEqual(mock_send.call_count, 3)
+            snapshot = backend_app._ingress_metrics_snapshot(backend_app.datetime.utcnow())
+            reasons = snapshot.get("send_api_failure_reasons") or {}
+            self.assertGreaterEqual(reasons.get("transient_5xx", 0), 1)
+        finally:
+            db.close()
+
     def test_eventsub_chat_notification_shadow_mode_request_does_not_mutate_queue(self) -> None:
         """Keep webhook chat commands parse-only when shadow mode is enabled."""
 
@@ -1514,6 +1579,7 @@ class ChannelEventTests(unittest.TestCase):
             backend_app._record_ingress_metric("callback_status", key="2xx")
             backend_app._record_ingress_metric("callback_status", key="4xx")
             backend_app._record_ingress_metric("signature_failure")
+            backend_app._record_ingress_metric("send_api_failure_reason", key="unknown_400")
         finally:
             db.close()
 
@@ -1525,6 +1591,7 @@ class ChannelEventTests(unittest.TestCase):
         self.assertGreaterEqual((summary.get("callback_status") or {}).get("2xx", 0), 1)
         self.assertGreaterEqual((summary.get("callback_status") or {}).get("4xx", 0), 1)
         self.assertGreaterEqual(summary.get("signature_failures", 0), 1)
+        self.assertGreaterEqual((summary.get("send_api_failure_reasons") or {}).get("unknown_400", 0), 1)
 
     def test_ingress_guard_degradation_can_auto_fallback_websocket_mode(self) -> None:
         """Auto-fallback to websocket mode when authoritative ingress is degraded."""


### PR DESCRIPTION
### Motivation
- Provide precise diagnostics when Twitch Send Chat Message returns non-2xx so operators can see which exact 400 validation class is occurring. 
- Avoid retrying deterministic 4xx validation failures while preserving retries for transient 5xx/timeouts. 
- Surface per-reason counters and last-error snippets in the `/system/health` ingress summary so the health endpoint immediately reports reply-failure classes.

### Description
- Add per-reason counters and last-error fields to `_INGRESS_METRICS` and expose `send_api_failure_reasons` via `_ingress_metrics_snapshot` for `/system/health` output. 
- Introduce `_sanitize_send_api_diagnostic_snippet`, `_extract_send_api_error_details`, and `_map_send_api_400_reason_code` to parse Twitch JSON (`message`, `error`, `status`), produce a sanitized snippet, and map 400 diagnostics into stable reason codes (`invalid_reply_parent_message_id`, `sender_token_mismatch`, `invalid_sender_broadcaster_relation`, `empty_or_invalid_message`, `unknown_400`). 
- Update `_send_eventsub_chat_reply` to record mapped reason codes and snippets, not retry deterministic 4xx errors, retry transient 5xx/timeouts, and increment the new ingress counters accordingly. 
- Add tests verifying 400 mapping/no-retry, 5xx retry classification, and health-summary exposure, and update docs (`docs/backend_api.md`, `docs/README.md`) to document new ingress summary counters and diagnostics.

### Testing
- Added unit tests `test_send_eventsub_chat_reply_400_maps_reason_and_skips_retry`, `test_send_eventsub_chat_reply_5xx_retries_and_tracks_transient_reason`, and updated `test_system_health_reports_ingress_summary_metrics`; these exercises the new mapping, retry, and health exposure logic. 
- Ran targeted pytest in this environment but test collection failed during import due to database bootstrap: `sqlite3.OperationalError: unable to open database file`, so the new tests could not be executed to completion. 
- A prior attempt without `PYTHONPATH` produced a `ModuleNotFoundError: No module named 'backend_app'`, so test invocation in CI/environment must ensure correct PYTHONPATH and accessible DB file for successful execution.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cd45aa0d248328b899e1cf34cf2fff)