### PR TITLE
docs: promote canonical EventSub architecture and add steady-state runbooks

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -13,6 +13,20 @@ Additional directories include:
 - **admin/** – static assets for the Admin control panel used to manage the shared bot account and view channel stats.
 - **data/** – persistent SQLite database storage.
 
+## Canonical chat architecture (steady state)
+The production architecture is now documented as a fixed three-stage flow:
+
+1. **Ingress**: Twitch EventSub webhook callbacks via conduit transport
+   (`/twitch/eventsub/callback`).
+2. **Execution**: shared chat command core (`command_resolution.py`) used by
+   both webhook and websocket paths to keep command semantics aligned.
+3. **Outbound**: Twitch Send Chat Message API (`POST /helix/chat/messages`) for
+   user-visible bot replies.
+
+Legacy websocket-only ingress is retained strictly as an explicit rollback path
+under `chat_websocket_fallback_legacy_enabled`; it is not the canonical steady
+state.
+
 ## Admin panel bot message controls
 - Channel detail cards in the Admin panel now include a dedicated **Bot Messages**
   tab beside **Custom Settings** and **Active Streams**.
@@ -88,15 +102,9 @@ unlocks the API for the bot, queue manager, and public web frontend.
     `chat_ingress_guard_callback_error_threshold`.
 - Startup import now validates ingress-guard symbol availability before running
   the guard so symbol-order regressions fail fast during process boot.
-- Migration `migrations/20260330_eventsub_conduits.sql` adds additive EventSub
-  replay/conduit tables (`eventsub_message_dedupe`, `twitch_conduits`,
-  `twitch_conduit_shards`) plus conduit linkage columns on
-  `event_subscriptions`.
 - Conduit shard metadata now persists `twitch_conduit_shards.transport_secret`
   so callback verification can validate Twitch conduit-shard challenges without
   requiring `subscription.id`.
-- Startup now includes a compatibility patch for the same tables/columns so
-  staggered deploys on legacy SQLite/prod databases continue booting safely.
 - EventSub health endpoints now include conduit + shard coverage summaries:
   - `GET /system/health` reports global conduit assignment coverage.
   - `GET /system/health.eventsub.ingress_summary` adds compact runtime counters:
@@ -212,6 +220,108 @@ unlocks the API for the bot, queue manager, and public web frontend.
     sends), while websocket remains authoritative.
   - With `chat_ingress_mode=webhook_conduit` and shadow mode disabled, webhook
     ingress is authoritative and performs real command execution/persistence.
+
+### Steady-state runbooks
+
+#### 1) Callback delivery failures (`/twitch/eventsub/callback`)
+**Symptoms**
+- Rising callback `4xx`/`5xx` counters in `GET /system/health` ingress summary.
+- Twitch retries for the same EventSub message IDs, or delayed command effects.
+
+**Dependencies**
+- Public HTTPS callback endpoint with exact path `/twitch/eventsub/callback`.
+- Valid callback secret lookup source (`event_subscriptions.secret` for classic
+  rows; `twitch_conduit_shards.transport_secret` for conduit shard callbacks).
+
+**Primary variables/origins to verify**
+- `eventsub_callback_override` (admin runtime source; highest precedence).
+- `public_backend_origin` (derived callback origin when override is unset).
+- Callback source metadata shown in reconciliation warnings (`eventsub_callback_override`, `public_backend_origin`, or `request_url`).
+
+**Procedure**
+1. `GET /system/health` and inspect callback status buckets + last error fields.
+2. `GET /channels/{channel}/eventsub/health?reconcile=true` to refresh callback
+   and shard registration status.
+3. If callback URL is invalid/degraded, update `eventsub_callback_override` to
+   an HTTPS public URL ending in `/twitch/eventsub/callback`.
+4. Re-run channel reconcile and confirm callback warnings clear.
+
+#### 2) Conduit shard degradation
+**Symptoms**
+- `eventsub.authoritative_guard` reports `missing_healthy_shards`.
+- Per-channel EventSub health reports incomplete shard assignment/coverage.
+
+**Dependencies**
+- Conduit assignment state persisted in `twitch_conduits` and
+  `twitch_conduit_shards`.
+- Guard thresholds in `/system/config` (minimum healthy shards + fallback flag).
+
+**Primary variables/origins to verify**
+- `chat_ingress_guard_min_healthy_shards`.
+- `chat_ingress_guard_auto_fallback_enabled`.
+- Per-channel shard status from `/channels/{channel}/eventsub/health`.
+
+**Procedure**
+1. Confirm degradation reason in `GET /system/health`.
+2. Reconcile affected channels with `?reconcile=true` and verify shard status
+   transitions settle to healthy coverage.
+3. If degradation persists and auto-fallback is disabled, manually enable
+   `chat_websocket_fallback_legacy_enabled=true` as rollback protection.
+4. Return to authoritative webhook mode only after shard coverage stabilizes.
+
+#### 3) Send Chat Message API `4xx`/`5xx` handling
+**Symptoms**
+- `send_api_failure_count` increases in ingress telemetry.
+- Reply outcomes show preflight/API reason codes (`sender_token_mismatch`,
+  `invalid_reply_parent_message_id`, `unknown_400`, transient failures).
+
+**Dependencies**
+- Valid bot OAuth token and `/oauth2/validate` subject match.
+- Non-empty `broadcaster_id`, `sender_id`, and reply payload length within
+  Twitch limits (`1-500` chars).
+
+**Primary variables/origins to verify**
+- `event.message_id` presence for reply threading origin.
+- Bot token subject (`sender_id`) versus configured bot account identity.
+- Message catalog visibility level (`bot_message_level`) if replies appear suppressed.
+
+**Procedure**
+1. Check `GET /system/health.eventsub.ingress_summary` failure reason counters.
+2. Separate deterministic `4xx` validation failures from transient `5xx`/network
+   classes before retry policy changes.
+3. Fix identity/payload mismatches first (`sender_id`, parent message ID,
+   message length).
+4. For transient classes, keep retries bounded and monitor recovery via
+   `reply_sent_count` versus `send_api_failure_count`.
+
+#### 4) Credential expiry remediation
+**Symptoms**
+- `401` from Twitch APIs (conduit registration or send chat).
+- Reconciliation/auth warnings indicating invalid or mismatched token context.
+
+**Dependencies**
+- App access token flow for conduit API + transport subscriptions.
+- Bot user token for Send Chat Message API calls.
+
+**Primary variables/origins to verify**
+- Twitch client credentials configured in setup (`client_id`, `client_secret`).
+- Bot OAuth configuration in `/bot/config`.
+- Token/client pairing validity (`/oauth2/validate` metadata).
+
+**Procedure**
+1. Validate app and bot tokens independently against Twitch validation endpoint.
+2. Re-run bot OAuth flow if bot token subject/scopes are stale or expired.
+3. Confirm conduit reconcile succeeds with app token auth.
+4. Confirm webhook command replies recover (Send API success + reduced 401s).
+
+## Archive: migration and compatibility notes
+- Migration `migrations/20260330_eventsub_conduits.sql` added additive EventSub
+  replay/conduit tables (`eventsub_message_dedupe`, `twitch_conduits`,
+  `twitch_conduit_shards`) plus conduit linkage columns on
+  `event_subscriptions`.
+- Startup includes a compatibility patch for those tables/columns so staggered
+  deploys on legacy SQLite/prod databases can boot before dedicated migration
+  rollout is completed.
 
 ### EventSub HTTPS callback pre-cutover check
 Use this before enabling `chat_ingress_mode=webhook_conduit` in production:

--- a/docs/backend_api.md
+++ b/docs/backend_api.md
@@ -2,6 +2,15 @@
 
 This document summarizes the REST endpoints exposed by `backend_app.py`.
 
+## Canonical chat architecture
+- **Ingress**: EventSub webhook + conduit transport on
+  `/twitch/eventsub/callback`.
+- **Execution**: shared chat command core used by webhook and websocket parsing
+  paths for consistent command semantics.
+- **Outbound**: Twitch Send Chat Message API (`POST /helix/chat/messages`) for
+  bot replies.
+
+
 ## System
 | Method | Path | Description |
 |--------|------|-------------|
@@ -28,7 +37,6 @@ This document summarizes the REST endpoints exposed by `backend_app.py`.
   - `chat_ingress_shadow_mode?: boolean`
   - `chat_websocket_fallback_legacy_enabled?: boolean`
   - `chat_ingress_guard_auto_fallback_enabled?: boolean`
-- **Compatibility note**: Startup includes additive schema patching for staggered deployments so older SQLite/prod DBs can run until the dedicated migration is applied.
 
 ### `/system/health` ingress summary
 - `eventsub.ingress_summary` includes compact operational counters:
@@ -199,11 +207,6 @@ Channel settings include queue intake controls:
 - `prio_only`, `max_requests_per_user`, `allow_bumps`, `other_flags`, and `max_prio_points` behave as before and are reflected in `settings.updated` events.
 - `bot_message_level` controls how chatty the bot is in channel responses; allowed values are exactly `mute`, `normal`, `verbose`, and `debug` (default `normal`).
 - Priority point pricing is configurable: `prio_follow_enabled`, `prio_raid_enabled`, `prio_bits_per_point`, `prio_gifts_per_point`, and per-tier fields (`prio_sub_tier1_points`, `prio_sub_tier2_points`, `prio_sub_tier3_points`) control how many points events grant. Reset bonuses (`prio_reset_points_tier1`, `prio_reset_points_tier2`, `prio_reset_points_tier3`, `prio_reset_points_vip`, `prio_reset_points_mod`) are awarded when the queue resets for a new stream. Use `free_mod_priority_requests` to allow moderators to request priority without spending points.
-- Existing deployments should apply `migrations/20240624_queue_caps.sql` to add the new capacity columns and backfill defaults for legacy channels; the application also attempts to patch missing columns on startup for SQLite/legacy installs before enforcing queue caps.
-- EventSub conduit/replay storage is added in `migrations/20260330_eventsub_conduits.sql`:
-  - `eventsub_message_dedupe` for message idempotency (`message_id`, `received_at`, unique message IDs).
-  - `twitch_conduits` and `twitch_conduit_shards` for conduit/shard sync state.
-  - additive `event_subscriptions.conduit_id` and `event_subscriptions.shard_id` linkage columns.
 
 ### Queue Manager unified bot dropdown API mapping
 - Queue Manager uses a single state-aware dropdown model with options:
@@ -221,6 +224,64 @@ Channel settings include queue intake controls:
   - `/channels/{channel}` accepts only `join_active` values `0` or `1`.
   - `/channels/{channel}/settings` keeps `bot_message_level` strict to enum
     values `mute|normal|verbose|debug`.
+
+## Steady-state runbooks
+
+### Callback failure runbook
+- **Description**: Recover EventSub callback delivery reliability when webhook
+  status buckets indicate persistent `4xx` or `5xx`.
+- **Dependencies**: Public HTTPS callback URL, callback secret resolution, and
+  successful per-channel reconciliation endpoint access.
+- **Code-customers**: On-call backend operators handling EventSub ingress
+  incidents and channel onboarding failures.
+- **Used variables/origin**:
+  - `eventsub_callback_override` (runtime config override).
+  - `public_backend_origin` (derived callback origin).
+  - `eventsub.ingress_summary` callback counters from `GET /system/health`.
+
+### Shard degradation runbook
+- **Description**: Restore healthy conduit shard coverage when guard health
+  reports `missing_healthy_shards`.
+- **Dependencies**: Conduit reconcile APIs, guard thresholds in `/system/config`,
+  and shard metadata persistence.
+- **Code-customers**: Operators supervising authoritative webhook ingest during
+  production incidents.
+- **Used variables/origin**:
+  - `chat_ingress_guard_min_healthy_shards`.
+  - `chat_ingress_guard_auto_fallback_enabled`.
+  - `/channels/{channel}/eventsub/health` shard assignment output.
+
+### Send API 4xx/5xx handling runbook
+- **Description**: Triage and remediate Send Chat Message API failures for
+  webhook command replies.
+- **Dependencies**: Valid bot identity token, preflight validation guard rails,
+  and ingress summary reason counters.
+- **Code-customers**: Bot/backend maintainers responsible for chat response SLOs.
+- **Used variables/origin**:
+  - `send_api_failure_count` / `reply_sent_count`.
+  - Send failure reason counters (`sender_token_mismatch`,
+    `invalid_reply_parent_message_id`, `unknown_400`, transient classes).
+  - `event.message_id` from EventSub payload for reply threading.
+
+### Credential expiry remediation runbook
+- **Description**: Recover from expired/invalid app or bot credentials impacting
+  EventSub reconciliation or Send API calls.
+- **Dependencies**: Twitch token validation, setup credentials, and bot OAuth
+  callback flow.
+- **Code-customers**: Platform operators rotating credentials or remediating auth outages.
+- **Used variables/origin**:
+  - Setup credentials in `/system/config` (`client_id`, `client_secret`).
+  - Bot auth state in `/bot/config`.
+  - Twitch `/oauth2/validate` responses for token subject/scope validation.
+
+## Archive: migration and compatibility notes
+- `migrations/20240624_queue_caps.sql` introduced queue capacity columns and
+  default backfill guidance for legacy deployments.
+- `migrations/20260330_eventsub_conduits.sql` introduced EventSub dedupe and
+  conduit/shard storage plus additive subscription linkage columns.
+- Startup compatibility patching for legacy SQLite/prod schemas remains a
+  historical rollout aid and should not be treated as a long-term migration
+  substitute.
 
 ## Songs
 | Method | Path | Description |


### PR DESCRIPTION
### Motivation
- Clarify and promote the EventSub + conduit path as the canonical chat ingress and document the three-stage steady-state architecture (ingress, execution core, outbound send API). 
- Remove migration/compatibility noise from the main operational sections so day-to-day runbooks focus on current-state behavior. 
- Provide on-call runbooks for the most common steady-state failure modes (callback failures, shard degradation, Send API errors, and credential expiry) so operators have reproducible remediation steps. 

### Description
- Added a canonical chat architecture section to `docs/README.md` and `docs/backend_api.md` that documents ingress = EventSub webhook + conduit, execution = shared `command_resolution.py` core, and outbound = Twitch Send Chat Message API. 
- Removed/relocated migration and compatibility bullets from the main operational text and consolidated them under explicit "Archive: migration and compatibility notes" sections. 
- Introduced a "Steady-state runbooks" area in both docs containing four runbooks (callback delivery failures, conduit shard degradation, Send Chat Message API 4xx/5xx handling, credential expiry remediation) that include descriptions, dependencies, primary variables/origins, and stepwise procedures. 
- Minor editorial alignment to health/ingress guidance and observability counters so the runbooks reference existing health endpoints and telemetry fields. 

### Testing
- Ran `git diff --check` to validate the patch for whitespace/conflict issues and it completed with no issues. 
- Verified presence of the new headings and sections using pattern searches (`rg`) and file inspections against `docs/README.md` and `docs/backend_api.md`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ceb7f9fc10832891a7c16b55f3d893)