### PR TITLE
Default Send Chat auth mode to app token with startup backfill

### DIFF
--- a/backend_app.py
+++ b/backend_app.py
@@ -85,6 +85,7 @@ SETTINGS_ENV_MAP: Dict[str, str] = {
 SETTINGS_DEFAULTS: Dict[str, Optional[str]] = {
     "twitch_scopes": "channel:bot channel:read:subscriptions channel:read:vips bits:read moderator:read:followers",
     "bot_app_scopes": "user:read:chat user:write:chat user:bot",
+    "twitch_send_chat_auth_mode": "app_token",
     "chat_ingress_mode": "webhook_conduit",
     "chat_ingress_shadow_mode": "0",
     "chat_websocket_fallback_legacy_enabled": "0",
@@ -216,7 +217,7 @@ BOT_MESSAGE_LEVEL_RANK: dict[str, int] = {"mute": 0, "normal": 1, "verbose": 2, 
 TWITCH_SEND_CHAT_MESSAGE_MAX_LENGTH = 500
 TWITCH_SEND_CHAT_AUTH_MODE_APP = "app_token"
 TWITCH_SEND_CHAT_AUTH_MODE_BOT_USER = "bot_user_token"
-TWITCH_SEND_CHAT_AUTH_MODE_DEFAULT = TWITCH_SEND_CHAT_AUTH_MODE_BOT_USER
+TWITCH_SEND_CHAT_AUTH_MODE_DEFAULT = TWITCH_SEND_CHAT_AUTH_MODE_APP
 
 _bot_log_listeners: set[asyncio.Queue[str]] = set()
 _bot_oauth_states: dict[str, Dict[str, Any]] = {}
@@ -636,6 +637,34 @@ def bootstrap_settings_from_env() -> None:
             changed = True
 
         if changed:
+            db.commit()
+        else:
+            db.rollback()
+    finally:
+        db.close()
+    settings_store.invalidate()
+
+
+def backfill_twitch_send_chat_auth_mode_setting() -> None:
+    """Ensure legacy databases always have an explicit Send Chat auth mode row.
+
+    Dependencies: Uses ``SessionLocal`` and the ``AppSetting`` ORM model.
+    Code customers: Startup migration/bootstrap path for EventSub reply
+    preflight policy reads.
+    Used variables/origin: Creates the ``twitch_send_chat_auth_mode`` key with
+    ``TWITCH_SEND_CHAT_AUTH_MODE_DEFAULT`` when the row is missing.
+    """
+
+    db = SessionLocal()
+    try:
+        row = db.get(AppSetting, "twitch_send_chat_auth_mode")
+        if row is None:
+            db.add(
+                AppSetting(
+                    key="twitch_send_chat_auth_mode",
+                    value=TWITCH_SEND_CHAT_AUTH_MODE_DEFAULT,
+                )
+            )
             db.commit()
         else:
             db.rollback()
@@ -4518,6 +4547,7 @@ ensure_channel_settings_schema()
 _ensure_playlist_schema()
 ensure_eventsub_conduit_schema()
 bootstrap_settings_from_env()
+backfill_twitch_send_chat_auth_mode_setting()
 cleanup_conduit_subscription_secret_semantics()
 _validate_startup_symbol_order()
 run_ingress_guard_startup_check()

--- a/docs/README.md
+++ b/docs/README.md
@@ -352,7 +352,8 @@ unlocks the API for the bot, queue manager, and public web frontend.
 **Dependencies**
 - App access token flow for conduit API + transport subscriptions.
 - Send Chat auth mode (`bot_user_token` or `app_token`) configured for
-  webhook replies.
+  webhook replies. Startup backfills missing `twitch_send_chat_auth_mode`
+  settings to `app_token` so preflight defaults to app-auth headers.
 
 **Primary variables/origins to verify**
 - Twitch client credentials configured in setup (`client_id`, `client_secret`).

--- a/docs/backend_api.md
+++ b/docs/backend_api.md
@@ -304,7 +304,9 @@ Channel settings include queue intake controls:
 - **Description**: Recover from expired/invalid app or bot credentials impacting
   EventSub reconciliation or Send API calls.
 - **Dependencies**: Twitch token validation, setup credentials, and bot OAuth
-  callback flow.
+  callback flow. Startup backfills a missing `twitch_send_chat_auth_mode`
+  `AppSetting` row to `app_token` so preflight uses app-auth headers by
+  default.
 - **Code-customers**: Platform operators rotating credentials or remediating auth outages.
 - **Used variables/origin**:
   - Setup credentials in `/system/config` (`client_id`, `client_secret`).

--- a/tests/test_bot_config.py
+++ b/tests/test_bot_config.py
@@ -81,6 +81,27 @@ class BotConfigApiTests(unittest.TestCase):
         self.assertEqual(data["scopes"], backend_app.get_bot_app_scopes())
         self.assertFalse(data["token_present"])
 
+    def test_backfill_twitch_send_chat_auth_mode_setting_inserts_default_row(self) -> None:
+        """Backfill startup helper should insert missing auth-mode app setting."""
+
+        db = backend_app.SessionLocal()
+        try:
+            db.query(backend_app.AppSetting).filter(backend_app.AppSetting.key == "twitch_send_chat_auth_mode").delete()
+            db.commit()
+        finally:
+            db.close()
+        backend_app.settings_store.invalidate()
+
+        backend_app.backfill_twitch_send_chat_auth_mode_setting()
+
+        db = backend_app.SessionLocal()
+        try:
+            row = db.get(backend_app.AppSetting, "twitch_send_chat_auth_mode")
+            self.assertIsNotNone(row)
+            self.assertEqual(row.value, backend_app.TWITCH_SEND_CHAT_AUTH_MODE_DEFAULT)
+        finally:
+            db.close()
+
     def test_existing_config_missing_required_scopes_is_healed(self) -> None:
         db = backend_app.SessionLocal()
         try:

--- a/tests/test_channel_events.py
+++ b/tests/test_channel_events.py
@@ -1397,6 +1397,72 @@ class ChannelEventTests(unittest.TestCase):
         finally:
             db.close()
 
+    def test_preflight_eventsub_chat_reply_payload_uses_app_headers_when_auth_mode_unset(self) -> None:
+        """Default missing auth-mode setting to app headers during preflight."""
+
+        details = _setup_channel()
+        db = backend_app.SessionLocal()
+        try:
+            db.query(backend_app.AppSetting).filter(backend_app.AppSetting.key == "twitch_send_chat_auth_mode").delete()
+            db.commit()
+            backend_app.settings_store.invalidate()
+            channel = db.get(backend_app.ActiveChannel, details["channel_pk"])
+            self.assertIsNotNone(channel)
+            with mock.patch.object(
+                backend_app,
+                "_eventsub_app_headers",
+                return_value={"Authorization": "Bearer app-token", "Client-Id": "cid"},
+            ) as mock_app_headers, mock.patch.object(
+                backend_app,
+                "_resolve_twitch_token_subject_id",
+            ) as mock_subject:
+                payload, reason_code, headers = backend_app._preflight_eventsub_chat_reply_payload(
+                    db,
+                    channel=channel,
+                    sender_id="bot-user-1",
+                    message="hello from webhook",
+                    reply_parent_message_id=None,
+                )
+            self.assertIsNone(reason_code)
+            self.assertIsNotNone(payload)
+            self.assertEqual(headers, {"Authorization": "Bearer app-token", "Client-Id": "cid"})
+            self.assertEqual(mock_app_headers.call_count, 1)
+            self.assertEqual(mock_subject.call_count, 0)
+        finally:
+            db.close()
+
+    def test_preflight_eventsub_chat_reply_payload_uses_app_headers_when_default_selected(self) -> None:
+        """Treat explicit default auth-mode value as app-header policy."""
+
+        details = _setup_channel()
+        db = backend_app.SessionLocal()
+        try:
+            backend_app.set_settings(db, {"twitch_send_chat_auth_mode": backend_app.TWITCH_SEND_CHAT_AUTH_MODE_DEFAULT})
+            channel = db.get(backend_app.ActiveChannel, details["channel_pk"])
+            self.assertIsNotNone(channel)
+            with mock.patch.object(
+                backend_app,
+                "_eventsub_app_headers",
+                return_value={"Authorization": "Bearer app-token", "Client-Id": "cid"},
+            ) as mock_app_headers, mock.patch.object(
+                backend_app,
+                "_resolve_twitch_token_subject_id",
+            ) as mock_subject:
+                payload, reason_code, headers = backend_app._preflight_eventsub_chat_reply_payload(
+                    db,
+                    channel=channel,
+                    sender_id="bot-user-1",
+                    message="hello from webhook",
+                    reply_parent_message_id=None,
+                )
+            self.assertIsNone(reason_code)
+            self.assertIsNotNone(payload)
+            self.assertEqual(headers, {"Authorization": "Bearer app-token", "Client-Id": "cid"})
+            self.assertEqual(mock_app_headers.call_count, 1)
+            self.assertEqual(mock_subject.call_count, 0)
+        finally:
+            db.close()
+
     def test_preflight_eventsub_chat_reply_payload_skips_user_subject_checks_in_app_mode(self) -> None:
         """Avoid user-token-only preflight failures when app-auth mode is selected."""
 


### PR DESCRIPTION
### Motivation

- Ensure EventSub Send Chat preflight defaults to app-auth headers for older databases that lack the new `twitch_send_chat_auth_mode` setting, avoiding unintended bot-token subject failures.  
- Make the default policy explicit in settings and docs so operator expectations and startup behaviour align.  

### Description

- Change the runtime default to app-auth by setting `TWITCH_SEND_CHAT_AUTH_MODE_DEFAULT = TWITCH_SEND_CHAT_AUTH_MODE_APP` and add `"twitch_send_chat_auth_mode": "app_token"` to `SETTINGS_DEFAULTS`.  
- Add a startup migration `backfill_twitch_send_chat_auth_mode_setting()` that inserts an `AppSetting` row with the default when the key is missing, and call it during bootstrap so existing DBs are deterministically backfilled.  
- Add regression tests: `tests/test_bot_config.py::test_backfill_twitch_send_chat_auth_mode_setting_inserts_default_row` verifies the backfill helper creates the row, and `tests/test_channel_events.py` includes two tests verifying preflight uses app headers when the setting is unset or explicitly set to the default.  
- Update operator/docs in `docs/README.md` and `docs/backend_api.md` to document the startup backfill and default app-auth preflight behaviour.  

### Testing

- Ran the new preflight regression tests with: `mkdir -p /data && PYTHONPATH=. pytest -q tests/test_channel_events.py -k "uses_app_headers_when_auth_mode_unset or uses_app_headers_when_default_selected or uses_app_auth_policy_headers"`, which completed successfully (3 passed, 45 deselected).  
- Ran the backfill unit test with: `PYTHONPATH=. pytest -q tests/test_bot_config.py -k "backfill_twitch_send_chat_auth_mode_setting_inserts_default_row"`, which passed (1 passed).  
- Test runs produced existing deprecation warnings from upstream code but all new/targeted tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cfa57449648328b96ed6ad2f836db1)