### PR TITLE
Route runtime bot announcements through backend send-chat pipeline

### DIFF
--- a/backend_app.py
+++ b/backend_app.py
@@ -194,6 +194,9 @@ BOT_MESSAGE_CATALOG: list[dict[str, Any]] = [
     {"id": "token_refreshed", "level": "debug", "group": "lifecycle", "template_key": "token_refreshed", "description": "Token refresh succeeded.", "customizable": True},
     {"id": "action_failed_debug", "level": "debug", "group": "errors", "template_key": "action_failed_debug", "description": "Internal action failure diagnostic.", "customizable": True},
 ]
+BOT_MESSAGE_CATALOG_BY_ID: dict[str, dict[str, Any]] = {
+    str(row.get("id") or ""): row for row in BOT_MESSAGE_CATALOG if row.get("id")
+}
 BOT_MESSAGE_DEFAULT_TEMPLATES: dict[str, str] = {
     "channel_not_registered": "Channel not registered in backend",
     "request_added": "Added: {artist} - {title}",
@@ -212,6 +215,19 @@ BOT_MESSAGE_DEFAULT_TEMPLATES: dict[str, str] = {
     "archive_success": "Archived current queue and started new stream",
     "archive_denied": "Only channel owner or moderators can archive the queue",
     "failed": "Failed: {error}",
+    "bot_joined": "Song queue bot connected to chat.",
+    "bot_left": "Song queue bot disconnected from chat.",
+    "played_next": "This was {artist} - {title} requested by {user}. Next up {next_artist} - {next_title} requested by {next_user}",
+    "played_last": "This was {artist} - {title} requested by {user}. @{channel} no more bumped songs",
+    "bump_free": "{artist} - {title} got a free bump, congrats {user}",
+    "award_follow": "Thx for following {username}, take {word} - you have now {points} {currency_plural}",
+    "award_raid": "Thx for raiding {username}, take {word} - you have now {points} {currency_plural}",
+    "award_gift_sub": "Thx for gifting {count} subs {username}, take {word} - you have now {points} {currency_plural}",
+    "award_bits": "Thx for cheering {amount} bits {username}, take {word} - you have now {points} {currency_plural}",
+    "vip_points_awarded": "Thx for becoming a VIP {username}, take {word} - you have now {points} {currency_plural}",
+    "queue_position_changed": "Request #{request_id} moved from #{old_position} to #{new_position}",
+    "token_refreshed": "Bot token refreshed successfully.",
+    "action_failed_debug": "Debug failure in {action}: {error}",
 }
 BOT_MESSAGE_LEVEL_RANK: dict[str, int] = {"mute": 0, "normal": 1, "verbose": 2, "debug": 3}
 TWITCH_SEND_CHAT_MESSAGE_MAX_LENGTH = 500
@@ -4740,6 +4756,22 @@ class BotLogAckOut(BaseModel):
     success: bool
 
 
+class BotRuntimeAnnouncementIn(BaseModel):
+    channel: str = Field(..., min_length=1, max_length=255)
+    message_id: str = Field(..., min_length=1, max_length=128)
+    template_vars: Dict[str, Any] = Field(default_factory=dict)
+
+
+class BotRuntimeAnnouncementOut(BaseModel):
+    success: bool
+    sent: bool
+    channel: str
+    message_id: str
+    template_key: str
+    visibility: Literal["mute", "normal", "verbose", "debug"]
+    delivery_path: Literal["send_chat_pipeline"]
+
+
 class BotOAuthStartIn(BaseModel):
     return_url: Optional[str] = None
 
@@ -6589,6 +6621,62 @@ def push_bot_log(event: BotLogEventIn):
     }
     _broadcast_bot_log(payload)
     return {"success": True}
+
+
+@app.post(
+    "/bot/runtime/announcements",
+    response_model=BotRuntimeAnnouncementOut,
+    dependencies=[Depends(require_token)],
+)
+def push_bot_runtime_announcement(
+    payload: BotRuntimeAnnouncementIn,
+    db: Session = Depends(get_db),
+):
+    """Send bot runtime announcements through webhook Send Chat transport.
+
+    Dependencies: resolves channels via ``get_channel_pk`` and reuses the
+    authoritative webhook reply pipeline ``_send_eventsub_chat_reply``.
+    Code customers: ``SongBot`` non-chat producer hooks call this endpoint
+    instead of websocket sends for played/bump/event announcements.
+    Used variables/origin: ``message_id``/``template_vars`` come from bot
+    runtime queue/event diffs and map through ``BOT_MESSAGE_CATALOG``.
+    """
+
+    channel_name = payload.channel.strip()
+    message_id = payload.message_id.strip()
+    channel_pk = get_channel_pk(channel_name, db)
+    channel = db.get(ActiveChannel, channel_pk)
+    if not channel:
+        raise HTTPException(status_code=404, detail="channel not found")
+
+    catalog_row = BOT_MESSAGE_CATALOG_BY_ID.get(message_id)
+    if not catalog_row:
+        raise HTTPException(status_code=400, detail=f"unknown bot message_id: {message_id}")
+
+    visibility = str(catalog_row.get("level") or "normal").strip().lower()
+    if visibility not in BOT_MESSAGE_LEVEL_RANK:
+        visibility = "normal"
+    reply = _eventsub_response_contract(
+        "success",
+        template_key=str(catalog_row.get("template_key") or message_id),
+        template_vars=payload.template_vars or {},
+        visibility=cast(Literal["mute", "normal", "verbose", "debug"], visibility),
+    )
+    sent = _send_eventsub_chat_reply(
+        db,
+        channel,
+        reply,
+        reply_parent_message_id=None,
+    )
+    return BotRuntimeAnnouncementOut(
+        success=True,
+        sent=bool(sent),
+        channel=channel.channel_name,
+        message_id=message_id,
+        template_key=str(catalog_row.get("template_key") or message_id),
+        visibility=cast(Literal["mute", "normal", "verbose", "debug"], visibility),
+        delivery_path="send_chat_pipeline",
+    )
 
 
 @app.get("/bot/logs/stream", dependencies=[Depends(require_token)])

--- a/bot/bot_app.py
+++ b/bot/bot_app.py
@@ -306,6 +306,32 @@ class Backend:
         }
         return await self._req('POST', "/bot/logs", payload)
 
+    async def announce_runtime_event(
+        self,
+        *,
+        channel: str,
+        message_id: str,
+        template_vars: Optional[Dict[str, object]] = None,
+    ) -> Dict[str, object]:
+        """Send a runtime event announcement through backend Send Chat pipeline.
+
+        Dependencies: calls backend ``POST /bot/runtime/announcements`` with
+        admin-token auth.
+        Code customers: ``SongBot`` non-chat queue/event producer methods
+        (``check_played``, ``check_bumps``, ``check_queue_position_changes``,
+        ``announce_event``).
+        Used variables/origin: ``channel`` comes from backend queue polling
+        state, ``message_id`` selects the catalog entry, and ``template_vars``
+        carries formatter values from queue/event payload fields.
+        """
+
+        payload = {
+            'channel': channel,
+            'message_id': message_id,
+            'template_vars': template_vars or {},
+        }
+        return await self._req('POST', "/bot/runtime/announcements", payload)
+
     async def random_playlist_request(
         self,
         channel: str,
@@ -1212,6 +1238,45 @@ class SongBot(commands.Bot):
                     metadata={'channel': channel_label},
                 )
 
+    async def _announce_backend_runtime_event(
+        self,
+        *,
+        login: str,
+        channel: str,
+        message_id: str,
+        template_vars: Optional[Dict[str, object]] = None,
+        metadata: Optional[Dict[str, object]] = None,
+    ) -> None:
+        """Publish catalog announcements via backend; websocket send is rollback-only.
+
+        Dependencies: backend ``announce_runtime_event`` endpoint; websocket
+        `_send_catalog_message` is used only as emergency fallback.
+        Code customers: non-chat runtime producers (queue/event polling hooks).
+        Used variables/origin: arguments originate from queue/event diff
+        evaluators and are forwarded unchanged to backend templating payload.
+        """
+
+        try:
+            await backend.announce_runtime_event(
+                channel=channel,
+                message_id=message_id,
+                template_vars=template_vars or {},
+            )
+            return
+        except Exception as exc:
+            await push_console_event(
+                'warning',
+                f'Backend runtime announcement failed for {channel}: {exc}; using websocket rollback path',
+                event='runtime_announcement_fallback',
+                metadata={**(metadata or {}), 'channel': channel, 'message_id': message_id, 'error': str(exc)},
+            )
+        await self._send_catalog_message(
+            login,
+            message_id,
+            template_vars=template_vars or {},
+            metadata={**(metadata or {}), 'channel': channel, 'delivery_mode': 'websocket_rollback'},
+        )
+
     async def update_enabled(self, enabled: bool) -> None:
         if self.enabled == enabled:
             return
@@ -1554,24 +1619,15 @@ class SongBot(commands.Bot):
                     next_req = pending_prio[0]
                     next_song = await backend.get_song(channel, next_req['song_id'])
                     next_user = await backend.get_user(channel, next_req['user_id'])
-                    msg = self.messages['played_next'].format(
-                        artist=song.get('artist', '?'),
-                        title=song.get('title', '?'),
-                        user=user.get('username', '?'),
-                        next_artist=next_song.get('artist', '?'),
-                        next_title=next_song.get('title', '?'),
-                        next_user=next_user.get('username', '?'),
-                    )
                 else:
-                    msg = self.messages['played_last'].format(
-                        artist=song.get('artist', '?'),
-                        title=song.get('title', '?'),
-                        user=user.get('username', '?'),
-                        channel=channel,
-                    )
-                await self._send_catalog_message(
-                    login,
-                    'played_next' if pending_prio else 'played_last',
+                    # cleanup_candidate: pre-rendered websocket text removed; the
+                    # backend announcement pipeline now owns authoritative text rendering.
+                    next_song = {}
+                    next_user = {}
+                await self._announce_backend_runtime_event(
+                    login=login,
+                    channel=channel,
+                    message_id='played_next' if pending_prio else 'played_last',
                     template_vars={
                         'artist': song.get('artist', '?'),
                         'title': song.get('title', '?'),
@@ -1601,9 +1657,10 @@ class SongBot(commands.Bot):
             if new_prio and not was_prio:
                 song = await backend.get_song(channel, req['song_id'])
                 user = await backend.get_user(channel, req['user_id'])
-                await self._send_catalog_message(
-                    login,
-                    'bump_free',
+                await self._announce_backend_runtime_event(
+                    login=login,
+                    channel=channel,
+                    message_id='bump_free',
                     template_vars={
                         'artist': song.get('artist', '?'),
                         'title': song.get('title', '?'),
@@ -1636,9 +1693,10 @@ class SongBot(commands.Bot):
             old_position = prev_positions.get(int(req_id))
             if old_position is None or old_position == index:
                 continue
-            await self._send_catalog_message(
-                login,
-                'queue_position_changed',
+            await self._announce_backend_runtime_event(
+                login=login,
+                channel=channel,
+                message_id='queue_position_changed',
                 template_vars={
                     'request_id': req_id,
                     'old_position': old_position,
@@ -1676,9 +1734,10 @@ class SongBot(commands.Bot):
             else f"these {delta} {self.currency_plural}"
         )
         message_id = 'vip_points_awarded' if etype == 'vip' else f"award_{etype}"
-        await self._send_catalog_message(
-            login,
-            message_id,
+        await self._announce_backend_runtime_event(
+            login=login,
+            channel=channel,
+            message_id=message_id,
             template_vars={
                 'username': user.get('username', ''),
                 'word': word,

--- a/docs/backend_api.md
+++ b/docs/backend_api.md
@@ -171,6 +171,7 @@ This document summarizes the REST endpoints exposed by `backend_app.py`.
 | PUT | `/bot/config` | Update bot settings such as scopes or enable flag (admin). |
 | POST | `/bot/config/oauth` | Start the OAuth authorization flow for the bot account (admin). |
 | GET | `/bot/config/oauth/callback` | Callback used by Twitch to finish the bot OAuth flow. |
+| POST | `/bot/runtime/announcements` | Authoritative runtime event announcement endpoint (admin/bot worker). |
 
 ### `/bot/messages/catalog`
 - **Authentication**: Requires admin authorization (`X-Admin-Token`, bearer token, or admin session cookie) via `require_token`.
@@ -187,6 +188,18 @@ This document summarizes the REST endpoints exposed by `backend_app.py`.
   - Posts `{"type":"bot-oauth-complete","success":<bool>,"error"?:<string>}` to the opener/parent window so the admin panel can render a success or error banner.
   - Auto-closes the popup only on success; failure responses stay open so the error message remains visible for debugging.
   - Includes a short CTA in the popup (`"You may close this window."` on failures).
+
+### `/bot/runtime/announcements`
+- **Authentication**: Requires admin authorization (`require_token`) and is intended for backend-trusted bot runtime callers.
+- **Request body**: `{ "channel": "<channel name>", "message_id": "<catalog id>", "template_vars": { ... } }`.
+- **Behavior**
+  - Validates `message_id` against the shared bot message catalog.
+  - Builds the same reply contract used by webhook command replies (`template_key`, `template_vars`, `visibility`).
+  - Sends through the authoritative Twitch Send Chat Message pipeline (`_send_eventsub_chat_reply`), which enforces the same auth-mode policy (`twitch_send_chat_auth_mode`) and channel `bot_message_level` threshold rules.
+  - Returns send status metadata including `delivery_path: "send_chat_pipeline"`.
+- **Rollback note**
+  - This endpoint is authoritative for non-chat runtime announcements.
+  - Bot websocket `_send_message` remains rollback-only and should only be used when explicit fallback is required.
 
 ## Bot Logs
 | Method | Path | Description |

--- a/tests/test_bot_config.py
+++ b/tests/test_bot_config.py
@@ -21,6 +21,8 @@ class BotConfigApiTests(unittest.TestCase):
         self._settings_snapshot = backend_app.settings_store.snapshot()
         db = backend_app.SessionLocal()
         try:
+            db.query(backend_app.ChannelSettings).delete()
+            db.query(backend_app.ActiveChannel).delete()
             db.query(backend_app.BotConfig).delete()
             db.query(backend_app.TwitchUser).delete()
             db.query(backend_app.AppSetting).delete()
@@ -80,6 +82,67 @@ class BotConfigApiTests(unittest.TestCase):
         self.assertFalse(data["enabled"])
         self.assertEqual(data["scopes"], backend_app.get_bot_app_scopes())
         self.assertFalse(data["token_present"])
+
+    def test_runtime_announcement_uses_send_chat_pipeline(self) -> None:
+        """Runtime announcements should reuse the authoritative Send Chat path."""
+
+        db = backend_app.SessionLocal()
+        try:
+            channel = backend_app.ActiveChannel(channel_id="12345", channel_name="ChannelOne")
+            db.add(channel)
+            db.commit()
+        finally:
+            db.close()
+
+        with patch.object(backend_app, "_send_eventsub_chat_reply", return_value=True) as send_reply:
+            response = self.client.post(
+                "/bot/runtime/announcements",
+                headers={"X-Admin-Token": backend_app.ADMIN_TOKEN},
+                json={
+                    "channel": "ChannelOne",
+                    "message_id": "queue_position_changed",
+                    "template_vars": {
+                        "request_id": 55,
+                        "old_position": 8,
+                        "new_position": 3,
+                    },
+                },
+            )
+
+        self.assertEqual(response.status_code, 200)
+        payload = response.json()
+        self.assertTrue(payload["success"])
+        self.assertTrue(payload["sent"])
+        self.assertEqual(payload["delivery_path"], "send_chat_pipeline")
+        self.assertEqual(payload["visibility"], "verbose")
+        send_reply.assert_called_once()
+        called_args, called_kwargs = send_reply.call_args
+        reply_payload = called_args[2] if len(called_args) > 2 else called_kwargs["reply"]
+        self.assertIsNone(called_kwargs["reply_parent_message_id"])
+        self.assertEqual(reply_payload["template_key"], "queue_position_changed")
+        self.assertEqual(reply_payload["visibility"], "verbose")
+
+    def test_runtime_announcement_rejects_unknown_message_id(self) -> None:
+        """Endpoint should fail fast for message IDs outside the shared catalog."""
+
+        db = backend_app.SessionLocal()
+        try:
+            channel = backend_app.ActiveChannel(channel_id="12346", channel_name="ChannelTwo")
+            db.add(channel)
+            db.commit()
+        finally:
+            db.close()
+
+        with patch.object(backend_app, "_send_eventsub_chat_reply", return_value=True) as send_reply:
+            response = self.client.post(
+                "/bot/runtime/announcements",
+                headers={"X-Admin-Token": backend_app.ADMIN_TOKEN},
+                json={"channel": "ChannelTwo", "message_id": "not_real", "template_vars": {}},
+            )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("unknown bot message_id", response.json().get("detail", ""))
+        send_reply.assert_not_called()
 
     def test_backfill_twitch_send_chat_auth_mode_setting_inserts_default_row(self) -> None:
         """Backfill startup helper should insert missing auth-mode app setting."""


### PR DESCRIPTION
### Motivation
- Move non-chat runtime announcements (queue played/bump/position/event producers) off the websocket send path and into the backend-owned Send Chat pipeline so auth-mode, visibility and policy match webhook command replies.
- Preserve websocket egress as a rollback-only emergency path while clarifying and documenting authoritative vs rollback responsibilities.
- Provide a single authoritative place (backend) to validate catalog IDs and render templates for runtime announcements.

### Description
- Added `POST /bot/runtime/announcements` in `backend_app.py` with request/response models (`BotRuntimeAnnouncementIn` / `BotRuntimeAnnouncementOut`) that validate `message_id` against the shared `BOT_MESSAGE_CATALOG` and route delivery through the existing `_send_eventsub_chat_reply` Send Chat pipeline, preserving auth-mode and `bot_message_level` gating.
- Introduced `BOT_MESSAGE_CATALOG_BY_ID` and expanded `BOT_MESSAGE_DEFAULT_TEMPLATES` so runtime announcement IDs used by the bot (e.g. `played_next`, `played_last`, `bump_free`, `award_*`, `queue_position_changed`) are covered by backend rendering.
- Added `Backend.announce_runtime_event` client helper in `bot/bot_app.py` and a `SongBot._announce_backend_runtime_event` helper that calls the backend endpoint and falls back to the websocket catalog send only on backend failure (websocket rollback path).
- Updated `SongBot` non-chat producers (`check_played`, `check_bumps`, `check_queue_position_changes`, `announce_event`) to call the backend runtime announcement endpoint rather than calling `_send_catalog_message` directly; left `_send_message` documented and retained as rollback-only.
- Updated `docs/backend_api.md` to document the new `/bot/runtime/announcements` endpoint and to state the authoritative-vs-rollback guidance.
- Marked a small cleanup candidate in `check_played` where pre-rendered websocket text was removed in favor of backend rendering.

### Testing
- Added unit tests in `tests/test_bot_config.py` to verify successful routing through the Send Chat pipeline and rejection of unknown `message_id` values.
- Ran: `pytest -q tests/test_bot_config.py tests/test_bot_service.py`, and all tests passed (36 passed; no failures).
- Existing bot service tests were run to ensure websocket rollback smoke harness and other BotService behaviors remained unchanged and they passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d12bdf12688328a0f8932ae762099f)