### PR TITLE
Centralize Send Chat auth policy and align token terminology

### DIFF
--- a/backend_app.py
+++ b/backend_app.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 import math
 import contextlib
 from functools import lru_cache
-from typing import Optional, List, Any, Dict, Mapping, Iterable, Literal, Sequence
+from typing import Optional, List, Any, Dict, Mapping, Iterable, Literal, Sequence, cast
 from threading import Event, Lock, Thread
 import os
 import json
@@ -214,6 +214,9 @@ BOT_MESSAGE_DEFAULT_TEMPLATES: dict[str, str] = {
 }
 BOT_MESSAGE_LEVEL_RANK: dict[str, int] = {"mute": 0, "normal": 1, "verbose": 2, "debug": 3}
 TWITCH_SEND_CHAT_MESSAGE_MAX_LENGTH = 500
+TWITCH_SEND_CHAT_AUTH_MODE_APP = "app_token"
+TWITCH_SEND_CHAT_AUTH_MODE_BOT_USER = "bot_user_token"
+TWITCH_SEND_CHAT_AUTH_MODE_DEFAULT = TWITCH_SEND_CHAT_AUTH_MODE_BOT_USER
 
 _bot_log_listeners: set[asyncio.Queue[str]] = set()
 _bot_oauth_states: dict[str, Dict[str, Any]] = {}
@@ -953,6 +956,21 @@ def get_chat_websocket_fallback_legacy_enabled() -> bool:
     """
 
     return _env_flag(get_setting("chat_websocket_fallback_legacy_enabled", "0"))
+
+
+def get_twitch_send_chat_auth_mode() -> Literal["app_token", "bot_user_token"]:
+    """Return outbound Send Chat auth mode with deterministic fallback.
+
+    Dependencies: Reads optional persisted setting via ``get_setting``.
+    Code customers: EventSub webhook Send Chat preflight and header selection.
+    Used variables/origin: ``twitch_send_chat_auth_mode`` setting value, with
+    unsupported values normalized to ``TWITCH_SEND_CHAT_AUTH_MODE_DEFAULT``.
+    """
+
+    configured = (get_setting("twitch_send_chat_auth_mode", TWITCH_SEND_CHAT_AUTH_MODE_DEFAULT) or "").strip().lower()
+    if configured not in {TWITCH_SEND_CHAT_AUTH_MODE_APP, TWITCH_SEND_CHAT_AUTH_MODE_BOT_USER}:
+        return TWITCH_SEND_CHAT_AUTH_MODE_DEFAULT
+    return cast(Literal["app_token", "bot_user_token"], configured)
 
 
 def _coerce_int(value: Any, *, default: int = 0) -> int:
@@ -1852,6 +1870,40 @@ def _eventsub_app_headers() -> dict[str, str]:
     return {"Authorization": f"Bearer {app_token}", "Client-Id": client_id}
 
 
+def _eventsub_send_chat_auth_headers(
+    db: Session,
+    *,
+    sender_id: str,
+) -> tuple[Optional[dict[str, str]], Optional[str], Literal["app_token", "bot_user_token"]]:
+    """Resolve Send Chat auth mode and compose matching Helix auth headers.
+
+    Dependencies: ``get_twitch_send_chat_auth_mode`` policy selector;
+    app-token mode uses ``_eventsub_app_headers``; bot-user mode reads
+    ``BotConfig`` and validates token subject via Twitch ``/oauth2/validate``.
+    Code customers: ``_preflight_eventsub_chat_reply_payload``.
+    Used variables/origin: ``sender_id`` comes from bot identity resolution;
+    ``BotConfig.access_token`` comes from bot OAuth callback persistence.
+    """
+
+    auth_mode = get_twitch_send_chat_auth_mode()
+    if auth_mode == TWITCH_SEND_CHAT_AUTH_MODE_APP:
+        try:
+            return _eventsub_app_headers(), None, auth_mode
+        except RuntimeError:
+            return None, "preflight_missing_app_access_token", auth_mode
+
+    cfg = db.query(BotConfig).order_by(BotConfig.id.asc()).first()
+    access_token = (cfg.access_token if cfg and cfg.access_token else "").strip()
+    if not access_token:
+        return None, "preflight_missing_bot_access_token", auth_mode
+    token_subject_id = _resolve_twitch_token_subject_id(access_token)
+    if not token_subject_id:
+        return None, "preflight_token_subject_unresolved", auth_mode
+    if token_subject_id != sender_id:
+        return None, "preflight_sender_token_subject_mismatch", auth_mode
+    return _eventsub_headers(access_token), None, auth_mode
+
+
 def ensure_eventsub_subscriptions(request: FastAPIRequest, channel_pk: int, db: Session) -> None:
     """Ensure required EventSub subscriptions are registered for a channel.
 
@@ -2210,8 +2262,8 @@ def _preflight_eventsub_chat_reply_payload(
 ) -> tuple[Optional[dict[str, Any]], Optional[str], Optional[dict[str, str]]]:
     """Validate deterministic Twitch send-chat inputs before HTTP requests.
 
-    Dependencies: Reads ``BotConfig`` for bot access token, validates token
-    subject via Twitch ``/oauth2/validate``, and assembles Helix headers.
+    Dependencies: Applies centralized Send Chat auth policy via
+    ``_eventsub_send_chat_auth_headers`` and assembles deterministic payload.
     Code customers: ``_send_eventsub_chat_reply`` deterministic preflight guard.
     Used variables/origin: broadcaster id from ``channel.channel_id``,
     ``sender_id`` from bot identity resolution, ``message`` from rendered reply,
@@ -2229,17 +2281,12 @@ def _preflight_eventsub_chat_reply_payload(
     if message_len < 1 or message_len > TWITCH_SEND_CHAT_MESSAGE_MAX_LENGTH:
         return None, "preflight_invalid_message_length", None
 
-    cfg = db.query(BotConfig).order_by(BotConfig.id.asc()).first()
-    access_token = (cfg.access_token if cfg and cfg.access_token else "").strip()
-    if not access_token:
-        return None, "preflight_missing_bot_access_token", None
-    token_subject_id = _resolve_twitch_token_subject_id(access_token)
-    if not token_subject_id:
-        return None, "preflight_token_subject_unresolved", None
-    if token_subject_id != normalized_sender_id:
-        return None, "preflight_sender_token_subject_mismatch", None
-
-    headers = _eventsub_headers(access_token)
+    headers, auth_reason_code, _ = _eventsub_send_chat_auth_headers(
+        db,
+        sender_id=normalized_sender_id,
+    )
+    if auth_reason_code or not headers:
+        return None, auth_reason_code or "preflight_auth_header_unresolved", None
     payload = _build_eventsub_chat_reply_payload(
         broadcaster_id=broadcaster_id,
         sender_id=normalized_sender_id,
@@ -6466,7 +6513,7 @@ def bot_oauth_callback(
             {
                 "type": "oauth_complete",
                 "level": "info",
-                "message": f"Bot app access token acquired for {login}",
+                "message": f"Bot user OAuth token acquired for {login}",
                 "timestamp": datetime.utcnow(),
             }
         )

--- a/bot/bot_app.py
+++ b/bot/bot_app.py
@@ -1141,6 +1141,27 @@ class SongBot(commands.Bot):
         reply_to: Optional[str] = None,
         fallback_partial: Optional[object] = None,
     ) -> None:
+        """Send a websocket-runtime chat message using bot-user token contract.
+
+        Description: rollback-only websocket egress helper; authoritative
+        webhook/conduit ingress should use backend Send Chat transport instead.
+        Dependencies: TwitchIO ``PartialUser.send_message`` and runtime
+        ``self._websocket_fallback_enabled`` policy flag.
+        Code customers: websocket ingress command handlers and debug/catalog
+        responses emitted during rollback operation.
+        Used variables/origin: ``channel_login`` and ``message`` come from
+        command dispatch flows; ``self.bot_user_id`` is persisted bot identity
+        used for both ``sender`` and ``token_for`` in TwitchIO sends.
+        """
+
+        if not self._websocket_fallback_enabled:
+            await push_console_event(
+                'warning',
+                f'Skipped websocket send for {channel_login}: fallback mode disabled',
+                event='message_skipped',
+                metadata={**(metadata or {}), 'channel': channel_login, 'reason_code': 'websocket_fallback_disabled'},
+            )
+            return
         info = self._channel_info(channel_login)
         partial = None
         channel_label = channel_login
@@ -1154,6 +1175,14 @@ class SongBot(commands.Bot):
             partial = fallback_partial
             channel_label = getattr(fallback_partial, 'display_name', None) or getattr(fallback_partial, 'name', channel_login)
         if partial is None:
+            return
+        if not self.bot_user_id:
+            await push_console_event(
+                'error',
+                f'Failed to send message to {channel_label}: bot_user_id is missing',
+                event='message',
+                metadata={**(metadata or {}), 'channel': channel_label, 'reason_code': 'missing_bot_user_id'},
+            )
             return
         try:
             await partial.send_message(

--- a/docs/README.md
+++ b/docs/README.md
@@ -327,8 +327,12 @@ unlocks the API for the bot, queue manager, and public web frontend.
   reports `preflight_token_subject_unresolved`.
 - Webhook replies are skipped before Send Chat API call.
 
+> This preflight reason only applies when Send Chat auth mode is
+> `bot_user_token`. In `app_token` mode, sender/token subject parity checks are
+> intentionally skipped.
+
 **Dependencies**
-- Valid bot access token in `/bot/config`.
+- Valid bot user access token in `/bot/config`.
 - Reachable Twitch `/oauth2/validate` endpoint.
 
 **Primary variables/origins to verify**
@@ -347,7 +351,8 @@ unlocks the API for the bot, queue manager, and public web frontend.
 
 **Dependencies**
 - App access token flow for conduit API + transport subscriptions.
-- Bot user token for Send Chat Message API calls.
+- Send Chat auth mode (`bot_user_token` or `app_token`) configured for
+  webhook replies.
 
 **Primary variables/origins to verify**
 - Twitch client credentials configured in setup (`client_id`, `client_secret`).
@@ -355,8 +360,8 @@ unlocks the API for the bot, queue manager, and public web frontend.
 - Token/client pairing validity (`/oauth2/validate` metadata).
 
 **Procedure**
-1. Validate app and bot tokens independently against Twitch validation endpoint.
-2. Re-run bot OAuth flow if bot token subject/scopes are stale or expired.
+1. Validate app token health for conduit management APIs.
+2. If Send Chat mode is `bot_user_token`, validate bot OAuth token subject/scopes and re-run bot OAuth flow if stale.
 3. Confirm conduit reconcile succeeds with app token auth.
 4. Confirm webhook command replies recover (Send API success + reduced 401s).
 
@@ -555,10 +560,11 @@ The web container hosts files in `web/public/`, including a simple `index.html`,
 ## Authentication & Channel Access
 Songbot relies on two distinct OAuth flows that map to the two management panels:
 
-1. **Bot account authorization (Admin panel)** – The Admin control panel triggers a
-   client credentials grant using the scopes `user:read:chat user:write:chat user:bot`.
-   The resulting app access token is stored through `/bot/config` and allows the
-   backend and bot worker to act as the shared bot account when calling the API.
+1. **Bot account authorization (Admin panel)** – The Admin control panel starts an
+   authorization code grant for the shared bot account using scopes such as
+   `user:read:chat user:write:chat user:bot`. The resulting **bot user access
+   token** (plus refresh token) is stored through `/bot/config` and is used for
+   bot-user-auth Send Chat paths (for example websocket rollback runtime).
    The Admin panel is protected with HTTP basic authentication configured via
    the `ADMIN_BASIC_AUTH_USERNAME` and `ADMIN_BASIC_AUTH_PASSWORD` environment
    variables.
@@ -567,7 +573,7 @@ Songbot relies on two distinct OAuth flows that map to the two management panels
    Queue Manager UI and complete the authorization code grant with the
    `channel:bot channel:read:subscriptions channel:read:vips bits:read moderator:read:followers user:read:email` scopes. The
    backend records the channel during this handshake and subscribes to chat
-   events using the previously obtained app access token. Only channels that
+   events using the app-auth conduit transport. Only channels that
    complete this flow are joined by the bot. Bits and follower access enable
    pricing features tied to cheers and follow events.
 

--- a/tests/test_channel_events.py
+++ b/tests/test_channel_events.py
@@ -1362,6 +1362,75 @@ class ChannelEventTests(unittest.TestCase):
         finally:
             db.close()
 
+    def test_preflight_eventsub_chat_reply_payload_uses_app_auth_policy_headers(self) -> None:
+        """Use app-auth headers for Send Chat when auth policy selects app mode."""
+
+        details = _setup_channel()
+        db = backend_app.SessionLocal()
+        try:
+            channel = db.get(backend_app.ActiveChannel, details["channel_pk"])
+            self.assertIsNotNone(channel)
+            with mock.patch.object(
+                backend_app,
+                "get_twitch_send_chat_auth_mode",
+                return_value=backend_app.TWITCH_SEND_CHAT_AUTH_MODE_APP,
+            ), mock.patch.object(
+                backend_app,
+                "_eventsub_app_headers",
+                return_value={"Authorization": "Bearer app-token", "Client-Id": "cid"},
+            ) as mock_app_headers, mock.patch.object(
+                backend_app,
+                "_resolve_twitch_token_subject_id",
+            ) as mock_subject:
+                payload, reason_code, headers = backend_app._preflight_eventsub_chat_reply_payload(
+                    db,
+                    channel=channel,
+                    sender_id="bot-user-1",
+                    message="hello from webhook",
+                    reply_parent_message_id="parent-msg-id",
+                )
+            self.assertIsNone(reason_code)
+            self.assertEqual(payload["sender_id"], "bot-user-1")
+            self.assertEqual(headers, {"Authorization": "Bearer app-token", "Client-Id": "cid"})
+            self.assertEqual(mock_app_headers.call_count, 1)
+            self.assertEqual(mock_subject.call_count, 0)
+        finally:
+            db.close()
+
+    def test_preflight_eventsub_chat_reply_payload_skips_user_subject_checks_in_app_mode(self) -> None:
+        """Avoid user-token-only preflight failures when app-auth mode is selected."""
+
+        details = _setup_channel()
+        db = backend_app.SessionLocal()
+        try:
+            channel = db.get(backend_app.ActiveChannel, details["channel_pk"])
+            self.assertIsNotNone(channel)
+            with mock.patch.object(
+                backend_app,
+                "get_twitch_send_chat_auth_mode",
+                return_value=backend_app.TWITCH_SEND_CHAT_AUTH_MODE_APP,
+            ), mock.patch.object(
+                backend_app,
+                "_eventsub_app_headers",
+                return_value={"Authorization": "Bearer app-token", "Client-Id": "cid"},
+            ), mock.patch.object(
+                backend_app,
+                "_resolve_twitch_token_subject_id",
+                return_value=None,
+            ):
+                payload, reason_code, headers = backend_app._preflight_eventsub_chat_reply_payload(
+                    db,
+                    channel=channel,
+                    sender_id="bot-user-1",
+                    message="hello",
+                    reply_parent_message_id=None,
+                )
+            self.assertIsNone(reason_code)
+            self.assertIsNotNone(payload)
+            self.assertEqual(headers, {"Authorization": "Bearer app-token", "Client-Id": "cid"})
+        finally:
+            db.close()
+
     def test_send_eventsub_chat_reply_400_maps_reason_and_skips_retry(self) -> None:
         """Map deterministic Twitch 400 reply diagnostics and avoid retries."""
 


### PR DESCRIPTION
### Motivation

- Provide a single, deterministic outbound Send Chat auth policy to choose app-token vs bot-user-token behavior for webhook replies and avoid duplicated logic spread across the codebase.
- Prevent bot-user-only token-subject checks from erroneously blocking Send Chat when app-auth is intentionally selected.
- Make websocket rollback runtime behavior explicit and guarded so fallback sends are clearly marked and constrained.
- Align docs and log wording with the actual implementation (authorization-code bot user token vs app client-credentials token).

### Description

- Added auth-mode constants and `get_twitch_send_chat_auth_mode()` to normalize configured Send Chat auth mode and fallback to a safe default. 
- Added a single header assembly helper `_eventsub_send_chat_auth_headers(db, sender_id=...)` that returns composed Helix headers, deterministic preflight reason codes, and the chosen auth mode (app vs bot-user). 
- Refactored `_preflight_eventsub_chat_reply_payload()` to use `_eventsub_send_chat_auth_headers()` and to only run token-subject validation when `bot_user_token` mode is active. 
- Hardened websocket rollback egress in `bot/bot_app.py::_send_message()` with a clear rollback-only docstring, skip behavior when websocket fallback is disabled, and an explicit guard for missing `bot_user_id`. 
- Added two unit tests in `tests/test_channel_events.py` validating that preflight uses app-auth headers when the policy selects `app_token` and that user-token subject checks are skipped in app mode. 
- Updated `docs/README.md` to correct token terminology and clarify that token-subject troubleshooting applies to `bot_user_token` mode, and adjusted a bot OAuth completion log message to refer to the bot user OAuth token.

### Testing

- Added unit tests `test_preflight_eventsub_chat_reply_payload_uses_app_auth_policy_headers` and `test_preflight_eventsub_chat_reply_payload_skips_user_subject_checks_in_app_mode` (present under `tests/test_channel_events.py`).
- Attempted to run the focused pytest invocation `python -m pytest tests/test_channel_events.py -k "preflight_eventsub_chat_reply_payload or send_eventsub_chat_reply_preflight_invalid_message_length"`, but test collection failed due to environment DB setup (`sqlite3.OperationalError: unable to open database file`).
- Verified file-level syntax by running `python -m py_compile backend_app.py bot/bot_app.py tests/test_channel_events.py`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cf9537c7108328b6e0c73074a16292)