### PR TITLE
Add websocket pruning ledger and archived deprecation rationale docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -355,6 +355,22 @@ Expected:
 5. Only remove websocket rollback harness/tests when product explicitly
    confirms **no websocket rollback supported** (rollback EOL).
 
+
+### Websocket-only pruning ledger policy
+- Every PR that removes websocket-only modules/functions/tests must append an
+  entry to `docs/websocket_pruning_ledger.md`.
+- Required entry fields:
+  1. removed modules/functions,
+  2. replacement path,
+  3. deprecation decision date,
+  4. rollback implications,
+  5. classification (`unused code removed` or `behavioral removal`), and
+  6. archived rationale link (`docs/archive/websocket_deprecation_rationale.md`).
+- Keep `unused code removed` entries even when removals are non-behavioral so
+  future audits can trace cleanup intent.
+- If code is identified as unused but intentionally retained, mark it as a
+  cleanup candidate in docs and defer removal until rollback policy is explicit.
+
 ### Maintenance checklist
 - Verify bot/app token refreshes complete successfully each day.
 - Reconcile conduit shards on a fixed cadence (recommended: every 15 minutes or

--- a/docs/archive/websocket_deprecation_rationale.md
+++ b/docs/archive/websocket_deprecation_rationale.md
@@ -1,0 +1,26 @@
+# Archived deprecation rationale: websocket-only command/runtime cleanup
+
+This document is the archived rationale referenced by the websocket-pruning changelog ledger.
+
+## Context
+- The canonical chat ingress path is `webhook_conduit`.
+- Websocket ingress and websocket-only routines are retained only as explicit rollback tooling during migration windows.
+
+## Deprecation decision criteria
+A websocket-only module/function/test can be removed when all items below are true:
+1. Product confirms rollback EOL for the targeted behavior.
+2. Authoritative webhook/conduit path has equivalent behavior coverage.
+3. At least one staging release window has verified rollback smoke expectations (if rollback is still in scope).
+4. Runbooks and API docs are updated in the same PR.
+
+## Rollback implications template
+When recording removals in the ledger, include:
+- operator-visible behavior changes,
+- required config toggles for emergency fallback,
+- explicit statement whether `chat_websocket_fallback_legacy_enabled` still restores the removed behavior.
+
+## Current cleanup candidates (tracked, not removed)
+- `random_request` webhook execution parity gap (currently rejected with a websocket-only cleanup marker).
+
+## Related ledger
+- `docs/websocket_pruning_ledger.md`

--- a/docs/backend_api.md
+++ b/docs/backend_api.md
@@ -283,6 +283,13 @@ Channel settings include queue intake controls:
   historical rollout aid and should not be treated as a long-term migration
   substitute.
 
+### Websocket-only cleanup ledger
+When pruning websocket-only code/tests, update `docs/websocket_pruning_ledger.md`
+in the same PR. Each entry must include removed modules/functions, replacement
+path, deprecation decision date, rollback implications, an `unused code removed`
+or `behavioral removal` classification, and a link to the archived rationale in
+`docs/archive/websocket_deprecation_rationale.md`.
+
 ## Songs
 | Method | Path | Description |
 |--------|------|-------------|

--- a/docs/websocket_pruning_ledger.md
+++ b/docs/websocket_pruning_ledger.md
@@ -1,0 +1,33 @@
+# Websocket-only pruning changelog ledger
+
+Use this ledger whenever websocket-only code/tests are removed.
+
+## Required fields per entry
+- **removed modules/functions**
+- **replacement path**
+- **deprecation decision date** (YYYY-MM-DD)
+- **rollback implications**
+- **classification** (`unused code removed` or `behavioral removal`)
+- **archived rationale link**
+
+## Entries
+
+### 2026-04-02 — Process baseline entry
+- **removed modules/functions**: none (documentation/process update only)
+- **replacement path**: n/a
+- **deprecation decision date**: 2026-04-02
+- **rollback implications**: none
+- **classification**: unused code removed (tracking baseline; no runtime deletion yet)
+- **archived rationale link**: [Archived websocket deprecation rationale](./archive/websocket_deprecation_rationale.md)
+
+## Entry template
+
+```md
+### YYYY-MM-DD — <short title>
+- **removed modules/functions**: <module/function list>
+- **replacement path**: <new authoritative path>
+- **deprecation decision date**: YYYY-MM-DD
+- **rollback implications**: <operator impact and recovery path>
+- **classification**: unused code removed | behavioral removal
+- **archived rationale link**: [name](./archive/websocket_deprecation_rationale.md)
+```


### PR DESCRIPTION
### Motivation
- Provide an auditable changelog process for removing websocket-only modules/functions/tests so future pruning is traceable and reversible. 
- Capture required metadata (removed items, replacement path, deprecation date, rollback implications, classification, archived rationale) to standardize PRs that remove websocket-only code. 
- Establish a migration/process baseline before any runtime websocket code or tests are deleted. 

### Description
- Add `docs/websocket_pruning_ledger.md` containing the required ledger fields, an entry template, and a baseline entry dated `2026-04-02`. 
- Add `docs/archive/websocket_deprecation_rationale.md` with the archived rationale, removal criteria, rollback-implication template, and tracked cleanup candidates. 
- Update `docs/README.md` and `docs/backend_api.md` to require ledger updates for websocket-only cleanup work and to link the archived rationale. 
- No runtime/websocket code or tests were removed in this change; this commit is documentation/process-only to meet the pruning policy requirements. 

### Testing
- Ran `python -m pytest -q tests/test_bot_service.py -k rollback_smoke_harness_enabled`, which completed successfully (`1 passed`). 
- Documentation changes only; no runtime behavior was modified so no additional automated tests were required or affected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ceb90e34fc83289d542a0f88ca59ae)