### PR TITLE
Harden conduit callback secret verification & add shard secret rotation

### DIFF
--- a/backend_app.py
+++ b/backend_app.py
@@ -125,6 +125,7 @@ EVENTSUB_EVENT_MAP: dict[str, str] = {
 }
 EVENTSUB_CONDUIT_CHAT_TYPE = "channel.chat.message"
 EVENTSUB_CONDUIT_SECRET_PLACEHOLDER = "__conduit_secret_unused__"
+CONDUIT_SECRET_ROTATION_GRACE_SECONDS = 300
 
 BOT_MESSAGE_LEVEL_DETAILS: list[dict[str, str]] = [
     {
@@ -415,6 +416,9 @@ def ensure_eventsub_conduit_schema() -> None:
                         conduit_fk INTEGER NOT NULL REFERENCES twitch_conduits(id) ON DELETE CASCADE,
                         shard_id VARCHAR NOT NULL,
                         transport_callback TEXT,
+                        current_secret TEXT,
+                        previous_secret TEXT,
+                        previous_secret_valid_until DATETIME,
                         transport_secret TEXT,
                         status VARCHAR NOT NULL DEFAULT 'pending',
                         last_sync_at DATETIME,
@@ -427,8 +431,25 @@ def ensure_eventsub_conduit_schema() -> None:
             )
         else:
             shard_columns = {col["name"] for col in inspector.get_columns("twitch_conduit_shards")}
+            if "current_secret" not in shard_columns:
+                conn.execute(text("ALTER TABLE twitch_conduit_shards ADD COLUMN current_secret TEXT"))
+            if "previous_secret" not in shard_columns:
+                conn.execute(text("ALTER TABLE twitch_conduit_shards ADD COLUMN previous_secret TEXT"))
+            if "previous_secret_valid_until" not in shard_columns:
+                conn.execute(text("ALTER TABLE twitch_conduit_shards ADD COLUMN previous_secret_valid_until DATETIME"))
             if "transport_secret" not in shard_columns:
                 conn.execute(text("ALTER TABLE twitch_conduit_shards ADD COLUMN transport_secret TEXT"))
+            conn.execute(
+                text(
+                    """
+                    UPDATE twitch_conduit_shards
+                    SET current_secret = transport_secret
+                    WHERE (current_secret IS NULL OR current_secret = '')
+                      AND transport_secret IS NOT NULL
+                      AND transport_secret != ''
+                    """
+                )
+            )
 
 
 def backfill_missing_channel_keys() -> None:
@@ -2800,7 +2821,9 @@ def _reconcile_twitch_conduit_shards(
     Code customers: Conduit reconciliation and eventsub health coverage checks.
     Used variables/origin: ``headers`` are app-auth conduit credentials; shard
     IDs come from Helix payloads and fallback to a local range when Twitch omits
-    data; callback originates from API route URL.
+    data; callback originates from API route URL. Secret rotation writes keep
+    shard metadata and ``current_secret``/``previous_secret`` updates in the
+    same transaction.
     """
 
     errors: list[str] = []
@@ -2815,8 +2838,11 @@ def _reconcile_twitch_conduit_shards(
             )
             .one_or_none()
         )
+        existing_secret = None
+        if existing:
+            existing_secret = existing.current_secret or existing.transport_secret
         secret_by_shard[shard_id] = (
-            existing.transport_secret if existing and existing.transport_secret else secrets.token_urlsafe(32)
+            existing_secret if existing_secret else secrets.token_urlsafe(32)
         )
     shards_payload = [
         {
@@ -2871,7 +2897,7 @@ def _reconcile_twitch_conduit_shards(
             db.add(row)
         transport = shard.get("transport") or {}
         row.transport_callback = transport.get("callback") or callback
-        row.transport_secret = secret_by_shard.get(shard_id) or row.transport_secret
+        _persist_conduit_shard_secret(row, secret_by_shard.get(shard_id) or "", now=now)
         next_status = shard.get("status") or "enabled"
         prev_status = row.status or "pending"
         if prev_status != next_status:
@@ -2895,7 +2921,7 @@ def _reconcile_twitch_conduit_shards(
             row = TwitchConduitShard(conduit_fk=conduit_row.id, shard_id=shard_id)
             db.add(row)
         row.transport_callback = callback
-        row.transport_secret = secret_by_shard.get(shard_id) or row.transport_secret
+        _persist_conduit_shard_secret(row, secret_by_shard.get(shard_id) or "", now=now)
         if (row.status or "pending") != "pending":
             _record_ingress_metric("shard_status_transition", key=f"{row.status}->pending")
         row.status = "pending"
@@ -2981,6 +3007,66 @@ def _refresh_conduit_shard_status_from_twitch(
     return updated
 
 
+def _active_conduit_shard_secret_candidates(
+    shard_row: TwitchConduitShard,
+    *,
+    now: datetime,
+) -> list[tuple[str, str]]:
+    """Return accepted shard secrets for signature checks with rotation grace.
+
+    Description: Produces ordered candidate secrets where current secret is
+    authoritative and an optional previous secret is accepted only within a
+    bounded grace window.
+    Dependencies: Reads ``TwitchConduitShard`` ORM fields and uses
+    ``datetime`` comparisons only.
+    Code customers: ``_resolve_conduit_notification_secret`` and conduit
+    verification flows.
+    Used variables/origin: ``shard_row`` comes from persistent shard state;
+    ``now`` comes from callback/reconciliation call sites for coherent timing.
+    """
+
+    candidates: list[tuple[str, str]] = []
+    current = (shard_row.current_secret or shard_row.transport_secret or "").strip()
+    if current:
+        candidates.append((current, "current_secret"))
+    previous = (shard_row.previous_secret or "").strip()
+    if previous and shard_row.previous_secret_valid_until and shard_row.previous_secret_valid_until >= now:
+        candidates.append((previous, "previous_secret"))
+    return candidates
+
+
+def _persist_conduit_shard_secret(
+    shard_row: TwitchConduitShard,
+    next_secret: str,
+    *,
+    now: datetime,
+) -> None:
+    """Persist shard secret rotation state atomically with shard metadata writes.
+
+    Description: Updates ``current_secret`` and moves the prior value to
+    ``previous_secret`` with a short validity window when a rotation occurs.
+    Dependencies: Uses ``CONDUIT_SECRET_ROTATION_GRACE_SECONDS`` and mutates a
+    tracked SQLAlchemy ``TwitchConduitShard`` row in the caller transaction.
+    Code customers: ``_reconcile_twitch_conduit_shards`` write path.
+    Used variables/origin: ``next_secret`` originates from reconciliation
+    secret planning; ``now`` comes from reconciliation clock.
+    """
+
+    trimmed_next = (next_secret or "").strip()
+    if not trimmed_next:
+        return
+    active = (shard_row.current_secret or shard_row.transport_secret or "").strip()
+    if active and active != trimmed_next:
+        shard_row.previous_secret = active
+        shard_row.previous_secret_valid_until = now + timedelta(seconds=CONDUIT_SECRET_ROTATION_GRACE_SECONDS)
+    elif not active:
+        shard_row.previous_secret = None
+        shard_row.previous_secret_valid_until = None
+    shard_row.current_secret = trimmed_next
+    # Legacy compatibility column: keep in sync until removed.
+    shard_row.transport_secret = trimmed_next
+
+
 def _resolve_conduit_verification_secret(
     payload: Mapping[str, Any],
     db: Session,
@@ -3014,25 +3100,29 @@ def _resolve_conduit_verification_secret(
     )
     if not rows:
         return None, conduit_id, shard_id, "unknown_conduit_shard"
-    if not rows[0].transport_secret:
-        return None, conduit_id, shard_id, "missing_conduit_shard_secret"
-    return rows[0].transport_secret, conduit_id, shard_id, None
+    now = datetime.utcnow()
+    candidates = _active_conduit_shard_secret_candidates(rows[0], now=now)
+    if not candidates:
+        return None, conduit_id, shard_id, "missing_shard_secret"
+    return candidates[0][0], conduit_id, shard_id, None
 
 
 def _resolve_conduit_notification_secret(
     subscription: EventSubscription,
     payload: Mapping[str, Any],
     db: Session,
-) -> tuple[Optional[str], Optional[str], Optional[str], Optional[str]]:
-    """Resolve conduit shard secret for ``notification`` callback signature checks.
+) -> tuple[list[tuple[str, str]], Optional[str], Optional[str], Optional[str]]:
+    """Resolve conduit shard secret candidates for ``notification`` signatures.
 
     Dependencies: Uses ``json`` for persisted ``EventSubscription.meta`` parsing
-    and ``TwitchConduit``/``TwitchConduitShard`` tables for secret lookup.
+    and ``TwitchConduit``/``TwitchConduitShard`` tables for secret lookup plus
+    rotation grace handling via ``_active_conduit_shard_secret_candidates``.
     Code customers: ``eventsub_callback`` notification branch for
     conduit-delivered chat messages.
     Used variables/origin: Reads conduit identity from subscription columns,
     subscription metadata, and payload transport fields; shard identity comes
-    from subscription column/metadata.
+    from payload/metadata and then subscription fields. Returns reason codes
+    including ``missing_shard_secret`` and ``secret_lookup_mismatch``.
     """
 
     sub_info = payload.get("subscription") or {}
@@ -3049,27 +3139,33 @@ def _resolve_conduit_notification_secret(
     conduit_meta = meta_payload.get("conduit_shard") if isinstance(meta_payload.get("conduit_shard"), dict) else {}
 
     conduit_id = (
-        subscription.conduit_id
-        or meta_payload.get("conduit_id")
-        or conduit_meta.get("conduit_id")
+        sub_transport.get("conduit_id")
         or meta_transport.get("conduit_id")
-        or sub_transport.get("conduit_id")
+        or conduit_meta.get("conduit_id")
+        or meta_payload.get("conduit_id")
+        or subscription.conduit_id
     )
     if conduit_id is not None:
         conduit_id = str(conduit_id)
     if not conduit_id:
-        return None, None, None, "missing_conduit_shard_field_conduit_id"
+        return [], None, None, "missing_conduit_shard_field_conduit_id"
 
     shard_id = (
-        subscription.shard_id
+        sub_transport.get("shard_id")
         or meta_payload.get("shard_id")
         or conduit_meta.get("shard_id")
         or conduit_meta.get("shard")
+        or subscription.shard_id
     )
     if shard_id is not None:
         shard_id = str(shard_id)
     if not shard_id:
-        return None, conduit_id, None, "missing_conduit_shard_field_shard"
+        return [], conduit_id, None, "missing_conduit_shard_field_shard"
+
+    if subscription.conduit_id and subscription.conduit_id != conduit_id:
+        return [], conduit_id, shard_id, "secret_lookup_mismatch"
+    if subscription.shard_id and subscription.shard_id != shard_id:
+        return [], conduit_id, shard_id, "secret_lookup_mismatch"
 
     shard_row = (
         db.query(TwitchConduitShard)
@@ -3081,10 +3177,11 @@ def _resolve_conduit_notification_secret(
         .one_or_none()
     )
     if not shard_row:
-        return None, conduit_id, shard_id, "unknown_conduit_shard"
-    if not shard_row.transport_secret:
-        return None, conduit_id, shard_id, "missing_conduit_shard_secret"
-    return shard_row.transport_secret, conduit_id, shard_id, None
+        return [], conduit_id, shard_id, "unknown_conduit_shard"
+    candidates = _active_conduit_shard_secret_candidates(shard_row, now=datetime.utcnow())
+    if not candidates:
+        return [], conduit_id, shard_id, "missing_shard_secret"
+    return candidates, conduit_id, shard_id, None
 
 
 def _persist_conduit_subscription_secret_placeholder(existing_secret: Optional[str]) -> str:
@@ -3573,6 +3670,9 @@ class TwitchConduitShard(Base):
     conduit_fk = Column(Integer, ForeignKey("twitch_conduits.id", ondelete="CASCADE"), nullable=False)
     shard_id = Column(String, nullable=False)
     transport_callback = Column(Text)
+    current_secret = Column(Text)
+    previous_secret = Column(Text)
+    previous_secret_valid_until = Column(DateTime)
     transport_secret = Column(Text)
     status = Column(String, nullable=False, default="pending")
     last_sync_at = Column(DateTime)
@@ -9780,12 +9880,13 @@ async def eventsub_callback(request: FastAPIRequest, db: Session = Depends(get_d
     verification_secret = subscription.secret
     conduit_id: Optional[str] = None
     shard_id: Optional[str] = None
+    verification_secret_candidates: list[tuple[str, str]] = []
     if is_conduit_chat_notification:
-        verification_secret, conduit_id, shard_id, resolve_error = _resolve_conduit_notification_secret(
+        verification_secret_candidates, conduit_id, shard_id, resolve_error = _resolve_conduit_notification_secret(
             subscription, payload, db
         )
-        if resolve_error or not verification_secret:
-            status_code = 503 if resolve_error == "missing_conduit_shard_secret" else 403
+        if resolve_error or not verification_secret_candidates:
+            status_code = 503 if resolve_error == "missing_shard_secret" else 403
             logger.warning(
                 "EventSub callback rejected: reason_code=%s message_id=%s message_type=%s subscription_id=%s conduit_id=%s shard_id=%s diagnostics=conduit_notification_secret_resolution_failed",
                 resolve_error or "unknown_conduit_secret_resolution_error",
@@ -9805,17 +9906,49 @@ async def eventsub_callback(request: FastAPIRequest, db: Session = Depends(get_d
                     "subscription_id": sub_id,
                 },
             )
+    else:
+        # cleanup_candidate: non-conduit notification verification still uses
+        # per-subscription secret semantics; future removal once conduit is
+        # fully authoritative for chat ingress.
+        verification_secret_candidates = [(verification_secret, "legacy_subscription_secret")]
 
-    if not _verify_eventsub_signature(verification_secret, message_id, timestamp, body, signature):
+    signature_match = False
+    matched_secret_source: Optional[str] = None
+    for candidate_secret, source_name in verification_secret_candidates:
+        if _verify_eventsub_signature(candidate_secret, message_id, timestamp, body, signature):
+            signature_match = True
+            matched_secret_source = source_name
+            break
+
+    if not signature_match:
         _record_ingress_metric("signature_failure")
         if is_conduit_chat_notification:
+            stale_secret_detected = _verify_eventsub_signature(
+                subscription.secret,
+                message_id,
+                timestamp,
+                body,
+                signature,
+            )
+            reason_code = "stale_shard_secret" if stale_secret_detected else "invalid_signature"
             logger.warning(
-                "EventSub callback rejected: reason_code=invalid_signature message_id=%s message_type=%s subscription_id=%s conduit_id=%s shard_id=%s signature_mode=conduit_shard_secret",
+                "EventSub callback rejected: reason_code=%s message_id=%s message_type=%s subscription_id=%s conduit_id=%s shard_id=%s signature_mode=conduit_shard_secret",
+                reason_code,
                 message_id,
                 message_type or "<missing>",
                 sub_id,
                 conduit_id or "<missing>",
                 shard_id or "<missing>",
+            )
+            raise HTTPException(
+                status_code=403,
+                detail={
+                    "reason_code": reason_code,
+                    "message": "Conduit notification signature validation failed.",
+                    "conduit_id": conduit_id,
+                    "shard_id": shard_id,
+                    "subscription_id": sub_id,
+                },
             )
         else:
             logger.warning(
@@ -9825,6 +9958,14 @@ async def eventsub_callback(request: FastAPIRequest, db: Session = Depends(get_d
                 sub_id,
             )
         raise HTTPException(status_code=403, detail="invalid signature")
+    if is_conduit_chat_notification:
+        logger.debug(
+            "EventSub callback signature accepted for conduit notification message_id=%s conduit_id=%s shard_id=%s secret_source=%s",
+            message_id,
+            conduit_id or "<missing>",
+            shard_id or "<missing>",
+            matched_secret_source or "<unknown>",
+        )
 
     subscription.status = sub_info.get("status") or subscription.status
     subscription.updated_at = datetime.utcnow()

--- a/docs/backend_api.md
+++ b/docs/backend_api.md
@@ -522,11 +522,11 @@ Certain events award priority points and are fed by EventSub subscriptions creat
 - **Signature verification**:
   - The backend computes `HMAC_SHA256(secret, message_id + timestamp + raw_body)` and rejects mismatches with `403`.
   - For classic webhook payloads, the `secret` is taken from `event_subscriptions.secret` via `subscription.id`.
-  - For conduit chat notifications (`subscription.type=channel.chat.message` and/or `subscription.transport.method=conduit`), the `secret` is resolved from `twitch_conduit_shards.transport_secret` using the persisted `(conduit_id, shard_id)` linkage from `event_subscriptions` columns/metadata/transport data.
-  - Conduit reconciliation stores linkage metadata (`conduit_id`, `shard_id`, and transport details) on `event_subscriptions`; the `event_subscriptions.secret` field for conduit rows is treated as a schema-compatibility placeholder and is not authoritative.
+  - For conduit chat notifications (`subscription.type=channel.chat.message` and/or `subscription.transport.method=conduit`), the `secret` is resolved from persisted shard state (`twitch_conduit_shards.current_secret`, optional `previous_secret` during grace, and legacy mirror `transport_secret`) using `(conduit_id, shard_id)` derived from payload transport + metadata linkage.
+  - Conduit reconciliation stores linkage metadata (`conduit_id`, `shard_id`, and transport details) on `event_subscriptions`; the `event_subscriptions.secret` field for conduit rows is treated as a schema-compatibility placeholder and is not authoritative for conduit notifications.
   - Migration-safe behavior: existing conduit rows that still contain legacy/random `event_subscriptions.secret` values are ignored during conduit notification signature verification.
-  - If a conduit notification cannot resolve shard secret material, the callback returns explicit diagnostics with reason code (for example `missing_conduit_shard_secret`) and uses `503` for missing secret state so operators can distinguish config drift from invalid signatures.
-  - For conduit verification payloads (`verification_shape=conduit_shard`), the `secret` is taken from `twitch_conduit_shards.transport_secret` using the persisted `(conduit_shard.conduit_id, conduit_shard.shard)` pair.
+  - If a conduit notification cannot resolve shard secret material, the callback returns explicit diagnostics with reason code (for example `missing_shard_secret`, `secret_lookup_mismatch`) and uses `503` for missing secret state so operators can distinguish config drift from invalid signatures; stale legacy signatures are surfaced with `stale_shard_secret`.
+  - For conduit verification payloads (`verification_shape=conduit_shard`), the `secret` is taken from active persisted shard secret material using the `(conduit_shard.conduit_id, conduit_shard.shard)` pair.
 - **Verification payload variants**:
   - Classic webhook verification payloads with `subscription` are supported.
   - Conduit shard verification payloads with `conduit_shard` and no `subscription` are supported.
@@ -567,7 +567,7 @@ Certain events award priority points and are fed by EventSub subscriptions creat
 4. Monitor callback logs for:
    - signature failures,
    - unknown subscription IDs,
-   - conduit shard secret resolution failures (`missing_conduit_shard_field_conduit_id`, `missing_conduit_shard_field_shard`, `missing_conduit_shard_secret`, `unknown_conduit_shard`),
+   - conduit shard secret resolution failures (`missing_conduit_shard_field_conduit_id`, `missing_conduit_shard_field_shard`, `missing_shard_secret`, `secret_lookup_mismatch`, `unknown_conduit_shard`),
    - dedupe hits (retry storms),
    - reply send failures / suppressions (`send_api_failure_count`, `reply_suppressed_count`),
    - webhook/websocket comparison deltas while shadow mode is enabled.

--- a/migrations/20260402_conduit_secret_rotation.sql
+++ b/migrations/20260402_conduit_secret_rotation.sql
@@ -1,0 +1,10 @@
+-- Add conduit shard secret rotation fields and backfill current_secret.
+ALTER TABLE twitch_conduit_shards ADD COLUMN current_secret TEXT;
+ALTER TABLE twitch_conduit_shards ADD COLUMN previous_secret TEXT;
+ALTER TABLE twitch_conduit_shards ADD COLUMN previous_secret_valid_until DATETIME;
+
+UPDATE twitch_conduit_shards
+SET current_secret = transport_secret
+WHERE (current_secret IS NULL OR current_secret = '')
+  AND transport_secret IS NOT NULL
+  AND transport_secret != '';

--- a/tests/test_channel_events.py
+++ b/tests/test_channel_events.py
@@ -1839,9 +1839,152 @@ remove:
         )
         self.assertEqual(response.status_code, 503, response.text)
         payload = response.json().get("detail") or {}
-        self.assertEqual(payload.get("reason_code"), "missing_conduit_shard_secret")
+        self.assertEqual(payload.get("reason_code"), "missing_shard_secret")
         self.assertEqual(payload.get("conduit_id"), conduit_id)
         self.assertEqual(payload.get("shard_id"), shard_id)
+
+    def test_eventsub_conduit_notification_signature_passes_with_current_shard_secret(self) -> None:
+        """Accept conduit notifications signed by the active shard secret.
+
+        Dependencies: callback HMAC verification and conduit shard secret lookup.
+        Code customers: webhook-conduit notification path.
+        Used variables/origin: payload transport + subscription metadata provide
+        conduit/shard identity while shard row ``current_secret`` is canonical.
+        """
+
+        details = _setup_channel()
+        conduit_id = "conduit-current-secret"
+        shard_id = "2"
+        _create_chat_conduit_subscription(
+            details["channel_pk"],
+            subscription_id="sub-current-secret",
+            conduit_id=conduit_id,
+            shard_id=shard_id,
+            secret="shard-current",
+        )
+        body = {
+            "subscription": {
+                "id": "sub-current-secret",
+                "type": "channel.chat.message",
+                "status": "enabled",
+                "version": "1",
+                "condition": {"broadcaster_user_id": details["channel_name"]},
+                "transport": {"method": "conduit", "conduit_id": conduit_id},
+            },
+            "event": {"chatter_user_id": "u1", "chatter_user_login": "u1", "message": {"text": "hello"}},
+        }
+        raw = json.dumps(body).encode()
+        headers = _signed_eventsub_headers("shard-current", "msg-current-secret", "2023-01-01T00:00:00Z", raw)
+        response = self.client.post("/twitch/eventsub/callback", data=raw, headers=headers)
+        self.assertEqual(response.status_code, 200, response.text)
+
+    def test_eventsub_conduit_notification_stale_secret_fails(self) -> None:
+        """Reject conduit notifications signed with an expired previous secret.
+
+        Dependencies: shard rotation fields and callback signature diagnostics.
+        Code customers: operators triaging drift after rotation grace expires.
+        Used variables/origin: subscription legacy secret intentionally matches
+        stale signing key to assert ``stale_shard_secret`` reason reporting.
+        """
+
+        details = _setup_channel()
+        conduit_id = "conduit-stale-secret"
+        shard_id = "3"
+        _create_chat_conduit_subscription(
+            details["channel_pk"],
+            subscription_id="sub-stale-secret",
+            conduit_id=conduit_id,
+            shard_id=shard_id,
+            secret="shard-current-new",
+        )
+        db = backend_app.SessionLocal()
+        try:
+            row = (
+                db.query(backend_app.TwitchConduitShard)
+                .join(backend_app.TwitchConduit, backend_app.TwitchConduitShard.conduit_fk == backend_app.TwitchConduit.id)
+                .filter(
+                    backend_app.TwitchConduit.conduit_id == conduit_id,
+                    backend_app.TwitchConduitShard.shard_id == shard_id,
+                )
+                .one()
+            )
+            row.current_secret = "shard-current-new"
+            row.previous_secret = "legacy-subscription-secret"
+            row.previous_secret_valid_until = backend_app.datetime.utcnow() - backend_app.timedelta(seconds=30)
+            row.transport_secret = "shard-current-new"
+            db.commit()
+        finally:
+            db.close()
+        body = {
+            "subscription": {
+                "id": "sub-stale-secret",
+                "type": "channel.chat.message",
+                "status": "enabled",
+                "version": "1",
+                "condition": {"broadcaster_user_id": details["channel_name"]},
+                "transport": {"method": "conduit", "conduit_id": conduit_id},
+            },
+            "event": {"chatter_user_id": "u2", "chatter_user_login": "u2", "message": {"text": "hello"}},
+        }
+        raw = json.dumps(body).encode()
+        headers = _signed_eventsub_headers("legacy-subscription-secret", "msg-stale-secret", "2023-01-01T00:00:00Z", raw)
+        response = self.client.post("/twitch/eventsub/callback", data=raw, headers=headers)
+        self.assertEqual(response.status_code, 403, response.text)
+        detail = response.json().get("detail") or {}
+        self.assertEqual(detail.get("reason_code"), "stale_shard_secret")
+
+    def test_eventsub_conduit_notification_rotation_grace_accepts_previous_secret(self) -> None:
+        """Accept conduit notifications signed with previous secret in grace.
+
+        Dependencies: shard rotation grace window and callback verification.
+        Code customers: zero-downtime shard secret rotation in conduit ingress.
+        Used variables/origin: previous secret is explicitly persisted with a
+        future ``previous_secret_valid_until`` timestamp.
+        """
+
+        details = _setup_channel()
+        conduit_id = "conduit-rotation-grace"
+        shard_id = "4"
+        _create_chat_conduit_subscription(
+            details["channel_pk"],
+            subscription_id="sub-rotation-grace",
+            conduit_id=conduit_id,
+            shard_id=shard_id,
+            secret="rotated-current-secret",
+        )
+        db = backend_app.SessionLocal()
+        try:
+            row = (
+                db.query(backend_app.TwitchConduitShard)
+                .join(backend_app.TwitchConduit, backend_app.TwitchConduitShard.conduit_fk == backend_app.TwitchConduit.id)
+                .filter(
+                    backend_app.TwitchConduit.conduit_id == conduit_id,
+                    backend_app.TwitchConduitShard.shard_id == shard_id,
+                )
+                .one()
+            )
+            row.current_secret = "rotated-current-secret"
+            row.previous_secret = "legacy-subscription-secret"
+            row.previous_secret_valid_until = backend_app.datetime.utcnow() + backend_app.timedelta(minutes=2)
+            row.transport_secret = "rotated-current-secret"
+            db.commit()
+        finally:
+            db.close()
+        body = {
+            "subscription": {
+                "id": "sub-rotation-grace",
+                "type": "channel.chat.message",
+                "status": "enabled",
+                "version": "1",
+                "condition": {"broadcaster_user_id": details["channel_name"]},
+                "transport": {"method": "conduit", "conduit_id": conduit_id},
+            },
+            "event": {"chatter_user_id": "u3", "chatter_user_login": "u3", "message": {"text": "hello"}},
+        }
+        raw = json.dumps(body).encode()
+        headers = _signed_eventsub_headers("legacy-subscription-secret", "msg-rotation-grace", "2023-01-01T00:00:00Z", raw)
+        response = self.client.post("/twitch/eventsub/callback", data=raw, headers=headers)
+        self.assertEqual(response.status_code, 200, response.text)
 
     def test_system_health_reports_ingress_summary_metrics(self) -> None:
         """Expose compact ingress summary with callback throughput and counters."""


### PR DESCRIPTION
### Motivation
- Ensure EventSub conduit notifications always validate against the correct, authoritative shard secret and provide clear diagnostics for resolution/rotation issues.
- Support zero-downtime secret rotations for conduit shards by accepting a short grace-window previous secret.
- Harden reconciliation write-path so secret state and shard metadata remain consistent and avoid accidental use of stale per-subscription secrets.

### Description
- Reworked conduit notification secret lookup to derive `(conduit_id, shard_id)` from payload transport/metadata first, enforce subscription-to-payload linkage, and refuse fallback to legacy per-subscription secrets for conduit notifications (adds `secret_lookup_mismatch` reason code). 
- Introduced shard secret rotation fields and logic: `current_secret`, `previous_secret`, and `previous_secret_valid_until`, plus `CONDUIT_SECRET_ROTATION_GRACE_SECONDS` and helpers `_active_conduit_shard_secret_candidates` and `_persist_conduit_shard_secret` to produce ordered candidate secrets and atomically persist rotations; legacy `transport_secret` is mirrored until removed. 
- Hardened `_reconcile_twitch_conduit_shards` to compute per-shard secrets using persisted `current_secret` when present and call `_persist_conduit_shard_secret` so metadata and secret writes occur together in the transaction.
- Updated EventSub callback logic to accept candidate secrets (current + optional previous within grace), emit explicit diagnostics (`missing_shard_secret`, `stale_shard_secret`, `secret_lookup_mismatch`) and log which secret source matched; preserved a legacy per-subscription branch for non-conduit notifications marked as a cleanup candidate. 
- Added migration `migrations/20260402_conduit_secret_rotation.sql` to add rotation columns and backfill `current_secret` from `transport_secret`, and updated `ensure_eventsub_conduit_schema` bootstrap to create/alter these columns and backfill at startup.
- Added/updated unit tests in `tests/test_channel_events.py` covering: valid conduit notification signed with current shard secret, stale previous-secret rejection (reports `stale_shard_secret`), and previous-secret rotation-grace acceptance; updated missing-secret expectation to `missing_shard_secret`.
- Updated documentation `docs/backend_api.md` to describe authoritative shard secret sources, rotation grace semantics, and new diagnostic reason codes.

### Testing
- Compiled affected modules to validate syntax: `python -m py_compile backend_app.py tests/test_channel_events.py` (succeeded).
- Attempted targeted pytest run for the new/updated callback tests, but collection failed in this environment due to database file access (`sqlite3.OperationalError: unable to open database file`), so functional test execution could not complete here; the tests were added and exercise the new paths locally when DB is available.
- Static checks: file edits compile and new migration created for DB schema changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ceea03fa848328b63fca37e8cd2b10)