### PR TITLE
Filter EventSub conduit reconciliation to connected channels

### DIFF
--- a/backend_app.py
+++ b/backend_app.py
@@ -3913,7 +3913,7 @@ def _format_eventsub_http_error(exc: Exception, auth_mode: str) -> str:
 
 
 def reconcile_eventsub_conduit_subscriptions(request: Optional[FastAPIRequest], db: Session) -> dict[str, Any]:
-    """Reconcile conduit + shards + chat subscriptions for every active channel.
+    """Reconcile conduit + shards + chat subscriptions for connected channels.
 
     Dependencies: Uses app-auth via ``_eventsub_app_headers`` for conduit/shard
     and chat-subscription Helix APIs, and bot identity via ``get_bot_user_id``;
@@ -3933,11 +3933,16 @@ def reconcile_eventsub_conduit_subscriptions(request: Optional[FastAPIRequest], 
     """
 
     channels = db.query(ActiveChannel).order_by(ActiveChannel.id.asc()).all()
-    channels_with_owner_tokens = [ch for ch in channels if ch.owner and ch.owner.access_token]
+    connected_channels = [
+        ch
+        for ch in channels
+        if ch.owner and ch.owner.access_token and int(getattr(ch, "join_active", 1) or 0) == 1
+    ]
     result: dict[str, Any] = {
         "run_at": datetime.utcnow().isoformat() + "Z",
         "channels_total": len(channels),
-        "channels_with_owner_tokens": len(channels_with_owner_tokens),
+        "channels_with_owner_tokens": len(connected_channels),
+        "connected_channels": len(connected_channels),
         "status": "ok",
         "degraded": False,
         "conduit": None,
@@ -3946,7 +3951,7 @@ def reconcile_eventsub_conduit_subscriptions(request: Optional[FastAPIRequest], 
         "warnings": [],
         "errors": [],
     }
-    if not channels_with_owner_tokens:
+    if not connected_channels:
         result["errors"].append("no_channels_with_owner_tokens")
         return result
 
@@ -3988,19 +3993,19 @@ def reconcile_eventsub_conduit_subscriptions(request: Optional[FastAPIRequest], 
         result["errors"].append(f"bot_identity_unavailable: {exc}")
         return result
 
-    conduit_row, conduit_errors = _ensure_twitch_conduit(headers, len(channels_with_owner_tokens), db, now)
+    conduit_row, conduit_errors = _ensure_twitch_conduit(headers, len(connected_channels), db, now)
     result["errors"].extend(conduit_errors)
     if not conduit_row:
         return result
     result["conduit"] = {"id": conduit_row.conduit_id, "status": conduit_row.status}
     assignment, shard_errors = _reconcile_twitch_conduit_shards(
-        headers, conduit_row, callback, len(channels_with_owner_tokens), db, now
+        headers, conduit_row, callback, len(connected_channels), db, now
     )
     result["errors"].extend(shard_errors)
     result["shards"] = [{"id": shard_id, "status": status} for shard_id, status in sorted(assignment.items())]
     shard_ids = sorted(assignment.keys()) or ["0"]
 
-    for index, channel in enumerate(channels_with_owner_tokens):
+    for index, channel in enumerate(connected_channels):
         channel_result: dict[str, Any] = {
             "channel": channel.channel_name,
             "channel_id": channel.channel_id,

--- a/tests/test_channel_events.py
+++ b/tests/test_channel_events.py
@@ -2440,6 +2440,99 @@ remove:
         finally:
             db.close()
 
+    def test_reconcile_eventsub_conduit_subscriptions_excludes_disconnected_channels(self) -> None:
+        """Reconcile conduit subscriptions using connected channels only.
+
+        Dependencies: ``ActiveChannel.join_active`` state, EventSub reconcile
+        helper calls, and mocked Helix subscription list responses.
+        Code customers: ingress repair/watcher reconcile paths that size conduit
+        shards and assign per-channel subscriptions.
+        Used variables/origin: creates one connected channel plus one
+        disconnected channel (both with owner tokens) to assert only connected
+        channels participate in shard sizing and subscription reconciliation.
+        """
+
+        connected_details = _setup_channel()
+        db = backend_app.SessionLocal()
+        try:
+            owner = backend_app.TwitchUser(
+                twitch_id="owner-disconnected",
+                username="owner_disconnected",
+                access_token="token-disconnected",
+                refresh_token="",
+                scopes="",
+            )
+            db.add(owner)
+            db.commit()
+            db.refresh(owner)
+            db.add(
+                backend_app.ActiveChannel(
+                    channel_id="cid-disconnected",
+                    channel_name="disconnected_channel",
+                    owner_id=owner.id,
+                    authorized=True,
+                    join_active=0,
+                )
+            )
+            db.commit()
+
+            with mock.patch.object(
+                backend_app,
+                "_public_eventsub_callback_url",
+                return_value=("https://example.com/twitch/eventsub/callback", None, {"source": "test", "warnings": []}),
+            ), mock.patch.object(
+                backend_app,
+                "_eventsub_app_headers",
+                return_value={"Authorization": "Bearer test", "Client-Id": "cid"},
+            ), mock.patch.object(
+                backend_app,
+                "get_bot_user_id",
+                return_value="bot-user-id",
+            ), mock.patch.object(
+                backend_app,
+                "_ensure_twitch_conduit",
+                return_value=(mock.Mock(conduit_id="conduit-1", status="enabled"), []),
+            ) as ensure_mock, mock.patch.object(
+                backend_app,
+                "_reconcile_twitch_conduit_shards",
+                return_value=({"0": "enabled"}, []),
+            ) as shards_mock, mock.patch.object(
+                backend_app.requests,
+                "get",
+                return_value=mock.Mock(
+                    json=lambda: {
+                        "data": [
+                            {
+                                "id": "remote-sub-1",
+                                "type": backend_app.EVENTSUB_CONDUIT_CHAT_TYPE,
+                                "condition": {
+                                    "broadcaster_user_id": "cid",
+                                    "user_id": "bot-user-id",
+                                },
+                                "transport": {"method": "conduit", "conduit_id": "conduit-1"},
+                                "status": "enabled",
+                            }
+                        ]
+                    },
+                    raise_for_status=lambda: None,
+                ),
+            ) as list_mock, mock.patch.object(backend_app.requests, "post") as post_mock:
+                result = backend_app.reconcile_eventsub_conduit_subscriptions(None, db)
+
+            self.assertEqual(result["channels_total"], 2)
+            self.assertEqual(result["connected_channels"], 1)
+            self.assertEqual(result["channels_with_owner_tokens"], 1)
+            self.assertEqual(len(result["subscriptions"]), 1)
+            self.assertEqual(result["subscriptions"][0]["channel"], connected_details["channel_name"])
+            ensure_mock.assert_called_once()
+            shards_mock.assert_called_once()
+            self.assertEqual(ensure_mock.call_args[0][1], 1)
+            self.assertEqual(shards_mock.call_args[0][3], 1)
+            self.assertEqual(list_mock.call_count, 1)
+            post_mock.assert_not_called()
+        finally:
+            db.close()
+
     def test_get_or_create_settings_backfills_queue_caps(self) -> None:
         """Ensure legacy channel settings rows gain default queue caps.
 


### PR DESCRIPTION
### Motivation

- Conduit/shard sizing and per-channel EventSub subscription reconciliation should only consider channels that are truly connected and able to participate (owner present, owner has an access token, and `join_active == 1`).
- Current flow counted channels with owner tokens but still processed disconnected channels, which can mis-size conduits and assign subscriptions where they are not needed.

### Description

- Update `reconcile_eventsub_conduit_subscriptions` to build a single filtered candidate list named `connected_channels` that requires `ch.owner` exists, `ch.owner.access_token` exists, and `ch.join_active == 1`.
- Use this `connected_channels` list consistently for conduit sizing (`_ensure_twitch_conduit(..., shard_count, ...)`), shard reconciliation sizing (`_reconcile_twitch_conduit_shards(..., shard_count, ...)`), and the per-channel subscription reconciliation loop.
- Add clearer telemetry by introducing `connected_channels` in the result and aligning the existing `channels_with_owner_tokens` field to the same filtered population to avoid ambiguity while maintaining backward compatibility.
- Add a unit test `test_reconcile_eventsub_conduit_subscriptions_excludes_disconnected_channels` in `tests/test_channel_events.py` that creates one connected and one disconnected channel and asserts disconnected channels are excluded from sizing and per-channel reconciliation.
- Update the function docstring to reflect the narrowed scope (connected channels) and preserve error/diagnostics behavior when no connected channels exist.

### Testing

- Ran static compile check with `python -m compileall -q backend_app.py tests/test_channel_events.py`, which succeeded.
- Attempted to run the targeted pytest: `python -m pytest -q tests/test_channel_events.py -k "reconcile_eventsub_conduit_subscriptions_excludes_disconnected_channels"`, but test collection failed in this environment due to an `sqlite3.OperationalError: unable to open database file` during module import/DB setup. The test itself exercises mocked Helix calls and was added to assert the intended behavior once the test environment DB path is available.
- The new test was added and compiles; it will validate conduit sizing and subscription assignment behavior in a functional test environment with a writable DB file.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d1a0d0e1408328909f5d6c7e95c648)