### PR TITLE
Handle conduit EventSub state on channel connect/disconnect

### DIFF
--- a/backend_app.py
+++ b/backend_app.py
@@ -8098,18 +8098,78 @@ def add_channel(payload: ChannelIn, db: Session = Depends(get_db)):
     publish_queue_changed(channel_pk)
     return ch
 
+def _set_channel_conduit_subscription_state(
+    db: Session,
+    channel_pk: int,
+    *,
+    enabled: bool,
+) -> int:
+    """Set persisted conduit chat EventSub state for a single channel.
+
+    Dependencies: Mutates ``EventSubscription`` rows using the provided
+    SQLAlchemy ``Session`` and shared ``EVENTSUB_CONDUIT_CHAT_TYPE`` constant.
+    Code customers: ``update_channel_status`` and planned admin/operator flows
+    that need explicit conduit chat subscription state transitions.
+    Used variables/origin: ``channel_pk`` is the resolved ``ActiveChannel``
+    primary key, while ``enabled`` maps to local row status semantics
+    (disconnect => ``disabled``, reconnect path currently leaves local row as-is
+    until reconcile repopulates authoritative state).
+    """
+
+    rows = (
+        db.query(EventSubscription)
+        .filter(
+            EventSubscription.channel_id == channel_pk,
+            EventSubscription.type == EVENTSUB_CONDUIT_CHAT_TYPE,
+            EventSubscription.transport == "conduit",
+        )
+        .all()
+    )
+    if enabled:
+        return len(rows)
+    now = datetime.utcnow()
+    for row in rows:
+        row.status = "disabled"
+        row.last_verified_at = None
+        row.updated_at = now
+    return len(rows)
+
 @app.put("/channels/{channel}", dependencies=[Depends(require_token)])
 def update_channel_status(
     channel: str,
     join_active: int = Query(..., ge=0, le=1),
     db: Session = Depends(get_db),
 ):
+    """Update channel connect/disconnect state and sync conduit subscriptions.
+
+    Dependencies: Resolves channel identity via ``get_channel_pk``, mutates
+    ``ActiveChannel.join_active``, toggles conduit-backed chat subscription rows
+    through ``_set_channel_conduit_subscription_state``, and may trigger
+    ``reconcile_eventsub_conduit_subscriptions`` for reconnects.
+    Code customers: Queue Manager connect/disconnect controls and admin channel
+    status automation.
+    Used variables/origin: ``join_active`` comes from validated query input
+    (`0|1`); ``channel`` is channel slug/name/ID routed path input.
+    """
+
     channel_pk = get_channel_pk(channel, db)
     ch = db.get(ActiveChannel, channel_pk)
     if not ch:
         raise HTTPException(404, "channel not found")
     ch.join_active = join_active
+    _set_channel_conduit_subscription_state(db, channel_pk, enabled=(join_active == 1))
     db.commit()
+    if join_active == 1 and (
+        get_chat_ingress_mode() == "webhook_conduit" or get_chat_ingress_shadow_mode()
+    ):
+        try:
+            reconcile_eventsub_conduit_subscriptions(None, db)
+        except Exception:
+            logger.warning(
+                "Conduit reconciliation failed after channel reconnect",
+                extra={"channel_id": channel_pk, "channel_name": ch.channel_name},
+                exc_info=True,
+            )
     publish_queue_changed(channel_pk)
     return {"success": True}
 

--- a/docs/backend_api.md
+++ b/docs/backend_api.md
@@ -258,7 +258,8 @@ Channel settings include queue intake controls:
   - `/channels/{channel}/settings` keeps `bot_message_level` strict to enum
     values `mute|normal|verbose|debug`.
 - Behavioral difference:
-  - `disconnect` (`join_active=0`) is the stronger switch: channel command ingress subscriptions are removed in the bot runtime and backend runtime announcements are suppressed.
+  - `disconnect` (`join_active=0`) is the stronger switch: channel command ingress subscriptions are removed in the bot runtime, conduit-backed `channel.chat.message` `EventSubscription` rows are locally marked `disabled`, and backend runtime announcements are suppressed.
+  - `connect` (`join_active=1`) restores runtime connectivity and immediately triggers conduit reconciliation to refresh authoritative EventSub state for the channel.
   - `mute` (`bot_message_level="mute"`) keeps the bot connected for control-plane behavior but suppresses all chat message output by visibility policy.
 
 ## Steady-state runbooks

--- a/tests/test_channel_events.py
+++ b/tests/test_channel_events.py
@@ -2674,11 +2674,36 @@ remove:
         self.assertEqual(invalid.status_code, 422, invalid.text)
 
     def test_channel_status_route_controls_join_active_and_rejects_invalid_values(self) -> None:
-        """Connect/disconnect should use `/channels/{channel}` with strict join_active validation."""
+        """Connect/disconnect should mutate join_active and conduit EventSub state.
+
+        Dependencies: Exercises ``/channels/{channel}`` update route,
+        ``EventSubscription`` persistence, and reconnect-driven conduit
+        reconcile hooks.
+        Code customers: Queue Manager bot connect/disconnect dropdown and admin
+        workflows that toggle channel runtime state.
+        Used variables/origin: seeds one conduit chat ``EventSubscription`` row
+        and patches reconcile dependencies to emulate a successful reconnect
+        refresh from Twitch.
+        """
 
         details = _setup_channel()
         channel = details["channel_name"]
         headers = {"X-Admin-Token": backend_app.ADMIN_TOKEN}
+        with backend_app.SessionLocal() as db:
+            db.add(
+                backend_app.EventSubscription(
+                    channel_id=details["channel_pk"],
+                    twitch_subscription_id="sub-channel-toggle",
+                    type=backend_app.EVENTSUB_CONDUIT_CHAT_TYPE,
+                    status="enabled",
+                    secret=backend_app.EVENTSUB_CONDUIT_SECRET_PLACEHOLDER,
+                    callback="https://example/callback",
+                    transport="conduit",
+                    conduit_id="conduit-toggle",
+                    shard_id="0",
+                )
+            )
+            db.commit()
 
         disconnect = self.client.put(
             f"/channels/{channel}",
@@ -2690,13 +2715,72 @@ remove:
         with backend_app.SessionLocal() as db:
             stored = db.query(backend_app.ActiveChannel).filter_by(channel_name=channel).one()
             self.assertEqual(stored.join_active, 0)
+            sub = (
+                db.query(backend_app.EventSubscription)
+                .filter(backend_app.EventSubscription.twitch_subscription_id == "sub-channel-toggle")
+                .one()
+            )
+            self.assertEqual(sub.status, "disabled")
 
-        reconnect = self.client.put(
-            f"/channels/{channel}",
-            params={"join_active": 1},
-            headers=headers,
-        )
+        with mock.patch.object(
+            backend_app,
+            "_public_eventsub_callback_url",
+            return_value=("https://example.com/twitch/eventsub/callback", None, {"source": "test", "warnings": []}),
+        ), mock.patch.object(
+            backend_app,
+            "_eventsub_app_headers",
+            return_value={"Authorization": "Bearer app", "Client-Id": "client"},
+        ), mock.patch.object(
+            backend_app,
+            "get_bot_user_id",
+            return_value="bot-user-id",
+        ), mock.patch.object(
+            backend_app,
+            "_ensure_twitch_conduit",
+            return_value=(mock.Mock(conduit_id="conduit-toggle", status="enabled"), []),
+        ), mock.patch.object(
+            backend_app,
+            "_reconcile_twitch_conduit_shards",
+            return_value=({"0": "enabled"}, []),
+        ), mock.patch.object(
+            backend_app.requests,
+            "get",
+            return_value=mock.Mock(
+                json=lambda: {
+                    "data": [
+                        {
+                            "id": "sub-channel-toggle",
+                            "type": backend_app.EVENTSUB_CONDUIT_CHAT_TYPE,
+                            "condition": {
+                                "broadcaster_user_id": details["channel_id"],
+                                "user_id": "bot-user-id",
+                            },
+                            "transport": {"method": "conduit", "conduit_id": "conduit-toggle"},
+                            "status": "enabled",
+                        }
+                    ]
+                },
+                raise_for_status=lambda: None,
+            ),
+        ), mock.patch.object(backend_app.requests, "post") as post_mock:
+            reconnect = self.client.put(
+                f"/channels/{channel}",
+                params={"join_active": 1},
+                headers=headers,
+            )
         self.assertEqual(reconnect.status_code, 200, reconnect.text)
+        post_mock.assert_not_called()
+
+        with backend_app.SessionLocal() as db:
+            stored = db.query(backend_app.ActiveChannel).filter_by(channel_name=channel).one()
+            self.assertEqual(stored.join_active, 1)
+            sub = (
+                db.query(backend_app.EventSubscription)
+                .filter(backend_app.EventSubscription.twitch_subscription_id == "sub-channel-toggle")
+                .one()
+            )
+            self.assertEqual(sub.status, "enabled")
+            self.assertEqual(sub.transport, "conduit")
 
         invalid = self.client.put(
             f"/channels/{channel}",


### PR DESCRIPTION
### Motivation
- Ensure channel connect/disconnect consistently updates persisted conduit-backed `channel.chat.message` EventSub state and let reconnect trigger a targeted reconcile so authoritative remote state is refreshed.
- Centralize mutation logic so future admin/operator flows can toggle conduit subscription rows in one place.
- Keep API docs accurate about the behavioral difference between `connect` and `disconnect`.

### Description
- Add helper ` _set_channel_conduit_subscription_state(db, channel_pk, enabled: bool)` which centralizes mutation of `EventSubscription` rows for `EVENTSUB_CONDUIT_CHAT_TYPE` and documents dependencies, code customers, and used variables in the function docstring. 
- Update `update_channel_status` to call the helper on status changes (marking conduit `EventSubscription` rows `disabled` on disconnect) and to trigger `reconcile_eventsub_conduit_subscriptions` on reconnect when conduit ingress or shadow mode is enabled, with guarded exception logging. 
- Extend `tests/test_channel_events.py::test_channel_status_route_controls_join_active_and_rejects_invalid_values` to seed a conduit chat `EventSubscription`, assert the row becomes `disabled` on a disconnect call, mock reconcile/list APIs on reconnect, and assert the subscription row is `enabled` again after reconnect. 
- Update `docs/backend_api.md` to document that `disconnect` locally marks conduit-backed `channel.chat.message` EventSub rows as `disabled` and that `connect` triggers immediate conduit reconciliation to refresh authoritative EventSub state.
- No unused code was removed; none were identified during this change.

### Testing
- Ran `python -m py_compile backend_app.py tests/test_channel_events.py` which completed successfully.
- Attempted `PYTHONPATH=. pytest -q tests/test_channel_events.py -k "channel_status_route_controls_join_active"` but test collection failed due to the environment SQLite error (`sqlite3.OperationalError: unable to open database file`), so the new DB-state assertions are exercised in the test but could not be executed end-to-end in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d1a2962fc883289df7ff2afd11cb61)