### PR TITLE
Support YouTube URL requests in EventSub request command

### DIFF
--- a/backend_app.py
+++ b/backend_app.py
@@ -1902,6 +1902,44 @@ def _send_eventsub_chat_reply(db: Session, channel: ActiveChannel, reply: dict[s
     return False
 
 
+def _fetch_youtube_oembed_title(url: str) -> Optional[str]:
+    """Fetch a YouTube title through oEmbed for webhook request command parity.
+
+    Dependencies: outbound HTTP via ``requests.get`` to YouTube oEmbed.
+    Code customers: ``_eventsub_execute_request_command``.
+    Used variables/origin: ``url`` is derived from chat command args after
+    canonical video URL parsing.
+    """
+
+    oembed_url = f"https://www.youtube.com/oembed?url={url}&format=json"
+    try:
+        response = requests.get(oembed_url, timeout=8)
+        response.raise_for_status()
+        payload = response.json()
+    except (requests.RequestException, ValueError):
+        return None
+    title = payload.get("title")
+    if isinstance(title, str):
+        normalized = title.strip()
+        return normalized or None
+    return None
+
+
+def _parse_artist_title_loose(raw: str) -> tuple[str, str]:
+    """Parse request text as ``Artist - Title`` with websocket-compatible fallback.
+
+    Dependencies: none.
+    Code customers: ``_eventsub_execute_request_command``.
+    Used variables/origin: ``raw`` comes from request chat args or oEmbed title.
+    """
+
+    candidate = (raw or "").strip()
+    if " - " in candidate:
+        artist, title = candidate.split(" - ", 1)
+        return artist.strip(), title.strip()
+    return "Unknown", candidate
+
+
 def _eventsub_execute_request_command(
     db: Session,
     channel: ActiveChannel,
@@ -1938,24 +1976,8 @@ def _eventsub_execute_request_command(
                 )
             },
         )
-    artist, sep, title = request_text.partition("-")
-    artist_name = artist.strip()
-    title_name = title.strip() if sep else ""
-    if not artist_name or not title_name:
-        return _eventsub_outcome(
-            "rejected",
-            command="request",
-            reason_code="invalid_args",
-            detail="expected format: artist - title",
-            metadata={
-                "response": _eventsub_response_contract(
-                    "error",
-                    template_key="failed",
-                    template_vars={"error": "expected format: artist - title"},
-                    visibility="normal",
-                )
-            },
-        )
+    request_url, request_video_id = _canonicalize_video_url(request_text, None)
+    request_is_youtube_url = bool(request_video_id)
 
     channel_pk = channel.id
     user = _get_or_create_channel_user(db, channel_pk, chatter_user_id, chatter_login)
@@ -1963,19 +1985,37 @@ def _eventsub_execute_request_command(
     settings = get_or_create_settings(db, channel_pk)
     enforce_queue_limits(db, channel_pk, user.id, False)
     stream_id = current_stream(db, channel_pk)
-    song = (
-        db.query(Song)
-        .filter(
-            Song.channel_id == channel_pk,
-            func.lower(Song.artist) == artist_name.lower(),
-            func.lower(Song.title) == title_name.lower(),
+    song: Optional[Song] = None
+    if request_is_youtube_url and request_url:
+        song = (
+            db.query(Song)
+            .filter(
+                Song.channel_id == channel_pk,
+                Song.youtube_link == request_url,
+            )
+            .one_or_none()
         )
-        .one_or_none()
-    )
-    if not song:
-        song = Song(channel_id=channel_pk, artist=artist_name, title=title_name, youtube_link=None)
-        db.add(song)
-        db.flush()
+        if not song:
+            extracted_title = _fetch_youtube_oembed_title(request_url)
+            artist_name, title_name = _parse_artist_title_loose(extracted_title) if extracted_title else ("YouTube", request_url)
+            song = Song(channel_id=channel_pk, artist=artist_name, title=title_name, youtube_link=request_url)
+            db.add(song)
+            db.flush()
+    else:
+        artist_name, title_name = _parse_artist_title_loose(request_text)
+        song = (
+            db.query(Song)
+            .filter(
+                Song.channel_id == channel_pk,
+                func.lower(Song.artist) == artist_name.lower(),
+                func.lower(Song.title) == title_name.lower(),
+            )
+            .one_or_none()
+        )
+        if not song:
+            song = Song(channel_id=channel_pk, artist=artist_name, title=title_name, youtube_link=None)
+            db.add(song)
+            db.flush()
     actor_ctx = actor or {}
     is_priority, priority_source = _apply_priority_to_new_request(
         db,

--- a/docs/README.md
+++ b/docs/README.md
@@ -309,7 +309,7 @@ Expected:
   so future per-command/per-message template or level customization can be
   rolled out without refactoring dispatch logic.
 - Supports commands:
-  - `!request` – add a song request.
+  - `!request` – add a song request from either a direct YouTube URL or free-form text (`Artist - Title` preferred, plain title falls back to `Unknown - <title>`).
   - `!playlist <name> <index>` – queue a song from a saved playlist by position.
   - `!prioritize` – bump one of your requests using priority points.
   - `!points` – check remaining priority points.

--- a/tests/test_channel_events.py
+++ b/tests/test_channel_events.py
@@ -931,6 +931,150 @@ class ChannelEventTests(unittest.TestCase):
         finally:
             db.close()
 
+    def test_eventsub_chat_notification_authoritative_request_accepts_youtube_url(self) -> None:
+        """Accept direct YouTube URLs and derive artist/title from oEmbed title text."""
+
+        details = _setup_channel()
+        secret = "chatsecret-authoritative-url"
+        conduit_id = "conduit-chat-authoritative-url"
+        shard_id = "4"
+        subscription_id = "sub-chat-authoritative-url"
+        db = backend_app.SessionLocal()
+        try:
+            backend_app.set_settings(db, {"chat_ingress_mode": "webhook_conduit", "chat_ingress_shadow_mode": "0"})
+        finally:
+            db.close()
+        _create_chat_conduit_subscription(
+            details["channel_pk"],
+            subscription_id=subscription_id,
+            conduit_id=conduit_id,
+            shard_id=shard_id,
+            secret=secret,
+        )
+
+        body = {
+            "subscription": {
+                "id": subscription_id,
+                "type": "channel.chat.message",
+                "status": "enabled",
+                "version": "1",
+                "condition": {"broadcaster_user_id": "cid"},
+                "transport": {"method": "conduit", "conduit_id": conduit_id},
+            },
+            "event": {
+                "chatter_user_id": "webhook-user-url",
+                "chatter_user_login": "webhookuserurl",
+                "message": {"text": "!request https://youtu.be/TvZskcqdYcE"},
+            },
+        }
+        raw = json.dumps(body).encode()
+        message_id = "msg-chat-authoritative-url"
+        timestamp = "2023-01-01T00:00:00Z"
+        signature = hmac.new(secret.encode(), msg=(message_id + timestamp).encode() + raw, digestmod=hashlib.sha256)
+        with mock.patch.object(backend_app, "_fetch_youtube_oembed_title", return_value="Artist D - Song Four"), mock.patch.object(
+            backend_app, "get_bot_user_id", return_value="bot-user-1"
+        ), mock.patch.object(backend_app, "_resolve_twitch_token_subject_id", return_value="bot-user-1"), mock.patch(
+            "backend_app.requests.post"
+        ) as mock_send:
+            mock_send.return_value.raise_for_status.return_value = None
+            response = self.client.post(
+                "/twitch/eventsub/callback",
+                data=raw,
+                headers={
+                    "Twitch-Eventsub-Message-Id": message_id,
+                    "Twitch-Eventsub-Message-Timestamp": timestamp,
+                    "Twitch-Eventsub-Message-Signature": f"sha256={signature.hexdigest()}",
+                    "Twitch-Eventsub-Message-Type": "notification",
+                },
+            )
+            self.assertEqual(mock_send.call_count, 1)
+            payload = mock_send.call_args.kwargs["json"]
+            self.assertEqual(payload["message"], "Added: Artist D - Song Four")
+        self.assertEqual(response.status_code, 200, response.text)
+
+        db = backend_app.SessionLocal()
+        try:
+            rows = db.query(backend_app.Request).filter(backend_app.Request.channel_id == details["channel_pk"]).all()
+            self.assertEqual(len(rows), 1)
+            song = db.get(backend_app.Song, rows[0].song_id)
+            self.assertIsNotNone(song)
+            self.assertEqual(song.artist, "Artist D")
+            self.assertEqual(song.title, "Song Four")
+            self.assertEqual(song.youtube_link, "https://www.youtube.com/watch?v=TvZskcqdYcE")
+        finally:
+            db.close()
+
+    def test_eventsub_chat_notification_authoritative_request_plain_title_fallback(self) -> None:
+        """Treat plain non-URL request text as valid and fall back to Unknown artist."""
+
+        details = _setup_channel()
+        secret = "chatsecret-authoritative-fallback"
+        conduit_id = "conduit-chat-authoritative-fallback"
+        shard_id = "5"
+        subscription_id = "sub-chat-authoritative-fallback"
+        db = backend_app.SessionLocal()
+        try:
+            backend_app.set_settings(db, {"chat_ingress_mode": "webhook_conduit", "chat_ingress_shadow_mode": "0"})
+        finally:
+            db.close()
+        _create_chat_conduit_subscription(
+            details["channel_pk"],
+            subscription_id=subscription_id,
+            conduit_id=conduit_id,
+            shard_id=shard_id,
+            secret=secret,
+        )
+
+        body = {
+            "subscription": {
+                "id": subscription_id,
+                "type": "channel.chat.message",
+                "status": "enabled",
+                "version": "1",
+                "condition": {"broadcaster_user_id": "cid"},
+                "transport": {"method": "conduit", "conduit_id": conduit_id},
+            },
+            "event": {
+                "chatter_user_id": "webhook-user-fallback",
+                "chatter_user_login": "webhookuserfallback",
+                "message": {"text": "!request Song Without Dash"},
+            },
+        }
+        raw = json.dumps(body).encode()
+        message_id = "msg-chat-authoritative-fallback"
+        timestamp = "2023-01-01T00:00:00Z"
+        signature = hmac.new(secret.encode(), msg=(message_id + timestamp).encode() + raw, digestmod=hashlib.sha256)
+        with mock.patch.object(backend_app, "get_bot_user_id", return_value="bot-user-1"), mock.patch.object(
+            backend_app, "_resolve_twitch_token_subject_id", return_value="bot-user-1"
+        ), mock.patch("backend_app.requests.post") as mock_send:
+            mock_send.return_value.raise_for_status.return_value = None
+            response = self.client.post(
+                "/twitch/eventsub/callback",
+                data=raw,
+                headers={
+                    "Twitch-Eventsub-Message-Id": message_id,
+                    "Twitch-Eventsub-Message-Timestamp": timestamp,
+                    "Twitch-Eventsub-Message-Signature": f"sha256={signature.hexdigest()}",
+                    "Twitch-Eventsub-Message-Type": "notification",
+                },
+            )
+            self.assertEqual(mock_send.call_count, 1)
+            payload = mock_send.call_args.kwargs["json"]
+            self.assertEqual(payload["message"], "Added: Unknown - Song Without Dash")
+        self.assertEqual(response.status_code, 200, response.text)
+
+        db = backend_app.SessionLocal()
+        try:
+            rows = db.query(backend_app.Request).filter(backend_app.Request.channel_id == details["channel_pk"]).all()
+            self.assertEqual(len(rows), 1)
+            song = db.get(backend_app.Song, rows[0].song_id)
+            self.assertIsNotNone(song)
+            self.assertEqual(song.artist, "Unknown")
+            self.assertEqual(song.title, "Song Without Dash")
+            self.assertIsNone(song.youtube_link)
+        finally:
+            db.close()
+
     def test_eventsub_chat_notification_reply_parent_uses_event_message_id(self) -> None:
         """Send replies threaded to ``event.message_id`` instead of header message id."""
 


### PR DESCRIPTION
### Motivation
- Bring EventSub webhook request handling into parity with the websocket path by accepting direct YouTube URLs and by providing the same loose `Artist - Title` fallback parsing. 
- Allow `!request` to accept a URL or plain text without rejecting inputs that are valid but not strictly `Artist - Title` formatted. 

### Description
- Added `_fetch_youtube_oembed_title(url: str)` to resolve YouTube titles via oEmbed for EventSub flows and documented its dependencies and usage. 
- Added `_parse_artist_title_loose(raw: str)` which mirrors websocket parsing semantics (prefer `Artist - Title`, otherwise return `Unknown - <raw>`). 
- Updated `_eventsub_execute_request_command` to detect YouTube URLs using existing `_canonicalize_video_url`, look up songs by `youtube_link`, create song rows with the canonical URL and extracted title when needed, and fall back to `_parse_artist_title_loose` for non-URL inputs. 
- Updated `docs/README.md` to document that `!request` accepts direct YouTube URLs and that plain titles fall back to an `Unknown` artist. 
- Added EventSub-focused tests to `tests/test_channel_events.py` validating URL acceptance with oEmbed parsing and plain-title fallback behavior. 

### Testing
- Ran `python -m compileall backend_app.py tests/test_channel_events.py` which succeeded. 
- Attempted `PYTHONPATH=. pytest -q tests/test_channel_events.py -k "authoritative_request_mutates_queue or authoritative_request_accepts_youtube_url or authoritative_request_plain_title_fallback"` which failed during test collection due to the test environment being unable to open the configured SQLite database file (environmental issue), not due to the new logic itself. 
- New unit tests were added and are present in `tests/test_channel_events.py` for the URL and fallback cases; they are currently blocked from running in this container because of the DB path issue.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cd65c8da988328b9512531ffdbd2c9)