### PR TITLE
Add ingress runtime invariant checks, telemetry reason codes, and runbook docs

### DIFF
--- a/backend_app.py
+++ b/backend_app.py
@@ -229,12 +229,14 @@ _INGRESS_METRICS: dict[str, Any] = {
     "shard_status_transitions": {},
     "last_errors": {
         "signature_failure_at": None,
+        "signature_failure_reason_code": None,
         "callback_4xx_at": None,
         "callback_5xx_at": None,
         "guard_degraded_at": None,
         "send_api_failure_at": None,
         "send_api_failure_reason_code": None,
         "send_api_failure_snippet": None,
+        "reply_preflight_failure_reason_code": None,
     },
     "callback_events": [],
 }
@@ -1001,6 +1003,8 @@ def _record_ingress_metric(metric: str, *, key: Optional[str] = None, timestamp:
         elif metric == "signature_failure":
             _INGRESS_METRICS["signature_failures"] = int(_INGRESS_METRICS.get("signature_failures", 0)) + 1
             _INGRESS_METRICS["last_errors"]["signature_failure_at"] = now
+            if key:
+                _INGRESS_METRICS["last_errors"]["signature_failure_reason_code"] = key
         elif metric == "dedupe_hit":
             _INGRESS_METRICS["dedupe_hits"] = int(_INGRESS_METRICS.get("dedupe_hits", 0)) + 1
         elif metric == "command_dispatch_outcome" and key:
@@ -1018,6 +1022,8 @@ def _record_ingress_metric(metric: str, *, key: Optional[str] = None, timestamp:
         elif metric == "send_api_failure_reason" and key:
             reasons = _INGRESS_METRICS["send_api_failure_reasons"]
             reasons[key] = int(reasons.get(key, 0)) + 1
+            if key.startswith("preflight_"):
+                _INGRESS_METRICS["last_errors"]["reply_preflight_failure_reason_code"] = key
         elif metric == "shard_status_transition" and key:
             transitions = _INGRESS_METRICS["shard_status_transitions"]
             transitions[key] = int(transitions.get(key, 0)) + 1
@@ -1070,10 +1076,20 @@ def _ingress_metrics_snapshot(now: datetime) -> dict[str, Any]:
 
 
 def _evaluate_ingress_guard(db: Session, now: datetime, *, apply_fallback: bool) -> dict[str, Any]:
-    """Evaluate authoritative webhook-conduit health and optional fallback policy."""
+    """Evaluate authoritative webhook-conduit guard health and runtime invariants.
+
+    Dependencies: Reads ingress counters via ``_ingress_metrics_snapshot``,
+    shard state from ``TwitchConduitShard``, persisted settings for fallback
+    thresholds, and invariant status from ``_evaluate_ingress_runtime_invariants``.
+    Code customers: startup guard checks, ``/system/health`` diagnostics, and
+    webhook callback post-processing guard reevaluation.
+    Used variables/origin: ``now`` comes from runtime clock and ``db`` is the
+    request/startup SQLAlchemy session used for shard and settings reads.
+    """
 
     thresholds = _ingress_guard_thresholds()
     summary = _ingress_metrics_snapshot(now)
+    invariants = _evaluate_ingress_runtime_invariants(db, now=now)
     shard_rows = db.query(TwitchConduitShard).all()
     healthy_shards = sum(1 for shard in shard_rows if (shard.status or "").lower() == "enabled")
     degraded_reasons: list[str] = []
@@ -1083,6 +1099,10 @@ def _evaluate_ingress_guard(db: Session, now: datetime, *, apply_fallback: bool)
     callback_errors = int(recent["callbacks_4xx"]) + int(recent["callbacks_5xx"])
     if callback_errors >= int(thresholds["callback_error_threshold"]):
         degraded_reasons.append("callback_errors_spike")
+    if not invariants["conduit_signature_secret_resolvable"]:
+        degraded_reasons.append("invalid_signature")
+    if not invariants["sender_token_subject_resolvable"]:
+        degraded_reasons.append("preflight_token_subject_unresolved")
     degraded = bool(degraded_reasons)
     auto_fallback_enabled = _env_flag(get_setting("chat_ingress_guard_auto_fallback_enabled", "0"))
     fallback_applied = False
@@ -1102,6 +1122,7 @@ def _evaluate_ingress_guard(db: Session, now: datetime, *, apply_fallback: bool)
         "degraded": degraded,
         "reasons": degraded_reasons,
         "healthy_shards": healthy_shards,
+        "runtime_invariants": invariants,
         "thresholds": {k: int(v) for k, v in thresholds.items()},
         "auto_fallback_enabled": auto_fallback_enabled,
         "auto_fallback_applied": fallback_applied,
@@ -1109,8 +1130,108 @@ def _evaluate_ingress_guard(db: Session, now: datetime, *, apply_fallback: bool)
     }
 
 
+def _resolve_bot_sender_token_subject_cached(
+    access_token: str,
+    *,
+    now: datetime,
+    ttl_seconds: int = 120,
+) -> Optional[str]:
+    """Resolve bot sender token subject with short-lived cache for guard loops.
+
+    Dependencies: Uses process-local cache state and
+    ``_resolve_twitch_token_subject_id`` for Twitch validation when cache misses.
+    Code customers: ``_evaluate_ingress_runtime_invariants`` guard checks.
+    Used variables/origin: ``access_token`` comes from persisted ``BotConfig``
+    credentials; ``now`` is the guard evaluation timestamp.
+    """
+
+    token = (access_token or "").strip()
+    if not token:
+        return None
+    cache = getattr(_resolve_bot_sender_token_subject_cached, "_cache", None)
+    if not isinstance(cache, dict):
+        cache = {}
+        setattr(_resolve_bot_sender_token_subject_cached, "_cache", cache)
+    expires_at = cache.get("expires_at")
+    if cache.get("access_token") == token and isinstance(expires_at, datetime) and now <= expires_at:
+        subject = cache.get("subject_id")
+        return str(subject).strip() if subject else None
+    subject_id = _resolve_twitch_token_subject_id(token)
+    cache["access_token"] = token
+    cache["subject_id"] = subject_id
+    cache["expires_at"] = now + timedelta(seconds=max(ttl_seconds, 15))
+    return subject_id
+
+
+def _evaluate_ingress_runtime_invariants(db: Session, *, now: datetime) -> dict[str, Any]:
+    """Evaluate critical conduit-secret and sender-token runtime invariants.
+
+    Dependencies: Reads conduit assignment rows from ``EventSubscription``,
+    conduit shard secret material from ``TwitchConduit``/``TwitchConduitShard``,
+    and bot OAuth credentials from ``BotConfig``.
+    Code customers: ``_evaluate_ingress_guard`` startup/runtime degradation
+    checks and operator diagnostics exposed via ``/system/health``.
+    Used variables/origin: ``now`` is reused for secret grace checks and token
+    subject cache expiry; ``db`` supplies persisted assignment/config state.
+    """
+
+    assignment_rows = (
+        db.query(EventSubscription.conduit_id, EventSubscription.shard_id)
+        .filter(
+            EventSubscription.type == EVENTSUB_CONDUIT_CHAT_TYPE,
+            EventSubscription.transport == "conduit",
+            EventSubscription.status == "enabled",
+        )
+        .all()
+    )
+    assignment_pairs = {
+        (str(conduit_id or "").strip(), str(shard_id or "").strip())
+        for conduit_id, shard_id in assignment_rows
+        if str(conduit_id or "").strip() and str(shard_id or "").strip()
+    }
+    unresolved_assignments: list[dict[str, str]] = []
+    for conduit_id, shard_id in sorted(assignment_pairs):
+        shard_row = (
+            db.query(TwitchConduitShard)
+            .join(TwitchConduit, TwitchConduitShard.conduit_fk == TwitchConduit.id)
+            .filter(
+                TwitchConduit.conduit_id == conduit_id,
+                TwitchConduitShard.shard_id == shard_id,
+            )
+            .one_or_none()
+        )
+        if not shard_row:
+            unresolved_assignments.append(
+                {"conduit_id": conduit_id, "shard_id": shard_id, "reason_code": "unknown_conduit_shard"}
+            )
+            continue
+        if not _active_conduit_shard_secret_candidates(shard_row, now=now):
+            unresolved_assignments.append(
+                {"conduit_id": conduit_id, "shard_id": shard_id, "reason_code": "missing_shard_secret"}
+            )
+
+    cfg = db.query(BotConfig).order_by(BotConfig.id.asc()).first()
+    bot_access_token = (cfg.access_token if cfg and cfg.access_token else "").strip()
+    token_subject_id = _resolve_bot_sender_token_subject_cached(bot_access_token, now=now) if bot_access_token else None
+
+    return {
+        "conduit_signature_secret_resolvable": not unresolved_assignments,
+        "sender_token_subject_resolvable": bool(token_subject_id),
+        "active_assignment_count": len(assignment_pairs),
+        "unresolved_assignment_count": len(unresolved_assignments),
+        "unresolved_assignments": unresolved_assignments[:10],
+        "bot_sender_subject_id": token_subject_id,
+    }
+
+
 def run_ingress_guard_startup_check() -> None:
-    """Run a startup ingress guard check and emit high-severity alerts when degraded."""
+    """Run startup ingress guard checks, including runtime invariant validation.
+
+    Dependencies: Uses ``SessionLocal`` and ``_evaluate_ingress_guard``.
+    Code customers: Module startup bootstrap after schema compatibility checks.
+    Used variables/origin: active only when ``chat_ingress_mode`` is
+    ``webhook_conduit`` so guard checks match authoritative ingress operation.
+    """
 
     db = SessionLocal()
     try:
@@ -1778,6 +1899,7 @@ def _send_eventsub_chat_reply(db: Session, channel: ActiveChannel, reply: dict[s
     if preflight_reason_code or not payload or not headers:
         _record_ingress_metric("send_api_failure")
         _record_ingress_metric("send_api_failure_reason", key="preflight_rejected")
+        _record_ingress_metric("send_api_failure_reason", key=preflight_reason_code or "preflight_unknown_failure")
         logger.warning(
             "Webhook reply send skipped by preflight: reason_code=%s channel=%s template_key=%s",
             preflight_reason_code or "preflight_unknown_failure",
@@ -9778,7 +9900,7 @@ async def eventsub_callback(request: FastAPIRequest, db: Session = Depends(get_d
                 return JSONResponse(status_code=202, content={"detail": "unknown subscription"})
             secret = subscription.secret
             if not _verify_eventsub_signature(secret, message_id, timestamp, body, signature):
-                _record_ingress_metric("signature_failure")
+                _record_ingress_metric("signature_failure", key="invalid_signature")
                 logger.warning(
                     "EventSub callback rejected: reason_code=invalid_signature message_id=%s message_type=%s verification_shape=%s",
                     message_id,
@@ -9811,7 +9933,7 @@ async def eventsub_callback(request: FastAPIRequest, db: Session = Depends(get_d
                 )
                 raise HTTPException(status_code=400, detail=resolve_error or "conduit_shard_secret_unavailable")
             if not _verify_eventsub_signature(secret, message_id, timestamp, body, signature):
-                _record_ingress_metric("signature_failure")
+                _record_ingress_metric("signature_failure", key="invalid_signature")
                 logger.warning(
                     "EventSub callback rejected: reason_code=invalid_signature message_id=%s message_type=%s verification_shape=%s conduit_id=%s shard_id=%s",
                     message_id,
@@ -9921,7 +10043,6 @@ async def eventsub_callback(request: FastAPIRequest, db: Session = Depends(get_d
             break
 
     if not signature_match:
-        _record_ingress_metric("signature_failure")
         if is_conduit_chat_notification:
             stale_secret_detected = _verify_eventsub_signature(
                 subscription.secret,
@@ -9931,6 +10052,7 @@ async def eventsub_callback(request: FastAPIRequest, db: Session = Depends(get_d
                 signature,
             )
             reason_code = "stale_shard_secret" if stale_secret_detected else "invalid_signature"
+            _record_ingress_metric("signature_failure", key=reason_code)
             logger.warning(
                 "EventSub callback rejected: reason_code=%s message_id=%s message_type=%s subscription_id=%s conduit_id=%s shard_id=%s signature_mode=conduit_shard_secret",
                 reason_code,
@@ -9951,6 +10073,7 @@ async def eventsub_callback(request: FastAPIRequest, db: Session = Depends(get_d
                 },
             )
         else:
+            _record_ingress_metric("signature_failure", key="invalid_signature")
             logger.warning(
                 "EventSub callback rejected: reason_code=invalid_signature message_id=%s message_type=%s subscription_id=%s signature_mode=legacy_subscription_secret",
                 message_id,

--- a/docs/README.md
+++ b/docs/README.md
@@ -110,9 +110,10 @@ unlocks the API for the bot, queue manager, and public web frontend.
   - `GET /system/health.eventsub.ingress_summary` adds compact runtime counters:
     callback 2xx/4xx/5xx, signature failures, dedupe hits, per-channel command
     dispatch outcomes, shard status transitions, Send Chat API failure reasons
-    (including mapped 400 validation classes), and last error timestamps.
+    (including mapped 400 validation classes), last signature failure reason,
+    last reply preflight failure reason, and last error timestamps.
   - `GET /system/health.eventsub.authoritative_guard` reports degradation
-    reasons and whether auto-fallback was applied.
+    reasons, whether auto-fallback was applied, and runtime invariant checks.
   - `GET /channels/{channel}/eventsub/health` reports per-channel shard
     assignment state and can trigger reconcile with `?reconcile=true`, which
     refreshes local/conduit/shard/coverage fields after reconciliation.
@@ -294,7 +295,47 @@ unlocks the API for the bot, queue manager, and public web frontend.
 4. For transient classes, keep retries bounded and monitor recovery via
    `reply_sent_count` versus `send_api_failure_count`.
 
-#### 4) Credential expiry remediation
+#### 4) `invalid_signature` (conduit shard secret path)
+**Symptoms**
+- `eventsub.ingress_summary.last_errors.signature_failure_reason_code`
+  repeatedly reports `invalid_signature`.
+- `eventsub.authoritative_guard.runtime_invariants` reports unresolved
+  conduit assignments.
+
+**Dependencies**
+- Active conduit assignment linkage (`event_subscriptions.conduit_id/shard_id`).
+- Resolvable shard secret material in `twitch_conduit_shards`.
+
+**Primary variables/origins to verify**
+- `runtime_invariants.conduit_signature_secret_resolvable`.
+- `runtime_invariants.unresolved_assignments[]`.
+
+**Procedure**
+1. Run `GET /system/health` and inspect `eventsub.authoritative_guard.runtime_invariants`.
+2. Reconcile channel assignments with
+   `GET /channels/{channel}/eventsub/health?reconcile=true`.
+3. Confirm unresolved assignment count returns to `0`.
+
+#### 5) `preflight_token_subject_unresolved` (sender identity path)
+**Symptoms**
+- `eventsub.ingress_summary.last_errors.reply_preflight_failure_reason_code`
+  reports `preflight_token_subject_unresolved`.
+- Webhook replies are skipped before Send Chat API call.
+
+**Dependencies**
+- Valid bot access token in `/bot/config`.
+- Reachable Twitch `/oauth2/validate` endpoint.
+
+**Primary variables/origins to verify**
+- `runtime_invariants.sender_token_subject_resolvable`.
+- Bot token subject (`/oauth2/validate` `user_id`) vs configured sender identity.
+
+**Procedure**
+1. Refresh/reauthorize bot OAuth token if validation subject is missing.
+2. Re-check `GET /system/health` and confirm invariant becomes `true`.
+3. Confirm preflight reason field stops reporting unresolved subject failures.
+
+#### 6) Credential expiry remediation
 **Symptoms**
 - `401` from Twitch APIs (conduit registration or send chat).
 - Reconciliation/auth warnings indicating invalid or mismatched token context.
@@ -343,6 +384,9 @@ Expected:
 2. If degraded (`missing_healthy_shards` / `callback_errors_spike`), run:
    - `GET /channels/{channel}/eventsub/health?reconcile=true`
    - validate callback URL config + shard statuses.
+   - verify invariants explicitly:
+     - `curl -sS http://localhost:7070/system/health | jq '.eventsub.authoritative_guard.runtime_invariants'`
+     - `curl -sS http://localhost:7070/system/health | jq '.eventsub.ingress_summary.last_errors | {signature_failure_reason_code, reply_preflight_failure_reason_code}'`
 3. Emergency rollback:
    - set `chat_websocket_fallback_legacy_enabled=true`,
    - optionally switch `chat_ingress_mode=websocket` if operator policy

--- a/docs/backend_api.md
+++ b/docs/backend_api.md
@@ -42,14 +42,18 @@ This document summarizes the REST endpoints exposed by `backend_app.py`.
 - `eventsub.ingress_summary` includes compact operational counters:
   - callback status buckets (`2xx/4xx/5xx`),
   - signature failures,
+  - last signature failure reason (`last_errors.signature_failure_reason_code`),
   - dedupe hits,
   - Send Chat API failure reason counters (`invalid_reply_parent_message_id`,
     `sender_token_mismatch`, `invalid_sender_broadcaster_relation`,
     `empty_or_invalid_message`, `unknown_400`, transient classes),
   - per-channel webhook command dispatch outcomes,
   - conduit shard status transitions,
+  - last reply preflight failure reason (`last_errors.reply_preflight_failure_reason_code`),
   - recent callback throughput + last error timestamps/diagnostic snippets.
 - `eventsub.authoritative_guard` includes degradation reasons (`missing_healthy_shards`, `callback_errors_spike`) and whether fallback was applied.
+- `eventsub.authoritative_guard.runtime_invariants` reports runtime checks for
+  conduit shard-secret resolvability and sender token-subject resolvability.
 - Recommended operator thresholds:
   - callback error threshold: 5 errors / 5 minutes,
   - minimum healthy shards: 1 (or expected shard count for larger deployments).
@@ -264,6 +268,29 @@ Channel settings include queue intake controls:
   - Send failure reason counters (`sender_token_mismatch`,
     `invalid_reply_parent_message_id`, `unknown_400`, transient classes).
   - `event.message_id` from EventSub payload for reply threading.
+
+### `invalid_signature` troubleshooting runbook
+- **Description**: Recover conduit signature validation when active shard
+  assignments cannot resolve usable shard secret material.
+- **Dependencies**: `twitch_conduit_shards` secret state, conduit assignment
+  linkage (`event_subscriptions.conduit_id` + `event_subscriptions.shard_id`),
+  and callback signature headers.
+- **Code-customers**: Operators handling EventSub `403 invalid_signature`.
+- **Used variables/origin**:
+  - `eventsub.ingress_summary.last_errors.signature_failure_reason_code`.
+  - `eventsub.authoritative_guard.runtime_invariants.unresolved_assignments`.
+  - Per-channel reconcile output from `/channels/{channel}/eventsub/health`.
+
+### `preflight_token_subject_unresolved` troubleshooting runbook
+- **Description**: Restore webhook reply preflight when sender token subject is
+  not resolvable from Twitch `/oauth2/validate`.
+- **Dependencies**: Valid bot user token from `/bot/config`, Twitch token
+  validation reachability, and sender identity parity guard.
+- **Code-customers**: Operators triaging skipped Send Chat API calls.
+- **Used variables/origin**:
+  - `eventsub.ingress_summary.last_errors.reply_preflight_failure_reason_code`.
+  - `eventsub.authoritative_guard.runtime_invariants.sender_token_subject_resolvable`.
+  - Bot sender token subject (`/oauth2/validate` `user_id`).
 
 ### Credential expiry remediation runbook
 - **Description**: Recover from expired/invalid app or bot credentials impacting
@@ -578,7 +605,14 @@ Certain events award priority points and are fed by EventSub subscriptions creat
 6. Operator verification endpoints:
    - Call `GET /system/health` and confirm global conduit/shard coverage reports healthy.
    - Call `GET /channels/{channel}/eventsub/health?reconcile=true` and confirm per-channel subscriptions/conduit/shard coverage reconcile successfully.
-7. Legacy bug note:
+7. Post-deploy invariant verification commands:
+   - `curl -sS http://localhost:7070/system/health | jq '.eventsub.authoritative_guard.runtime_invariants'`
+   - `curl -sS http://localhost:7070/system/health | jq '.eventsub.ingress_summary.last_errors | {signature_failure_reason_code, reply_preflight_failure_reason_code}'`
+   - Expected healthy values:
+     - `conduit_signature_secret_resolvable=true`
+     - `sender_token_subject_resolvable=true`
+     - `unresolved_assignment_count=0`
+8. Legacy bug note:
    - If you previously saw `subscription id missing` on valid conduit verification callbacks, upgrade to this patch level; the callback now branches verification shape before subscription lookup.
 
 ### Channel event stream

--- a/tests/test_channel_events.py
+++ b/tests/test_channel_events.py
@@ -1994,8 +1994,9 @@ remove:
         try:
             backend_app._record_ingress_metric("callback_status", key="2xx")
             backend_app._record_ingress_metric("callback_status", key="4xx")
-            backend_app._record_ingress_metric("signature_failure")
+            backend_app._record_ingress_metric("signature_failure", key="invalid_signature")
             backend_app._record_ingress_metric("send_api_failure_reason", key="unknown_400")
+            backend_app._record_ingress_metric("send_api_failure_reason", key="preflight_token_subject_unresolved")
         finally:
             db.close()
 
@@ -2008,6 +2009,46 @@ remove:
         self.assertGreaterEqual((summary.get("callback_status") or {}).get("4xx", 0), 1)
         self.assertGreaterEqual(summary.get("signature_failures", 0), 1)
         self.assertGreaterEqual((summary.get("send_api_failure_reasons") or {}).get("unknown_400", 0), 1)
+        last_errors = summary.get("last_errors") or {}
+        self.assertEqual(last_errors.get("signature_failure_reason_code"), "invalid_signature")
+        self.assertEqual(
+            last_errors.get("reply_preflight_failure_reason_code"),
+            "preflight_token_subject_unresolved",
+        )
+
+    def test_runtime_invariant_detects_unresolved_conduit_assignment(self) -> None:
+        """Report unresolved conduit shard secret path in runtime invariants.
+
+        Dependencies: Persists conduit chat assignment rows without matching
+        shard metadata and calls runtime invariant evaluator directly.
+        Code customers: ingress guard startup/runtime invariant diagnostics.
+        Used variables/origin: assignment conduit/shard IDs come from persisted
+        ``event_subscriptions`` rows and are expected to fail secret resolution.
+        """
+
+        details = _setup_channel()
+        db = backend_app.SessionLocal()
+        try:
+            db.add(
+                backend_app.EventSubscription(
+                    channel_id=details["channel_pk"],
+                    twitch_subscription_id="sub-invariant-missing-secret",
+                    type="channel.chat.message",
+                    status="enabled",
+                    secret=backend_app.EVENTSUB_CONDUIT_SECRET_PLACEHOLDER,
+                    callback="https://example/callback",
+                    transport="conduit",
+                    conduit_id="conduit-invariant-missing",
+                    shard_id="9",
+                )
+            )
+            db.commit()
+            invariants = backend_app._evaluate_ingress_runtime_invariants(db, now=backend_app.datetime.utcnow())
+            self.assertFalse(invariants.get("conduit_signature_secret_resolvable"))
+            self.assertGreaterEqual(invariants.get("unresolved_assignment_count", 0), 1)
+            self.assertFalse(invariants.get("sender_token_subject_resolvable"))
+        finally:
+            db.close()
 
     def test_ingress_guard_degradation_can_auto_fallback_websocket_mode(self) -> None:
         """Auto-fallback to websocket mode when authoritative ingress is degraded."""


### PR DESCRIPTION
### Motivation
- Ensure two critical invariants introduced by conduit cleanup are validated at startup/runtime: conduit shard secret resolvability for active shard assignments and bot sender token subject resolvability.
- Make those invariant failures visible in health telemetry so operators can triage signature and preflight reply failures quickly.
- Provide operator runbook commands and troubleshooting docs for the two failure modes to simplify post-deploy verification and remediation.

### Description
- Added telemetry fields to `_INGRESS_METRICS.last_errors`: `signature_failure_reason_code` and `reply_preflight_failure_reason_code`, and wired them through `_record_ingress_metric` to capture explicit failure reason codes.
- Implemented `_evaluate_ingress_runtime_invariants(db, *, now)` to enumerate active conduit `event_subscriptions` assignments, check corresponding `twitch_conduit_shards` secret candidates, and resolve bot sender token subject (via a short-lived cached `_resolve_bot_sender_token_subject_cached`).
- Integrated invariant results into `_evaluate_ingress_guard(...)` under `eventsub.authoritative_guard.runtime_invariants` and added invariant-driven degradation reasons `invalid_signature` and `preflight_token_subject_unresolved` where appropriate.
- Record explicit reason codes at preflight/signature failure sites: the reply preflight path records the specific `preflight_*` reason into send failure counters, and EventSub signature branches now record `invalid_signature` / `stale_shard_secret` when detected.
- Updated operator docs (`docs/backend_api.md`, `docs/README.md`) with: ingress-summary exposure of the new fields, troubleshooting runbooks for `invalid_signature` and `preflight_token_subject_unresolved`, and explicit post-deploy verification commands to check runtime invariants.
- Added tests in `tests/test_channel_events.py` to assert ingress-summary exposure of the new last-error reason fields and to validate the runtime invariant detection for unresolved conduit assignment secret paths.

### Testing
- Compiled affected modules successfully with `python -m py_compile backend_app.py tests/test_channel_events.py` (succeeds).
- Attempted targeted pytest run with `PYTHONPATH=. pytest -q tests/test_channel_events.py -k "ingress_summary_metrics or runtime_invariant_detects_unresolved_conduit_assignment or ingress_guard_degradation_can_auto_fallback_websocket_mode"`, but test collection failed in this environment due to local DB path/environment (`sqlite3.OperationalError: unable to open database file`).
- Notes: tests were added/updated (`tests/test_channel_events.py`) and a focused test run was attempted; failure is an environment/setup issue unrelated to the code changes (DB path/permissions), not a functional assertion failure in the new logic.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cef9c289d48328a0024275a3e3a260)