### PR TITLE
Keep websocket rollback smoke harness during migration window

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -235,8 +235,13 @@ Expected:
    - set `chat_websocket_fallback_legacy_enabled=true`,
    - optionally switch `chat_ingress_mode=websocket` if operator policy
      requires immediate handoff.
+   - keep a minimal staging rollback smoke harness enabled for one additional
+     release window (toggle websocket mode + legacy fallback and verify at
+     least one end-to-end command such as `!request` still recovers).
 4. After stabilization, disable rollback flag again and restore
    `chat_ingress_mode=webhook_conduit`.
+5. Only remove websocket rollback harness/tests when product explicitly
+   confirms **no websocket rollback supported** (rollback EOL).
 
 ### Maintenance checklist
 - Verify bot/app token refreshes complete successfully each day.

--- a/docs/backend_api.md
+++ b/docs/backend_api.md
@@ -78,6 +78,12 @@ This document summarizes the REST endpoints exposed by `backend_app.py`.
 3. Rollback playbook:
    - Enable `chat_websocket_fallback_legacy_enabled=true` for immediate websocket subscription restore.
    - If required, switch `chat_ingress_mode=websocket`.
+   - Keep at least one rollback smoke check (`!request` or `!points`) active in
+     staging for one additional release window before deleting websocket test
+     fixtures.
+   - If product decision explicitly confirms **no websocket rollback supported**,
+     declare rollback EOL and remove both the smoke harness and websocket toggle
+     path together.
    - Re-run conduit reconcile + callback validation before returning to authoritative mode.
 
 ## Authentication

--- a/tests/test_bot_service.py
+++ b/tests/test_bot_service.py
@@ -318,6 +318,51 @@ class BotServiceTests(unittest.IsolatedAsyncioTestCase):
 
         self.assertFalse(song_bot._websocket_ingress_enabled)
 
+    async def test_sync_channels_keeps_websocket_rollback_smoke_harness_enabled(self) -> None:
+        """Keep minimal websocket rollback smoke coverage during migration window.
+
+        Dependencies: ``sync_channels`` ingress mode fetch and websocket
+        subscription scheduling behavior.
+        Code customers: release rollout validation that needs a staging rollback
+        harness while websocket fallback support remains undecided.
+        Used variables/origin: system config toggles
+        ``chat_ingress_mode=websocket`` and
+        ``chat_websocket_fallback_legacy_enabled=true``.
+        """
+
+        song_bot = bot_app.SongBot.__new__(bot_app.SongBot)
+        song_bot.channel_map = {}
+        song_bot.state = {}
+        song_bot.listeners = {}
+        song_bot.joined = set()
+        song_bot._sync_lock = asyncio.Lock()
+        song_bot.enabled = True
+        song_bot._announce_joined = AsyncMock()
+        song_bot._announce_left = AsyncMock()
+        song_bot.listen_backend = AsyncMock(return_value=None)
+        song_bot._subscribe_for_channel = AsyncMock()
+        song_bot._unsubscribe_channel = AsyncMock()
+        song_bot._send_message = AsyncMock()
+
+        self.backend.get_system_config = AsyncMock(
+            return_value={"chat_ingress_mode": "websocket", "chat_websocket_fallback_legacy_enabled": True}
+        )
+        self.backend.get_channels = AsyncMock(
+            return_value=[{"channel_name": "Foo", "channel_id": "1", "authorized": True, "join_active": 1}]
+        )
+        self.backend.get_queue = AsyncMock(return_value=[])
+
+        def fake_create_task(coro):
+            coro.close()
+            return MagicMock()
+
+        with patch.object(bot_app.asyncio, "create_task", fake_create_task), patch.object(bot_app, "push_console_event", AsyncMock()):
+            await song_bot.sync_channels()
+
+        self.assertTrue(song_bot._websocket_ingress_enabled)
+        song_bot._subscribe_for_channel.assert_any_await("1")
+        self.assertGreaterEqual(song_bot._subscribe_for_channel.await_count, 1)
+
     async def test_songbot_does_not_assign_readonly_nick(self) -> None:
         commands_map = {k: ([v] if not isinstance(v, list) else v) for k, v in bot_app.DEFAULT_COMMANDS.items()}
         with patch.object(bot_app.commands.Bot, "__init__", return_value=None):


### PR DESCRIPTION
### Motivation
- Preserve a minimal websocket rollback smoke harness in staging to validate at least one end-to-end command path while migrating authoritative chat ingress to webhook conduit.
- Make rollback explicit and operator-controlled (`chat_websocket_fallback_legacy_enabled`) and avoid removing websocket test fixtures until a product decision confirms rollback EOL.

### Description
- Add a new test `test_sync_channels_keeps_websocket_rollback_smoke_harness_enabled` in `tests/test_bot_service.py` that validates `SongBot.sync_channels` keeps websocket subscriptions active when `chat_ingress_mode=websocket` and `chat_websocket_fallback_legacy_enabled=true` are returned from system config.
- Adjust the test assertion to tolerate multiple awaits by using `assert_any_await` and checking `await_count` to avoid flakiness in task scheduling.
- Update operational docs in `docs/backend_api.md` and `docs/README.md` to require keeping at least one rollback smoke check in staging for one additional release window and to only remove the harness when product confirms “no websocket rollback supported”.

### Testing
- Ran `pytest -q tests/test_bot_service.py -k "rollback_smoke_harness_enabled or disables_websocket_subscriptions_in_authoritative_mode or event_message_routes_playlist_command"` and iterated after a failing assertion; final run yielded `3 passed, 17 deselected`.
- Test run emitted unrelated deprecation/warning messages but the targeted tests passed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ce99da5e448328bed68345a2ec2174)