### PR TITLE
Suppress backend runtime announcements for disconnected channels; add reason_code and tests

### DIFF
--- a/backend_app.py
+++ b/backend_app.py
@@ -4785,7 +4785,7 @@ class BotRuntimeAnnouncementOut(BaseModel):
     template_key: str
     visibility: Literal["mute", "normal", "verbose", "debug"]
     delivery_path: Literal["send_chat_pipeline"]
-    reason_code: Optional[Literal["suppressed_by_level", "preflight_rejected", "api_failure"]] = None
+    reason_code: Optional[Literal["suppressed_by_level", "suppressed_disconnected", "preflight_rejected", "api_failure"]] = None
 
 
 class BotOAuthStartIn(BaseModel):
@@ -6667,6 +6667,18 @@ def _send_catalog_announcement(
     if visibility not in BOT_MESSAGE_LEVEL_RANK:
         visibility = "normal"
     template_key = str(catalog_row.get("template_key") or normalized_message_id)
+    if not bool(getattr(channel, "join_active", 1)):
+        return BotRuntimeAnnouncementOut(
+            success=True,
+            sent=False,
+            channel=channel.channel_name,
+            message_id=normalized_message_id,
+            template_key=template_key,
+            visibility=cast(Literal["mute", "normal", "verbose", "debug"], visibility),
+            delivery_path="send_chat_pipeline",
+            reason_code="suppressed_disconnected",
+        )
+
     reply = _eventsub_response_contract(
         "success",
         template_key=template_key,
@@ -6688,7 +6700,7 @@ def _send_catalog_announcement(
         template_key=template_key,
         visibility=cast(Literal["mute", "normal", "verbose", "debug"], visibility),
         delivery_path="send_chat_pipeline",
-        reason_code=cast(Optional[Literal["suppressed_by_level", "preflight_rejected", "api_failure"]], reason_code),
+        reason_code=cast(Optional[Literal["suppressed_by_level", "suppressed_disconnected", "preflight_rejected", "api_failure"]], reason_code),
     )
 
 

--- a/docs/backend_api.md
+++ b/docs/backend_api.md
@@ -196,9 +196,11 @@ This document summarizes the REST endpoints exposed by `backend_app.py`.
   - Validates `message_id` against the shared bot message catalog.
   - Builds the same reply contract used by webhook command replies (`template_key`, `template_vars`, `visibility`).
   - Sends through the authoritative Twitch Send Chat Message pipeline (`_send_eventsub_chat_reply`), which enforces the same auth-mode policy (`twitch_send_chat_auth_mode`) and channel `bot_message_level` threshold rules.
+  - Suppresses chat sends when the channel is disconnected (`join_active = 0`) so runtime announcements remain silent until reconnect.
   - Returns send status metadata including `delivery_path: "send_chat_pipeline"`.
   - When `sent=false`, includes `reason_code` with one of:
     - `suppressed_by_level`: channel message-level threshold or empty rendered template suppressed the send.
+    - `suppressed_disconnected`: channel is disconnected (`join_active = 0`), so no runtime announcement is sent.
     - `preflight_rejected`: auth/header/payload preflight checks failed before calling Twitch Send Chat API.
     - `api_failure`: Twitch Send Chat API request failed (HTTP/request/timeout path).
 - **Rollback note**
@@ -255,6 +257,9 @@ Channel settings include queue intake controls:
   - `/channels/{channel}` accepts only `join_active` values `0` or `1`.
   - `/channels/{channel}/settings` keeps `bot_message_level` strict to enum
     values `mute|normal|verbose|debug`.
+- Behavioral difference:
+  - `disconnect` (`join_active=0`) is the stronger switch: channel command ingress subscriptions are removed in the bot runtime and backend runtime announcements are suppressed.
+  - `mute` (`bot_message_level="mute"`) keeps the bot connected for control-plane behavior but suppresses all chat message output by visibility policy.
 
 ## Steady-state runbooks
 

--- a/docs/websocket_pruning_ledger.md
+++ b/docs/websocket_pruning_ledger.md
@@ -12,6 +12,22 @@ Use this ledger whenever websocket-only code/tests are removed.
 
 ## Entries
 
+### 2026-04-04 — Verify mute-level silence on backend runtime announcements
+- **removed modules/functions**: none (verification + automated coverage update)
+- **replacement path**: `POST /bot/runtime/announcements` -> `backend_app._send_catalog_announcement` -> `_send_eventsub_chat_reply` mute suppression gate.
+- **deprecation decision date**: 2026-04-04
+- **rollback implications**: none; this entry adds a regression guard to ensure muted channels do not emit chat via Send Chat API.
+- **classification**: unused code removed (tracking/coverage only; no runtime deletion)
+- **archived rationale link**: [Archived websocket deprecation rationale](./archive/websocket_deprecation_rationale.md)
+
+### 2026-04-04 — Suppress runtime announcements when bot is disconnected
+- **removed modules/functions**: none (behavioral guard + automated coverage update)
+- **replacement path**: `POST /bot/runtime/announcements` now short-circuits in `backend_app._send_catalog_announcement` when `join_active=0`, returning `reason_code=suppressed_disconnected`.
+- **deprecation decision date**: 2026-04-04
+- **rollback implications**: behavioral tightening; rollback would restore announcement sends even when the Queue Manager connect/disconnect control is set to disconnected.
+- **classification**: behavioral removal
+- **archived rationale link**: [Archived websocket deprecation rationale](./archive/websocket_deprecation_rationale.md)
+
 ### 2026-04-04 — Remove websocket runtime announcement rollback fallback/gate
 - **removed modules/functions**: `bot/bot_app.py` `SongBot._announce_backend_runtime_event` websocket fallback branch, `SongBot` queue/event polling announcers (`check_played`, `check_bumps`, `check_queue_position_changes`, `announce_event`), and `BotService._requires_runtime` gate branch from `BotService.run`.
 - **replacement path**: backend-authoritative catalog announcement dispatch in `backend_app._send_catalog_announcement`, called directly from `move_request`, `mark_played`, and `_persist_channel_event`.

--- a/tests/test_bot_config.py
+++ b/tests/test_bot_config.py
@@ -168,6 +168,57 @@ class BotConfigApiTests(unittest.TestCase):
         self.assertFalse(payload["sent"])
         self.assertEqual(payload["reason_code"], "suppressed_by_level")
 
+    def test_runtime_announcement_respects_mute_level_without_send_attempt(self) -> None:
+        """Muted channels should suppress runtime announcements before Send Chat API calls."""
+
+        db = backend_app.SessionLocal()
+        try:
+            channel = backend_app.ActiveChannel(channel_id="12348", channel_name="ChannelMute")
+            db.add(channel)
+            db.flush()
+            settings = backend_app.get_or_create_settings(db, channel.id)
+            settings.bot_message_level = "mute"
+            db.commit()
+        finally:
+            db.close()
+
+        with patch("backend_app.requests.post") as send_api_post:
+            response = self.client.post(
+                "/bot/runtime/announcements",
+                headers={"X-Admin-Token": backend_app.ADMIN_TOKEN},
+                json={"channel": "ChannelMute", "message_id": "queue_position_changed", "template_vars": {}},
+            )
+
+        self.assertEqual(response.status_code, 200)
+        payload = response.json()
+        self.assertFalse(payload["sent"])
+        self.assertEqual(payload["reason_code"], "suppressed_by_level")
+        send_api_post.assert_not_called()
+
+    def test_runtime_announcement_suppresses_when_channel_disconnected(self) -> None:
+        """Disconnected channels should suppress runtime announcements before Send Chat API calls."""
+
+        db = backend_app.SessionLocal()
+        try:
+            channel = backend_app.ActiveChannel(channel_id="12349", channel_name="ChannelDisconnected", join_active=0)
+            db.add(channel)
+            db.commit()
+        finally:
+            db.close()
+
+        with patch("backend_app.requests.post") as send_api_post:
+            response = self.client.post(
+                "/bot/runtime/announcements",
+                headers={"X-Admin-Token": backend_app.ADMIN_TOKEN},
+                json={"channel": "ChannelDisconnected", "message_id": "queue_position_changed", "template_vars": {}},
+            )
+
+        self.assertEqual(response.status_code, 200)
+        payload = response.json()
+        self.assertFalse(payload["sent"])
+        self.assertEqual(payload["reason_code"], "suppressed_disconnected")
+        send_api_post.assert_not_called()
+
     def test_backfill_twitch_send_chat_auth_mode_setting_inserts_default_row(self) -> None:
         """Backfill startup helper should insert missing auth-mode app setting."""
 


### PR DESCRIPTION
### Motivation
- Ensure backend runtime announcements do not attempt to send chat when a channel is disconnected (`join_active = 0`) and provide an explicit `reason_code` for that case.
- Make the bot message catalog API and runtime behavior descriptions consistent with the connect/disconnect semantics used by the Queue Manager UI.
- Add automated coverage to guard against regressions around mute/disconnect suppression logic.

### Description
- Added a new `reason_code` literal value `"suppressed_disconnected"` to `BotRuntimeAnnouncementOut` and its cast sites to represent suppressed sends due to channel disconnection.
- Short-circuited `_send_catalog_announcement` to return early with `sent=false` and `reason_code="suppressed_disconnected"` when `channel.join_active` is falsy, avoiding any outbound Send Chat API calls.
- Updated API docs in `docs/backend_api.md` and the websocket pruning ledger to document the behavioral change that runtime announcements are suppressed when a channel is disconnected.
- Added unit tests in `tests/test_bot_config.py` to verify mute-level suppression still prevents API calls and to verify the new disconnected-channel suppression behavior.

### Testing
- Ran unit tests in `tests/test_bot_config.py` covering announcement behavior, including `test_runtime_announcement_returns_reason_code_when_unsent`, `test_runtime_announcement_respects_mute_level_without_send_attempt`, and `test_runtime_announcement_suppresses_when_channel_disconnected`, and they all passed.
- Verified that the new tests assert `sent=false` and the expected `reason_code` values and that external `requests.post` (Send Chat API) is not called when suppressed.
- No other automated test failures were observed when running the modified test file.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d1953d84848328ad8337a4fb4cba86)