### PR TITLE
Add backend-managed bot token refresh worker and ingress health signal

### DIFF
--- a/backend_app.py
+++ b/backend_app.py
@@ -3,7 +3,7 @@ import math
 import contextlib
 from functools import lru_cache
 from typing import Optional, List, Any, Dict, Mapping, Iterable, Literal, Sequence
-from threading import Lock
+from threading import Event, Lock, Thread
 import os
 import json
 import time
@@ -115,6 +115,9 @@ DEV_MODE = True
 APP_ACCESS_TOKEN: Optional[str] = None
 APP_TOKEN_EXPIRES = 0
 BOT_USER_ID: Optional[str] = None
+BOT_TOKEN_REFRESH_POLL_SECONDS = 60
+BOT_TOKEN_REFRESH_LEEWAY_SECONDS = 300
+BOT_TOKEN_REFRESH_FAILURE_GRACE_SECONDS = 900
 
 EVENTSUB_EVENT_MAP: dict[str, str] = {
     "channel.follow": "follow",
@@ -240,6 +243,17 @@ _INGRESS_METRICS: dict[str, Any] = {
     },
     "callback_events": [],
 }
+
+_BOT_TOKEN_REFRESH_LOCK = Lock()
+_BOT_TOKEN_REFRESH_STATE: dict[str, Any] = {
+    "last_attempt_at": None,
+    "last_success_at": None,
+    "last_failure_at": None,
+    "last_error": None,
+    "failure_count": 0,
+}
+_BOT_TOKEN_REFRESH_STOP_EVENT = Event()
+_BOT_TOKEN_REFRESH_WORKER: Optional[Thread] = None
 
 engine = create_engine(DB_URL, connect_args={"check_same_thread": False} if DB_URL.startswith("sqlite") else {})
 SessionLocal = sessionmaker(bind=engine, autoflush=False, autocommit=False)
@@ -1103,6 +1117,8 @@ def _evaluate_ingress_guard(db: Session, now: datetime, *, apply_fallback: bool)
         degraded_reasons.append("invalid_signature")
     if not invariants["sender_token_subject_resolvable"]:
         degraded_reasons.append("preflight_token_subject_unresolved")
+    if not invariants.get("token_refresh_healthy", True):
+        degraded_reasons.append("token_refresh_unhealthy")
     degraded = bool(degraded_reasons)
     auto_fallback_enabled = _env_flag(get_setting("chat_ingress_guard_auto_fallback_enabled", "0"))
     fallback_applied = False
@@ -1163,6 +1179,203 @@ def _resolve_bot_sender_token_subject_cached(
     return subject_id
 
 
+def _record_bot_token_refresh_result(
+    *,
+    success: bool,
+    now: datetime,
+    error: Optional[str] = None,
+) -> None:
+    """Persist in-memory token refresh worker outcomes for health diagnostics.
+
+    Dependencies: Mutates ``_BOT_TOKEN_REFRESH_STATE`` under
+    ``_BOT_TOKEN_REFRESH_LOCK``.
+    Code customers: ``_refresh_bot_access_token_once`` and ingress guard
+    runtime invariant telemetry.
+    Used variables/origin: ``now`` comes from worker runtime clock and
+    ``error`` captures Twitch/token refresh failures.
+    """
+
+    with _BOT_TOKEN_REFRESH_LOCK:
+        _BOT_TOKEN_REFRESH_STATE["last_attempt_at"] = now
+        if success:
+            _BOT_TOKEN_REFRESH_STATE["last_success_at"] = now
+            _BOT_TOKEN_REFRESH_STATE["last_error"] = None
+            _BOT_TOKEN_REFRESH_STATE["failure_count"] = 0
+            return
+        _BOT_TOKEN_REFRESH_STATE["last_failure_at"] = now
+        _BOT_TOKEN_REFRESH_STATE["last_error"] = (error or "unknown_error").strip()[:300]
+        _BOT_TOKEN_REFRESH_STATE["failure_count"] = int(_BOT_TOKEN_REFRESH_STATE.get("failure_count", 0)) + 1
+
+
+def _refresh_deadline(cfg: "BotConfig", *, leeway_seconds: int = BOT_TOKEN_REFRESH_LEEWAY_SECONDS) -> datetime:
+    """Compute token refresh deadline from ``BotConfig.expires_at`` with leeway.
+
+    Dependencies: Uses persisted ``BotConfig.expires_at`` when present.
+    Code customers: ``_refresh_bot_access_token_once`` worker refresh gate.
+    Used variables/origin: ``cfg.expires_at`` is written by bot OAuth callback
+    and previous token refresh updates.
+    """
+
+    expiry = cfg.expires_at or datetime.utcnow()
+    return expiry - timedelta(seconds=max(int(leeway_seconds), 0))
+
+
+def _refresh_token_health_snapshot(*, now: datetime) -> dict[str, Any]:
+    """Return refresh-worker health state used by ingress runtime invariants.
+
+    Dependencies: Reads ``_BOT_TOKEN_REFRESH_STATE`` under lock and compares
+    timestamps with ``BOT_TOKEN_REFRESH_FAILURE_GRACE_SECONDS``.
+    Code customers: ``_evaluate_ingress_runtime_invariants`` and
+    ``/system/health`` ingress guard diagnostics.
+    Used variables/origin: ``now`` comes from guard/worker runtime clock.
+    """
+
+    with _BOT_TOKEN_REFRESH_LOCK:
+        state = dict(_BOT_TOKEN_REFRESH_STATE)
+    last_failure_at = state.get("last_failure_at")
+    last_success_at = state.get("last_success_at")
+    failure_recent = (
+        isinstance(last_failure_at, datetime)
+        and now - last_failure_at <= timedelta(seconds=BOT_TOKEN_REFRESH_FAILURE_GRACE_SECONDS)
+        and (not isinstance(last_success_at, datetime) or last_success_at < last_failure_at)
+    )
+    return {
+        "healthy": not failure_recent,
+        "last_attempt_at": state.get("last_attempt_at"),
+        "last_success_at": last_success_at,
+        "last_failure_at": last_failure_at,
+        "last_error": state.get("last_error"),
+        "failure_count": int(state.get("failure_count") or 0),
+        "failure_grace_seconds": BOT_TOKEN_REFRESH_FAILURE_GRACE_SECONDS,
+    }
+
+
+def _refresh_bot_access_token_once(*, now: Optional[datetime] = None) -> dict[str, Any]:
+    """Refresh persisted bot OAuth credentials when expiry approaches.
+
+    Dependencies: Reads/stores ``BotConfig`` via ``SessionLocal`` and calls
+    Twitch ``/oauth2/token`` refresh-token grant with configured client creds.
+    Code customers: Background refresh worker loop; can also be used by tests.
+    Used variables/origin: refresh credentials come from persisted
+    ``BotConfig.access_token``/``refresh_token``/``expires_at``.
+    """
+
+    current_time = now or datetime.utcnow()
+    db = SessionLocal()
+    try:
+        cfg = db.query(BotConfig).order_by(BotConfig.id.asc()).first()
+        if not cfg:
+            return {"status": "missing_config"}
+        refresh_token = str(cfg.refresh_token or "").strip()
+        access_token = str(cfg.access_token or "").strip()
+        if not refresh_token or not access_token:
+            return {"status": "missing_credentials"}
+        deadline = _refresh_deadline(cfg)
+        if current_time < deadline:
+            return {
+                "status": "not_due",
+                "refresh_due_at": deadline,
+                "expires_at": cfg.expires_at,
+            }
+        client_id = get_twitch_client_id()
+        client_secret = get_twitch_client_secret()
+        if not client_id or not client_secret:
+            reason = "twitch_oauth_not_configured"
+            _record_bot_token_refresh_result(success=False, now=current_time, error=reason)
+            return {"status": "error", "reason": reason}
+        response = requests.post(
+            "https://id.twitch.tv/oauth2/token",
+            data={
+                "grant_type": "refresh_token",
+                "refresh_token": refresh_token,
+                "client_id": client_id,
+                "client_secret": client_secret,
+            },
+            timeout=10,
+        )
+        response.raise_for_status()
+        payload = response.json()
+        next_access = str(payload.get("access_token") or "").strip()
+        next_refresh = str(payload.get("refresh_token") or "").strip() or refresh_token
+        if not next_access:
+            raise RuntimeError("missing_access_token_in_refresh_response")
+        expires_in = payload.get("expires_in")
+        refreshed_scopes = payload.get("scope")
+        expires_at = cfg.expires_at
+        if isinstance(expires_in, (int, float)) and int(expires_in) > 0:
+            expires_at = current_time + timedelta(seconds=int(expires_in))
+        cfg.access_token = next_access
+        cfg.refresh_token = next_refresh
+        cfg.expires_at = expires_at
+        if isinstance(refreshed_scopes, list):
+            normalized_scopes = _normalize_scope_list(refreshed_scopes)
+            cfg.scopes = " ".join(normalized_scopes) if normalized_scopes else cfg.scopes
+        cfg.updated_at = current_time
+        db.commit()
+        _record_bot_token_refresh_result(success=True, now=current_time)
+        logger.info(
+            "BOT_TOKEN_REFRESH_SUCCESS expires_at=%s",
+            expires_at.isoformat() if isinstance(expires_at, datetime) else "<unknown>",
+        )
+        return {
+            "status": "refreshed",
+            "expires_at": expires_at,
+            "refresh_due_at": _refresh_deadline(cfg),
+        }
+    except Exception as exc:
+        db.rollback()
+        _record_bot_token_refresh_result(success=False, now=current_time, error=str(exc))
+        logger.exception("BOT_TOKEN_REFRESH_FAILED error=%s", exc)
+        return {"status": "error", "reason": str(exc)}
+    finally:
+        db.close()
+
+
+def _bot_token_refresh_worker_loop(stop_event: Event) -> None:
+    """Run a backend-managed bot token refresh loop independent of websocket runtime.
+
+    Dependencies: Calls ``_refresh_bot_access_token_once`` on a fixed cadence
+    and uses ``threading.Event`` for cooperative process shutdown.
+    Code customers: ``start_bot_token_refresh_worker`` startup bootstrap.
+    Used variables/origin: cadence comes from
+    ``BOT_TOKEN_REFRESH_POLL_SECONDS``; credentials are read from ``BotConfig``.
+    """
+
+    logger.info(
+        "BOT_TOKEN_REFRESH_WORKER_STARTED poll_seconds=%s leeway_seconds=%s",
+        BOT_TOKEN_REFRESH_POLL_SECONDS,
+        BOT_TOKEN_REFRESH_LEEWAY_SECONDS,
+    )
+    while not stop_event.is_set():
+        _refresh_bot_access_token_once()
+        stop_event.wait(timeout=max(int(BOT_TOKEN_REFRESH_POLL_SECONDS), 10))
+
+
+def start_bot_token_refresh_worker() -> None:
+    """Start singleton background worker that keeps bot OAuth token refreshed.
+
+    Dependencies: Spawns daemon ``Thread`` targeting
+    ``_bot_token_refresh_worker_loop``.
+    Code customers: module startup path after ingress-guard bootstrap.
+    Used variables/origin: singleton thread reference stored in
+    ``_BOT_TOKEN_REFRESH_WORKER``.
+    """
+
+    global _BOT_TOKEN_REFRESH_WORKER
+    worker = _BOT_TOKEN_REFRESH_WORKER
+    if worker and worker.is_alive():
+        return
+    _BOT_TOKEN_REFRESH_STOP_EVENT.clear()
+    worker = Thread(
+        target=_bot_token_refresh_worker_loop,
+        args=(_BOT_TOKEN_REFRESH_STOP_EVENT,),
+        daemon=True,
+        name="bot-token-refresh-worker",
+    )
+    worker.start()
+    _BOT_TOKEN_REFRESH_WORKER = worker
+
+
 def _evaluate_ingress_runtime_invariants(db: Session, *, now: datetime) -> dict[str, Any]:
     """Evaluate critical conduit-secret and sender-token runtime invariants.
 
@@ -1214,13 +1427,17 @@ def _evaluate_ingress_runtime_invariants(db: Session, *, now: datetime) -> dict[
     bot_access_token = (cfg.access_token if cfg and cfg.access_token else "").strip()
     token_subject_id = _resolve_bot_sender_token_subject_cached(bot_access_token, now=now) if bot_access_token else None
 
+    refresh_health = _refresh_token_health_snapshot(now=now)
+
     return {
         "conduit_signature_secret_resolvable": not unresolved_assignments,
         "sender_token_subject_resolvable": bool(token_subject_id),
+        "token_refresh_healthy": bool(refresh_health["healthy"]),
         "active_assignment_count": len(assignment_pairs),
         "unresolved_assignment_count": len(unresolved_assignments),
         "unresolved_assignments": unresolved_assignments[:10],
         "bot_sender_subject_id": token_subject_id,
+        "token_refresh_health": refresh_health,
     }
 
 
@@ -3998,7 +4215,12 @@ def _validate_startup_symbol_order() -> None:
     startup execution ordering.
     """
 
-    required_symbols = ("_coerce_int", "_ingress_guard_thresholds", "run_ingress_guard_startup_check")
+    required_symbols = (
+        "_coerce_int",
+        "_ingress_guard_thresholds",
+        "run_ingress_guard_startup_check",
+        "start_bot_token_refresh_worker",
+    )
     missing = [name for name in required_symbols if name not in globals()]
     if missing:
         raise RuntimeError(f"Startup symbol order invalid; missing definitions: {', '.join(missing)}")
@@ -4011,6 +4233,7 @@ bootstrap_settings_from_env()
 cleanup_conduit_subscription_secret_semantics()
 _validate_startup_symbol_order()
 run_ingress_guard_startup_check()
+start_bot_token_refresh_worker()
 
 # =====================================
 # Schemas

--- a/bot/bot_app.py
+++ b/bot/bot_app.py
@@ -589,6 +589,10 @@ class SongBot(commands.Bot):
             pass
 
     async def event_token_refreshed(self, payload: TokenRefreshedPayload) -> None:
+        # cleanup_candidate: token refresh events sourced from live websocket
+        # session lifecycle are now legacy because backend_app runs an
+        # authoritative refresh worker for webhook_conduit mode. Keep this path
+        # as rollback compatibility until worker stability is confirmed.
         self._user_token = payload.token
         self._refresh_token = payload.refresh_token
         self._scopes = list(payload.scopes)

--- a/docs/README.md
+++ b/docs/README.md
@@ -355,6 +355,30 @@ unlocks the API for the bot, queue manager, and public web frontend.
 3. Confirm conduit reconcile succeeds with app token auth.
 4. Confirm webhook command replies recover (Send API success + reduced 401s).
 
+#### 7) `token_refresh_unhealthy` (backend refresh worker path)
+**Symptoms**
+- `eventsub.authoritative_guard.reasons` includes `token_refresh_unhealthy`.
+- `runtime_invariants.token_refresh_healthy=false`.
+- Backend logs include `BOT_TOKEN_REFRESH_FAILED`.
+
+**Dependencies**
+- Persisted `/bot/config` credentials (`access_token`, `refresh_token`,
+  `expires_at`, `scopes`).
+- Twitch OAuth refresh-token grant endpoint.
+
+**Primary variables/origins to verify**
+- `runtime_invariants.token_refresh_health.last_success_at`.
+- `runtime_invariants.token_refresh_health.last_failure_at`.
+- Refresh deadline policy: `BotConfig.expires_at - 5 minutes`.
+
+**Procedure**
+1. Check `GET /system/health` and inspect
+   `eventsub.authoritative_guard.runtime_invariants.token_refresh_health`.
+2. Confirm backend refresh cadence (poll every 60s, refresh at `T-5m`) is
+   active in logs.
+3. If failures persist, re-run `/bot/config/oauth` to reseed tokens manually.
+4. Verify `token_refresh_healthy=true` and reason clears.
+
 ## Archive: migration and compatibility notes
 - Migration `migrations/20260330_eventsub_conduits.sql` added additive EventSub
   replay/conduit tables (`eventsub_message_dedupe`, `twitch_conduits`,
@@ -480,9 +504,15 @@ Expected:
 - In `chat_ingress_mode=webhook_conduit`, startup logs now explicitly state that
   webhook/conduit is the canonical ingress path and websocket chat subscriptions
   are rollback-only.
+- Backend now runs a dedicated token refresh worker (60s poll, refresh at
+  `expires_at - 5m`) so OAuth renewal remains active even when websocket bot
+  runtime stays idle in authoritative webhook mode.
 - Legacy websocket rollback keeps only minimal `subscribe_websocket` hooks;
   prior websocket subscription reuse/recovery loops are intentionally disabled
   to avoid accidental authoritative use during normal operations.
+- Legacy websocket-driven `event_token_refreshed` handling remains only as a
+  rollback compatibility path and is marked as a cleanup candidate after worker
+  stability is validated.
 - Honors each channel's `bot_message_level` (`mute`, `normal`, `verbose`,
   `debug`) when deciding whether to send chat output; suppressed messages still
   go to backend bot logs for observability.

--- a/docs/backend_api.md
+++ b/docs/backend_api.md
@@ -51,9 +51,11 @@ This document summarizes the REST endpoints exposed by `backend_app.py`.
   - conduit shard status transitions,
   - last reply preflight failure reason (`last_errors.reply_preflight_failure_reason_code`),
   - recent callback throughput + last error timestamps/diagnostic snippets.
-- `eventsub.authoritative_guard` includes degradation reasons (`missing_healthy_shards`, `callback_errors_spike`) and whether fallback was applied.
+- `eventsub.authoritative_guard` includes degradation reasons (`missing_healthy_shards`, `callback_errors_spike`, `token_refresh_unhealthy`) and whether fallback was applied.
 - `eventsub.authoritative_guard.runtime_invariants` reports runtime checks for
-  conduit shard-secret resolvability and sender token-subject resolvability.
+  conduit shard-secret resolvability, sender token-subject resolvability, and
+  bot token refresh-worker health (`token_refresh_healthy`,
+  `token_refresh_health.*`).
 - Recommended operator thresholds:
   - callback error threshold: 5 errors / 5 minutes,
   - minimum healthy shards: 1 (or expected shard count for larger deployments).
@@ -302,6 +304,32 @@ Channel settings include queue intake controls:
   - Setup credentials in `/system/config` (`client_id`, `client_secret`).
   - Bot auth state in `/bot/config`.
   - Twitch `/oauth2/validate` responses for token subject/scope validation.
+
+### `token_refresh_unhealthy` troubleshooting runbook
+- **Description**: Recover backend-managed bot token refresh when authoritative
+  webhook mode no longer receives healthy refresh outcomes.
+- **Dependencies**: Stored `BotConfig` refresh credentials, Twitch OAuth token
+  endpoint, and ingress guard runtime invariants.
+- **Code-customers**: Operators responsible for webhook-conduit ingress
+  continuity while websocket runtime is disabled.
+- **Used variables/origin**:
+  - `eventsub.authoritative_guard.runtime_invariants.token_refresh_healthy`.
+  - `eventsub.authoritative_guard.runtime_invariants.token_refresh_health`.
+  - `BotConfig.expires_at` with refresh deadline (`expires_at - 5m`).
+- **Refresh cadence**:
+  1. Backend refresh worker polls every 60s.
+  2. Token refresh triggers at `T-5m` before `expires_at`.
+  3. On success, backend persists `access_token`, `refresh_token`,
+     `expires_at`, and refreshed `scopes`.
+- **Failure alarms**:
+  1. `token_refresh_healthy=false` in `/system/health`.
+  2. `token_refresh_unhealthy` appears in
+     `eventsub.authoritative_guard.reasons`.
+  3. Backend logs emit `BOT_TOKEN_REFRESH_FAILED`.
+- **Manual recovery flow**:
+  1. Validate Twitch app credentials in `/system/config`.
+  2. Re-run `/bot/config/oauth` authorization to reseed bot tokens.
+  3. Confirm `/system/health` shows `token_refresh_healthy=true`.
 
 ## Archive: migration and compatibility notes
 - `migrations/20240624_queue_caps.sql` introduced queue capacity columns and

--- a/tests/test_channel_events.py
+++ b/tests/test_channel_events.py
@@ -33,11 +33,22 @@ def _wipe_db() -> None:
             backend_app.ChannelModerator,
             backend_app.ActiveChannel,
             backend_app.TwitchUser,
+            backend_app.BotConfig,
         ]:
             db.query(model).delete()
         db.commit()
     finally:
         db.close()
+    with backend_app._BOT_TOKEN_REFRESH_LOCK:
+        backend_app._BOT_TOKEN_REFRESH_STATE.update(
+            {
+                "last_attempt_at": None,
+                "last_success_at": None,
+                "last_failure_at": None,
+                "last_error": None,
+                "failure_count": 0,
+            }
+        )
 
 
 def _setup_channel() -> Dict[str, int]:
@@ -2070,6 +2081,83 @@ remove:
             self.assertTrue(guard["degraded"])
             self.assertTrue(guard["auto_fallback_applied"])
             self.assertEqual(backend_app.get_chat_ingress_mode(), "websocket")
+        finally:
+            db.close()
+
+    def test_backend_token_refresh_worker_persists_refreshed_bot_tokens(self) -> None:
+        """Refresh due bot credentials and persist replacement token fields.
+
+        Dependencies: BotConfig persistence, Twitch refresh-token grant API,
+        and ``_refresh_bot_access_token_once`` scheduler routine.
+        Code customers: backend token refresh worker in webhook_conduit mode.
+        Used variables/origin: stored ``BotConfig`` refresh credentials and
+        ``expires_at`` trigger refresh before expiry (T-5m).
+        """
+
+        db = backend_app.SessionLocal()
+        try:
+            db.query(backend_app.BotConfig).delete()
+            cfg = backend_app.BotConfig(
+                login="botlogin",
+                display_name="Bot Login",
+                access_token="old-access",
+                refresh_token="old-refresh",
+                scopes="user:bot",
+                expires_at=backend_app.datetime.utcnow() + backend_app.timedelta(minutes=3),
+                enabled=True,
+            )
+            db.add(cfg)
+            db.commit()
+        finally:
+            db.close()
+
+        response_mock = mock.Mock()
+        response_mock.raise_for_status.return_value = None
+        response_mock.json.return_value = {
+            "access_token": "new-access",
+            "refresh_token": "new-refresh",
+            "expires_in": 3600,
+            "scope": ["user:bot", "user:read:chat"],
+        }
+        with mock.patch.object(backend_app, "get_twitch_client_id", return_value="cid"), mock.patch.object(
+            backend_app, "get_twitch_client_secret", return_value="secret"
+        ), mock.patch.object(backend_app.requests, "post", return_value=response_mock):
+            result = backend_app._refresh_bot_access_token_once(now=backend_app.datetime.utcnow())
+        self.assertEqual(result.get("status"), "refreshed")
+
+        verify_db = backend_app.SessionLocal()
+        try:
+            refreshed = verify_db.query(backend_app.BotConfig).order_by(backend_app.BotConfig.id.asc()).first()
+            self.assertIsNotNone(refreshed)
+            assert refreshed
+            self.assertEqual(refreshed.access_token, "new-access")
+            self.assertEqual(refreshed.refresh_token, "new-refresh")
+            self.assertIn("user:read:chat", str(refreshed.scopes))
+            self.assertIsNotNone(refreshed.expires_at)
+        finally:
+            verify_db.close()
+
+    def test_ingress_guard_runtime_invariants_report_refresh_health(self) -> None:
+        """Expose token refresh worker health separately from callback health.
+
+        Dependencies: in-memory refresh worker state, ingress runtime invariant
+        evaluator, and guard degradation reason composition.
+        Code customers: `/system/health` operator diagnostics and guard alerting.
+        Used variables/origin: refresh failure timestamps in
+        ``_BOT_TOKEN_REFRESH_STATE`` are checked via
+        ``runtime_invariants.token_refresh_health``.
+        """
+
+        _setup_channel()
+        db = backend_app.SessionLocal()
+        now = backend_app.datetime.utcnow()
+        try:
+            backend_app._record_bot_token_refresh_result(success=False, now=now, error="synthetic_failure")
+            invariants = backend_app._evaluate_ingress_runtime_invariants(db, now=now)
+            self.assertFalse(invariants.get("token_refresh_healthy"))
+            self.assertEqual((invariants.get("token_refresh_health") or {}).get("last_error"), "synthetic_failure")
+            guard = backend_app._evaluate_ingress_guard(db, now, apply_fallback=False)
+            self.assertIn("token_refresh_unhealthy", guard.get("reasons", []))
         finally:
             db.close()
 


### PR DESCRIPTION
### Motivation
- Ensure bot OAuth refresh continues to run even when websocket bot runtime is idle in authoritative `webhook_conduit` mode so webhook replies and conduit reconciliation keep a valid bot token.
- Persist refreshed `access_token`/`refresh_token`/`expires_at`/`scopes` from refresh grant responses to the existing `BotConfig` record so other subsystems keep using updated credentials.
- Surface token-refresh health separately from callback/shard health so the ingress guard can distinguish token expiry/refresh problems from webhook delivery issues.
- Provide operator runbook guidance, alarms, and a manual recovery flow for token refresh failures and mark websocket-driven refresh paths as legacy to enable removal later.

### Description
- Added a backend refresh worker: cadence constants (`BOT_TOKEN_REFRESH_POLL_SECONDS`, `BOT_TOKEN_REFRESH_LEEWAY_SECONDS`, `BOT_TOKEN_REFRESH_FAILURE_GRACE_SECONDS`), in-memory refresh state and lock, `_refresh_bot_access_token_once`, `_bot_token_refresh_worker_loop`, `start_bot_token_refresh_worker`, and supporting helpers (`_refresh_deadline`, `_record_bot_token_refresh_result`, `_refresh_token_health_snapshot`) that persist refreshed tokens to `BotConfig` via DB commits.
- Integrated refresh health into ingress invariants and guard: `_evaluate_ingress_runtime_invariants` now returns `token_refresh_healthy` and `token_refresh_health`, and `_evaluate_ingress_guard` adds `token_refresh_unhealthy` to degradation reasons when appropriate.
- Startup wiring: `start_bot_token_refresh_worker()` is invoked during module startup after ingress guard bootstrap so the worker runs in authoritative `webhook_conduit` deployments.
- Bot runtime compatibility: marked websocket-sourced `event_token_refreshed` handling in `bot/bot_app.py` as a cleanup candidate/legacy path while preserving behavior for rollback compatibility.
- Documentation and runbook updates: updated `docs/backend_api.md` and `docs/README.md` to document refresh cadence (poll 60s, refresh at T-5m), failure alarms, and manual recovery steps.
- Tests and hygiene: added tests in `tests/test_channel_events.py` to assert refresh persistence and refresh-health reporting, reset in-memory refresh state in test DB wipe, and added/expanded function docstrings following the requested format (short description, dependencies, code-customers, used variables/origin).

### Testing
- Successfully compiled modules with `python -m py_compile backend_app.py bot/bot_app.py tests/test_channel_events.py` (OK).
- Ran targeted pytest invocation for the new/specific tests but environment constraints prevented DB access: `PYTHONPATH=. pytest -q tests/test_channel_events.py -k "token_refresh_worker_persists_refreshed_bot_tokens or ingress_guard_runtime_invariants_report_refresh_health"` failed due to the container's SQLite DB path `/data/db.sqlite` being unavailable during import (test runtime limitation), so DB-backed tests could not be executed here.
- Added unit test cases exercising `_refresh_bot_access_token_once` (mocking Twitch responses) and invariants; these tests compile and are included under `tests/test_channel_events.py` for CI environments with DB access.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cefe708b4883289deaa004fdc36c5a)