### PR TITLE
Harden EventSub webhook reply preflight identity validation

### DIFF
--- a/backend_app.py
+++ b/backend_app.py
@@ -199,9 +199,12 @@ BOT_MESSAGE_DEFAULT_TEMPLATES: dict[str, str] = {
 }
 BOT_MESSAGE_LEVEL_RANK: dict[str, int] = {"mute": 0, "normal": 1, "verbose": 2, "debug": 3}
 TWITCH_SEND_CHAT_MESSAGE_MAX_LENGTH = 500
+TWITCH_TOKEN_SUBJECT_CACHE_TTL_SECONDS = 300
 
 _bot_log_listeners: set[asyncio.Queue[str]] = set()
 _bot_oauth_states: dict[str, Dict[str, Any]] = {}
+_BOT_TOKEN_SUBJECT_CACHE_LOCK = Lock()
+_BOT_TOKEN_SUBJECT_CACHE: dict[str, dict[str, Any]] = {}
 
 logger = logging.getLogger(__name__)
 
@@ -220,6 +223,9 @@ _INGRESS_METRICS: dict[str, Any] = {
         "sender_token_mismatch": 0,
         "invalid_sender_broadcaster_relation": 0,
         "empty_or_invalid_message": 0,
+        "preflight_validate_failed": 0,
+        "preflight_missing_bot_token": 0,
+        "preflight_subject_mismatch": 0,
         "unknown_400": 0,
         "transient_5xx": 0,
         "timeout": 0,
@@ -1573,10 +1579,16 @@ def _should_send_eventsub_reply(channel: ActiveChannel, visibility: str) -> bool
     return threshold_name != "mute" and message_rank <= threshold_rank
 
 
-def _resolve_twitch_token_subject_id(access_token: str, *, timeout: float = 6.0) -> Optional[str]:
-    """Resolve Twitch OAuth token subject user id via validation endpoint.
+def _resolve_twitch_token_subject_id(
+    access_token: str,
+    *,
+    timeout: float = 6.0,
+    force_revalidate: bool = False,
+) -> tuple[Optional[str], str]:
+    """Resolve and cache Twitch OAuth token subject user id from token validation.
 
-    Dependencies: Performs an HTTPS GET to Twitch ``/oauth2/validate``.
+    Dependencies: Uses in-process TTL cache and Twitch ``/oauth2/validate``
+    HTTPS GET fallback for cache misses/revalidation.
     Code customers: ``_preflight_eventsub_chat_reply_payload`` sender parity.
     Used variables/origin: ``access_token`` comes from persisted bot OAuth
     credentials and maps to validation response field ``user_id``.
@@ -1584,17 +1596,38 @@ def _resolve_twitch_token_subject_id(access_token: str, *, timeout: float = 6.0)
 
     token = (access_token or "").strip()
     if not token:
-        return None
-    response = requests.get(
-        "https://id.twitch.tv/oauth2/validate",
-        headers={"Authorization": f"OAuth {token}"},
-        timeout=timeout,
-    )
+        return None, "missing_bot_token"
+    now = time.time()
+    if not force_revalidate:
+        with _BOT_TOKEN_SUBJECT_CACHE_LOCK:
+            cached = _BOT_TOKEN_SUBJECT_CACHE.get(token)
+            if cached and float(cached.get("expires_at", 0)) > now:
+                cached_subject = str(cached.get("subject_id") or "").strip()
+                if cached_subject:
+                    return cached_subject, "cache_hit"
+    try:
+        response = requests.get(
+            "https://id.twitch.tv/oauth2/validate",
+            headers={"Authorization": f"OAuth {token}"},
+            timeout=timeout,
+        )
+    except requests.RequestException:
+        return None, "validate_failed"
     if response.status_code != 200:
-        return None
-    payload = response.json()
+        return None, "validate_failed"
+    try:
+        payload = response.json()
+    except ValueError:
+        return None, "validate_failed"
     subject_id = str(payload.get("user_id") or "").strip()
-    return subject_id or None
+    if not subject_id:
+        return None, "validate_failed"
+    with _BOT_TOKEN_SUBJECT_CACHE_LOCK:
+        _BOT_TOKEN_SUBJECT_CACHE[token] = {
+            "subject_id": subject_id,
+            "expires_at": now + TWITCH_TOKEN_SUBJECT_CACHE_TTL_SECONDS,
+        }
+    return subject_id, "validated"
 
 
 def _build_eventsub_chat_reply_payload(
@@ -1633,8 +1666,9 @@ def _preflight_eventsub_chat_reply_payload(
 ) -> tuple[Optional[dict[str, Any]], Optional[str], Optional[dict[str, str]]]:
     """Validate deterministic Twitch send-chat inputs before HTTP requests.
 
-    Dependencies: Reads ``BotConfig`` for bot access token, validates token
-    subject via Twitch ``/oauth2/validate``, and assembles Helix headers.
+    Dependencies: Reads ``BotConfig`` for bot access token, resolves/caches
+    token subject via ``_resolve_twitch_token_subject_id``, and assembles Helix
+    headers.
     Code customers: ``_send_eventsub_chat_reply`` deterministic preflight guard.
     Used variables/origin: broadcaster id from ``channel.channel_id``,
     ``sender_id`` from bot identity resolution, ``message`` from rendered reply,
@@ -1655,17 +1689,24 @@ def _preflight_eventsub_chat_reply_payload(
     cfg = db.query(BotConfig).order_by(BotConfig.id.asc()).first()
     access_token = (cfg.access_token if cfg and cfg.access_token else "").strip()
     if not access_token:
-        return None, "preflight_missing_bot_access_token", None
-    token_subject_id = _resolve_twitch_token_subject_id(access_token)
+        return None, "preflight_missing_bot_token", None
+    token_subject_id, resolution_status = _resolve_twitch_token_subject_id(access_token)
+    if not token_subject_id and resolution_status == "validate_failed":
+        # cleanup_candidate: collapse this explicit one-shot refresh path into
+        # shared bot-auth refresh orchestration once unified token management
+        # lands across EventSub preflight and admin OAuth maintenance.
+        token_subject_id, resolution_status = _resolve_twitch_token_subject_id(access_token, force_revalidate=True)
     if not token_subject_id:
-        return None, "preflight_token_subject_unresolved", None
+        return None, (
+            "preflight_missing_bot_token" if resolution_status == "missing_bot_token" else "preflight_validate_failed"
+        ), None
     if token_subject_id != normalized_sender_id:
-        return None, "preflight_sender_token_subject_mismatch", None
+        return None, "preflight_subject_mismatch", None
 
     headers = _eventsub_headers(access_token)
     payload = _build_eventsub_chat_reply_payload(
         broadcaster_id=broadcaster_id,
-        sender_id=normalized_sender_id,
+        sender_id=token_subject_id,
         message=normalized_message,
         reply_parent_message_id=(reply_parent_message_id or "").strip() or None,
     )
@@ -1750,8 +1791,8 @@ def _map_send_api_400_reason_code(*, status_code: Optional[int], message: str, e
 def _send_eventsub_chat_reply(db: Session, channel: ActiveChannel, reply: dict[str, Any], *, reply_parent_message_id: Optional[str]) -> bool:
     """Send webhook reply text through Twitch Send Chat Message API with retries.
 
-    Dependencies: Resolves sender identity via ``get_bot_user_id``, validates
-    deterministic payload constraints through
+    Dependencies: Resolves sender identity via ``get_bot_user_id`` (configured
+    bot identity), validates deterministic payload constraints through
     ``_preflight_eventsub_chat_reply_payload``, then POSTs
     ``/helix/chat/messages``.
     Code customers: ``_process_eventsub_chat_notification`` authoritative path.
@@ -1777,10 +1818,11 @@ def _send_eventsub_chat_reply(db: Session, channel: ActiveChannel, reply: dict[s
     )
     if preflight_reason_code or not payload or not headers:
         _record_ingress_metric("send_api_failure")
-        _record_ingress_metric("send_api_failure_reason", key="preflight_rejected")
+        tracked_reason = preflight_reason_code or "preflight_rejected"
+        _record_ingress_metric("send_api_failure_reason", key=tracked_reason)
         logger.warning(
             "Webhook reply send skipped by preflight: reason_code=%s channel=%s template_key=%s",
-            preflight_reason_code or "preflight_unknown_failure",
+            tracked_reason,
             channel.channel_name,
             reply.get("template_key"),
         )

--- a/docs/README.md
+++ b/docs/README.md
@@ -110,7 +110,9 @@ unlocks the API for the bot, queue manager, and public web frontend.
   - `GET /system/health.eventsub.ingress_summary` adds compact runtime counters:
     callback 2xx/4xx/5xx, signature failures, dedupe hits, per-channel command
     dispatch outcomes, shard status transitions, Send Chat API failure reasons
-    (including mapped 400 validation classes), and last error timestamps.
+    (including mapped 400 validation classes plus preflight token-subject
+    classes `preflight_validate_failed`, `preflight_missing_bot_token`, and
+    `preflight_subject_mismatch`), and last error timestamps.
   - `GET /system/health.eventsub.authoritative_guard` reports degradation
     reasons and whether auto-fallback was applied.
   - `GET /channels/{channel}/eventsub/health` reports per-channel shard

--- a/docs/backend_api.md
+++ b/docs/backend_api.md
@@ -45,7 +45,9 @@ This document summarizes the REST endpoints exposed by `backend_app.py`.
   - dedupe hits,
   - Send Chat API failure reason counters (`invalid_reply_parent_message_id`,
     `sender_token_mismatch`, `invalid_sender_broadcaster_relation`,
-    `empty_or_invalid_message`, `unknown_400`, transient classes),
+    `empty_or_invalid_message`, `preflight_validate_failed`,
+    `preflight_missing_bot_token`, `preflight_subject_mismatch`, `unknown_400`,
+    transient classes),
   - per-channel webhook command dispatch outcomes,
   - conduit shard status transitions,
   - recent callback throughput + last error timestamps/diagnostic snippets.

--- a/tests/test_channel_events.py
+++ b/tests/test_channel_events.py
@@ -174,6 +174,30 @@ def _create_chat_conduit_subscription(
         db.close()
 
 
+def _upsert_bot_config_token(*, access_token: str) -> None:
+    """Persist a deterministic bot token fixture for EventSub reply preflight tests.
+
+    Dependencies: ``BotConfig`` ORM row in the shared SQLite test database.
+    Code customers: send-chat preflight tests needing explicit bot token
+    presence/absence controls. Used variables/origin: ``access_token`` is
+    provided by each test scenario.
+    """
+
+    db = backend_app.SessionLocal()
+    try:
+        cfg = db.query(backend_app.BotConfig).order_by(backend_app.BotConfig.id.asc()).first()
+        if not cfg:
+            cfg = backend_app.BotConfig(access_token=access_token, refresh_token="refresh-token", enabled=True)
+            db.add(cfg)
+        else:
+            cfg.access_token = access_token
+            cfg.refresh_token = cfg.refresh_token or "refresh-token"
+            cfg.enabled = True
+        db.commit()
+    finally:
+        db.close()
+
+
 def _signed_eventsub_headers(secret: str, message_id: str, timestamp: str, raw_payload: bytes) -> Dict[str, str]:
     """Build Twitch EventSub callback headers with a valid HMAC signature.
 
@@ -195,6 +219,9 @@ def _signed_eventsub_headers(secret: str, message_id: str, timestamp: str, raw_p
 class ChannelEventTests(unittest.TestCase):
     def setUp(self) -> None:
         _wipe_db()
+        backend_app.BOT_USER_ID = None
+        with backend_app._BOT_TOKEN_SUBJECT_CACHE_LOCK:
+            backend_app._BOT_TOKEN_SUBJECT_CACHE.clear()
         self.client = TestClient(backend_app.app)
 
     def tearDown(self) -> None:
@@ -900,7 +927,7 @@ class ChannelEventTests(unittest.TestCase):
         timestamp = "2023-01-01T00:00:00Z"
         signature = hmac.new(secret.encode(), msg=(message_id + timestamp).encode() + raw, digestmod=hashlib.sha256)
         with mock.patch.object(backend_app, "get_bot_user_id", return_value="bot-user-1"), mock.patch.object(
-            backend_app, "_resolve_twitch_token_subject_id", return_value="bot-user-1"
+            backend_app, "_resolve_twitch_token_subject_id", return_value=("bot-user-1", "validated")
         ), mock.patch("backend_app.requests.post") as mock_send:
             mock_send.return_value.raise_for_status.return_value = None
             response = self.client.post(
@@ -973,7 +1000,7 @@ class ChannelEventTests(unittest.TestCase):
         signature = hmac.new(secret.encode(), msg=(message_id + timestamp).encode() + raw, digestmod=hashlib.sha256)
         with mock.patch.object(backend_app, "_fetch_youtube_oembed_title", return_value="Artist D - Song Four"), mock.patch.object(
             backend_app, "get_bot_user_id", return_value="bot-user-1"
-        ), mock.patch.object(backend_app, "_resolve_twitch_token_subject_id", return_value="bot-user-1"), mock.patch(
+        ), mock.patch.object(backend_app, "_resolve_twitch_token_subject_id", return_value=("bot-user-1", "validated")), mock.patch(
             "backend_app.requests.post"
         ) as mock_send:
             mock_send.return_value.raise_for_status.return_value = None
@@ -1046,7 +1073,7 @@ class ChannelEventTests(unittest.TestCase):
         signature = hmac.new(secret.encode(), msg=(message_id + timestamp).encode() + raw, digestmod=hashlib.sha256)
         with mock.patch.object(backend_app, "_fetch_youtube_oembed_title", return_value="Artist D - Song Four"), mock.patch.object(
             backend_app, "get_bot_user_id", return_value="bot-user-1"
-        ), mock.patch.object(backend_app, "_resolve_twitch_token_subject_id", return_value="bot-user-1"), mock.patch(
+        ), mock.patch.object(backend_app, "_resolve_twitch_token_subject_id", return_value=("bot-user-1", "validated")), mock.patch(
             "backend_app.requests.post"
         ) as mock_send:
             mock_send.return_value.raise_for_status.return_value = None
@@ -1118,7 +1145,7 @@ class ChannelEventTests(unittest.TestCase):
         timestamp = "2023-01-01T00:00:00Z"
         signature = hmac.new(secret.encode(), msg=(message_id + timestamp).encode() + raw, digestmod=hashlib.sha256)
         with mock.patch.object(backend_app, "get_bot_user_id", return_value="bot-user-1"), mock.patch.object(
-            backend_app, "_resolve_twitch_token_subject_id", return_value="bot-user-1"
+            backend_app, "_resolve_twitch_token_subject_id", return_value=("bot-user-1", "validated")
         ), mock.patch("backend_app.requests.post") as mock_send:
             mock_send.return_value.raise_for_status.return_value = None
             response = self.client.post(
@@ -1190,7 +1217,7 @@ class ChannelEventTests(unittest.TestCase):
         timestamp = "2023-01-01T00:00:00Z"
         signature = hmac.new(secret.encode(), msg=(header_message_id + timestamp).encode() + raw, digestmod=hashlib.sha256)
         with mock.patch.object(backend_app, "get_bot_user_id", return_value="bot-user-1"), mock.patch.object(
-            backend_app, "_resolve_twitch_token_subject_id", return_value="bot-user-1"
+            backend_app, "_resolve_twitch_token_subject_id", return_value=("bot-user-1", "validated")
         ), mock.patch("backend_app.requests.post") as mock_send:
             mock_send.return_value.raise_for_status.return_value = None
             response = self.client.post(
@@ -1248,7 +1275,7 @@ class ChannelEventTests(unittest.TestCase):
         timestamp = "2023-01-01T00:00:00Z"
         signature = hmac.new(secret.encode(), msg=(header_message_id + timestamp).encode() + raw, digestmod=hashlib.sha256)
         with mock.patch.object(backend_app, "get_bot_user_id", return_value="bot-user-1"), mock.patch.object(
-            backend_app, "_resolve_twitch_token_subject_id", return_value="bot-user-1"
+            backend_app, "_resolve_twitch_token_subject_id", return_value=("bot-user-1", "validated")
         ), mock.patch("backend_app.requests.post") as mock_send:
             mock_send.return_value.raise_for_status.return_value = None
             response = self.client.post(
@@ -1306,8 +1333,9 @@ class ChannelEventTests(unittest.TestCase):
         header_message_id = "header-message-id-sender-mismatch"
         timestamp = "2023-01-01T00:00:00Z"
         signature = hmac.new(secret.encode(), msg=(header_message_id + timestamp).encode() + raw, digestmod=hashlib.sha256)
+        _upsert_bot_config_token(access_token="bot-access-token-mismatch")
         with mock.patch.object(backend_app, "get_bot_user_id", return_value="bot-user-1"), mock.patch.object(
-            backend_app, "_resolve_twitch_token_subject_id", return_value="bot-user-2"
+            backend_app, "_resolve_twitch_token_subject_id", return_value=("bot-user-2", "validated")
         ), mock.patch("backend_app.requests.post") as mock_send:
             response = self.client.post(
                 "/twitch/eventsub/callback",
@@ -1321,6 +1349,67 @@ class ChannelEventTests(unittest.TestCase):
             )
             self.assertEqual(mock_send.call_count, 0)
         self.assertEqual(response.status_code, 200, response.text)
+        snapshot = backend_app._ingress_metrics_snapshot(backend_app.datetime.utcnow())
+        reasons = snapshot.get("send_api_failure_reasons") or {}
+        self.assertGreaterEqual(reasons.get("preflight_subject_mismatch", 0), 1)
+
+    def test_send_eventsub_chat_reply_preflight_valid_subject_sends(self) -> None:
+        """Send reply when resolved bot token subject matches configured bot identity."""
+
+        details = _setup_channel()
+        _upsert_bot_config_token(access_token="bot-access-token-valid")
+        db = backend_app.SessionLocal()
+        try:
+            channel = db.get(backend_app.ActiveChannel, details["channel_pk"])
+            self.assertIsNotNone(channel)
+            reply = {"status": "success", "template_key": "queue_open", "template_vars": {}, "visibility": "normal"}
+            with mock.patch.object(backend_app, "get_bot_user_id", return_value="bot-user-1"), mock.patch.object(
+                backend_app, "_resolve_twitch_token_subject_id", return_value=("bot-user-1", "validated")
+            ), mock.patch.object(
+                backend_app, "_eventsub_headers", return_value={"Authorization": "Bearer bot-access-token-valid", "Client-Id": "cid"}
+            ), mock.patch("backend_app.requests.post") as mock_send:
+                mock_send.return_value.raise_for_status.return_value = None
+                sent = backend_app._send_eventsub_chat_reply(
+                    db,
+                    channel,
+                    reply,
+                    reply_parent_message_id="event-message-id-valid",
+                )
+            self.assertTrue(sent)
+            self.assertEqual(mock_send.call_count, 1)
+            self.assertEqual(mock_send.call_args.kwargs["json"]["sender_id"], "bot-user-1")
+        finally:
+            db.close()
+
+    def test_send_eventsub_chat_reply_preflight_transient_validate_failure_recovers(self) -> None:
+        """Retry token subject validation once on transient failure before skipping send."""
+
+        details = _setup_channel()
+        _upsert_bot_config_token(access_token="bot-access-token-recover")
+        db = backend_app.SessionLocal()
+        try:
+            channel = db.get(backend_app.ActiveChannel, details["channel_pk"])
+            self.assertIsNotNone(channel)
+            reply = {"status": "success", "template_key": "queue_open", "template_vars": {}, "visibility": "normal"}
+            with mock.patch.object(backend_app, "get_bot_user_id", return_value="bot-user-1"), mock.patch.object(
+                backend_app,
+                "_resolve_twitch_token_subject_id",
+                side_effect=[(None, "validate_failed"), ("bot-user-1", "validated")],
+            ) as mock_resolve, mock.patch.object(
+                backend_app, "_eventsub_headers", return_value={"Authorization": "Bearer bot-access-token-recover", "Client-Id": "cid"}
+            ), mock.patch("backend_app.requests.post") as mock_send:
+                mock_send.return_value.raise_for_status.return_value = None
+                sent = backend_app._send_eventsub_chat_reply(
+                    db,
+                    channel,
+                    reply,
+                    reply_parent_message_id="event-message-id-recover",
+                )
+            self.assertTrue(sent)
+            self.assertEqual(mock_resolve.call_count, 2)
+            self.assertEqual(mock_send.call_count, 1)
+        finally:
+            db.close()
 
     def test_send_eventsub_chat_reply_preflight_invalid_message_length_skips_request(self) -> None:
         """Skip Send Chat API call when rendered message violates Twitch length limits."""
@@ -1338,7 +1427,7 @@ class ChannelEventTests(unittest.TestCase):
                 "visibility": "normal",
             }
             with mock.patch.object(backend_app, "get_bot_user_id", return_value="bot-user-1"), mock.patch.object(
-                backend_app, "_resolve_twitch_token_subject_id", return_value="bot-user-1"
+                backend_app, "_resolve_twitch_token_subject_id", return_value=("bot-user-1", "validated")
             ), mock.patch("backend_app.requests.post") as mock_send:
                 sent = backend_app._send_eventsub_chat_reply(
                     db,
@@ -1366,7 +1455,7 @@ class ChannelEventTests(unittest.TestCase):
             response._content = b'{"error":"Bad Request","status":400,"message":"reply_parent_message_id is invalid"}'
             error = requests.HTTPError(response=response)
             with mock.patch.object(backend_app, "get_bot_user_id", return_value="bot-user-1"), mock.patch.object(
-                backend_app, "_resolve_twitch_token_subject_id", return_value="bot-user-1"
+                backend_app, "_resolve_twitch_token_subject_id", return_value=("bot-user-1", "validated")
             ), mock.patch("backend_app.requests.post", side_effect=error) as mock_send:
                 sent = backend_app._send_eventsub_chat_reply(
                     db,
@@ -1397,7 +1486,7 @@ class ChannelEventTests(unittest.TestCase):
             response._content = b'{"error":"Service Unavailable","status":503,"message":"server overloaded"}'
             error = requests.HTTPError(response=response)
             with mock.patch.object(backend_app, "get_bot_user_id", return_value="bot-user-1"), mock.patch.object(
-                backend_app, "_resolve_twitch_token_subject_id", return_value="bot-user-1"
+                backend_app, "_resolve_twitch_token_subject_id", return_value=("bot-user-1", "validated")
             ), mock.patch("backend_app.requests.post", side_effect=error) as mock_send, mock.patch(
                 "backend_app.time.sleep", return_value=None
             ):


### PR DESCRIPTION
### Motivation
- Ensure webhook-authoritative EventSub chat replies reliably validate the configured bot identity before sending replies so outgoing `sender_id` cannot be forged by stale/mismatched tokens. 

### Description
- Add a TTL-backed in-process cache and lock (`_BOT_TOKEN_SUBJECT_CACHE`, `_BOT_TOKEN_SUBJECT_CACHE_LOCK`) and a TTL constant `TWITCH_TOKEN_SUBJECT_CACHE_TTL_SECONDS` for bot token subject resolution. 
- Replace the old `_resolve_twitch_token_subject_id` with a version that returns `(subject_id, status)` and supports cache hits, validation via `/oauth2/validate`, structured statuses (`cache_hit`, `validated`, `validate_failed`, `missing_bot_token`) and an optional `force_revalidate` path. 
- Update `_preflight_eventsub_chat_reply_payload` to require explicit bot token presence, perform one controlled revalidate on transient validation failure, enforce subject parity (`preflight_subject_mismatch`), and set the outgoing `sender_id` from the resolved token subject; add a cleanup marker for the temporary one-shot revalidate branch. 
- Split preflight failure telemetry into named reason keys and add ingress counters `preflight_validate_failed`, `preflight_missing_bot_token`, and `preflight_subject_mismatch`; make preflight reason used for `send_api_failure_reason` tracking and logs. 
- Update tests to persist a deterministic bot token fixture (`_upsert_bot_config_token`), clear in-process bot identity cache in test `setUp`, and add/adjust tests covering valid subject send, transient validation recovery, and subject mismatch tracking. 
- Update docs (`docs/README.md`, `docs/backend_api.md`) to include the new preflight reason taxonomy in `/system/health` ingress summaries. 

### Testing
- Ran targeted unit tests: `PYTHONPATH=. pytest -q tests/test_channel_events.py -k "preflight_valid_subject_sends or transient_validate_failure_recovers or sender_subject_mismatch_skips_send"` and fixed environment issues (added `/data` as DB path mount) to allow DB creation; final run passed 3 tests. 
- Earlier automated test runs initially failed due to test environment issues (`ModuleNotFoundError` from missing `PYTHONPATH` and `sqlite` `/data` directory), which were resolved and the tests re-run successfully. 
- The three focused tests that validate the change (`test_send_eventsub_chat_reply_preflight_valid_subject_sends`, `test_send_eventsub_chat_reply_preflight_transient_validate_failure_recovers`, `test_eventsub_chat_notification_preflight_sender_subject_mismatch_skips_send`) passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ceee4679fc8328a2c63f1cd3e55c27)