### PR TITLE
Structured EventSub decision logging and stable reply reason codes

### DIFF
--- a/backend_app.py
+++ b/backend_app.py
@@ -2434,13 +2434,22 @@ def _send_eventsub_chat_reply(
     Used variables/origin: ``reply`` contract is emitted by command executors;
     ``reply_parent_message_id`` comes from the inbound EventSub message id.
     When ``return_reason=True``, returns ``(sent, reason_code)`` where
-    ``reason_code`` is one of ``suppressed_by_level``, ``preflight_rejected``,
-    or ``api_failure`` for non-send outcomes.
+    ``reason_code`` is one of ``success``, ``suppressed_by_level``,
+    ``preflight_rejected``, or ``api_failure``.
     """
 
     def _finish(sent: bool, reason_code: Optional[str] = None) -> Any:
+        normalized_reason = str(reason_code or ("success" if sent else "api_failure")).strip() or "api_failure"
+        logger.info(
+            "EventSub reply delivery decision",
+            extra={
+                "channel": channel.channel_name,
+                "decision_result": "sent" if sent else "not_sent",
+                "reason_code": normalized_reason,
+            },
+        )
         if return_reason:
-            return sent, reason_code
+            return sent, normalized_reason
         return sent
 
     visibility = str(reply.get("visibility") or "normal")
@@ -2481,7 +2490,7 @@ def _send_eventsub_chat_reply(
             )
             response.raise_for_status()
             _record_ingress_metric("reply_sent")
-            return _finish(True, None)
+            return _finish(True, "success")
         except requests.HTTPError as exc:
             _record_ingress_metric("send_api_failure")
             status_code, reason_code, diagnostic_snippet = _extract_send_api_error_details(exc.response)
@@ -3295,9 +3304,38 @@ def _process_eventsub_chat_notification(
         )
         webhook_result = "shadow_observe_only"
 
-    _record_ingress_metric(
-        "command_dispatch_outcome",
-        key=f"{channel.channel_name}:{webhook_result}",
+    canonical_command = str(
+        outcome.get("command")
+        or parsed.get("canonical")
+        or ""
+    ).strip() or None
+    reason_code = str(outcome.get("reason_code") or "").strip() or None
+    status = str(outcome.get("status") or "").strip().lower()
+    if status == "executed":
+        outcome_category = "passed"
+    elif reason_code == "parse_non_command":
+        outcome_category = "rejected_non_command"
+    elif reason_code in {"shadow_mode_observe_only", "suppressed_by_level", "suppressed_disconnected"}:
+        outcome_category = "suppressed"
+    elif status == "error":
+        outcome_category = "failed"
+    elif status == "rejected":
+        outcome_category = "suppressed"
+    else:
+        outcome_category = "failed"
+
+    _record_ingress_metric("command_dispatch_outcome", key=f"{channel.channel_name}:{webhook_result}")
+
+    logger.info(
+        "EventSub chat command decision",
+        extra={
+            "channel": channel.channel_name,
+            "canonical_command": canonical_command or "<none>",
+            "eventsub_message_id": message_id,
+            "outcome_category": outcome_category,
+            "reason_code": reason_code,
+            "decision_result": webhook_result,
+        },
     )
 
     logger.info(
@@ -3310,9 +3348,17 @@ def _process_eventsub_chat_notification(
             "websocket_authoritative": not webhook_authoritative,
             "webhook_authoritative": webhook_authoritative,
             "chatter_login": chatter_login,
-            "webhook_parse": parsed,
+            "webhook_parse": {
+                "canonical": parsed.get("canonical"),
+                "alias": parsed.get("alias"),
+                "parse_reason": parsed.get("parse_reason"),
+            },
             "webhook_execution_result": webhook_result,
-            "webhook_outcome": outcome,
+            "webhook_outcome": {
+                "status": outcome.get("status"),
+                "command": outcome.get("command"),
+                "reason_code": outcome.get("reason_code"),
+            },
             "websocket_result": "authoritative_path_external_to_callback_deprecated",
         },
     )
@@ -4790,7 +4836,7 @@ class BotRuntimeAnnouncementOut(BaseModel):
     template_key: str
     visibility: Literal["mute", "normal", "verbose", "debug"]
     delivery_path: Literal["send_chat_pipeline"]
-    reason_code: Optional[Literal["suppressed_by_level", "suppressed_disconnected", "preflight_rejected", "api_failure"]] = None
+    reason_code: Optional[Literal["success", "suppressed_by_level", "suppressed_disconnected", "preflight_rejected", "api_failure"]] = None
 
 
 class BotOAuthStartIn(BaseModel):
@@ -6705,7 +6751,7 @@ def _send_catalog_announcement(
         template_key=template_key,
         visibility=cast(Literal["mute", "normal", "verbose", "debug"], visibility),
         delivery_path="send_chat_pipeline",
-        reason_code=cast(Optional[Literal["suppressed_by_level", "suppressed_disconnected", "preflight_rejected", "api_failure"]], reason_code),
+        reason_code=cast(Optional[Literal["success", "suppressed_by_level", "suppressed_disconnected", "preflight_rejected", "api_failure"]], reason_code),
     )
 
 

--- a/docs/backend_api.md
+++ b/docs/backend_api.md
@@ -197,8 +197,9 @@ This document summarizes the REST endpoints exposed by `backend_app.py`.
   - Builds the same reply contract used by webhook command replies (`template_key`, `template_vars`, `visibility`).
   - Sends through the authoritative Twitch Send Chat Message pipeline (`_send_eventsub_chat_reply`), which enforces the same auth-mode policy (`twitch_send_chat_auth_mode`) and channel `bot_message_level` threshold rules.
   - Suppresses chat sends when the channel is disconnected (`join_active = 0`) so runtime announcements remain silent until reconnect.
-  - Returns send status metadata including `delivery_path: "send_chat_pipeline"`.
-  - When `sent=false`, includes `reason_code` with one of:
+  - Returns send status metadata including `delivery_path: "send_chat_pipeline"` and a stable `reason_code` decision enum.
+  - `reason_code` values:
+    - `success`: Twitch Send Chat API accepted the message.
     - `suppressed_by_level`: channel message-level threshold or empty rendered template suppressed the send.
     - `suppressed_disconnected`: channel is disconnected (`join_active = 0`), so no runtime announcement is sent.
     - `preflight_rejected`: auth/header/payload preflight checks failed before calling Twitch Send Chat API.
@@ -636,6 +637,9 @@ Certain events award priority points and are fed by EventSub subscriptions creat
   - Deterministic preflight validation now runs before Send Chat API calls to prevent guaranteed 400 retries: non-empty `broadcaster_id`, non-empty `sender_id`, message length `1-500`, and `sender_id` equality with bot token subject (`/oauth2/validate` `user_id`).
   - Preflight failures emit explicit reason codes and skip HTTP requests/retries.
   - Reply rendering uses the same message-catalog template semantics as websocket bot command responses.
+  - Reply send logging now emits a sanitized structured decision record with destination `channel`, `decision_result`, and `reason_code` only (no payload/body text).
+  - Command ingress logging now emits a sanitized structured decision record with `channel`, canonical command, EventSub message id, and normalized outcome category (`passed`, `suppressed`, `failed`, `rejected_non_command`) plus optional reason code.
+  - Webhook comparison telemetry excludes raw message/payload text and retains only parse/outcome summary keys.
   - Channel `bot_message_level` thresholds still gate webhook replies exactly like bot/websocket mode (`mute` suppresses all, `normal`/`verbose`/`debug` thresholds allow <= level).
   - In `chat_ingress_shadow_mode=true`, webhook command notifications stay observe-only and do not send chat replies or mutate queue state.
   - `random_request` remains a websocket-only execution path for now and is marked as a cleanup candidate to remove once authoritative migration completes.


### PR DESCRIPTION
### Motivation
- Make EventSub webhook command outcomes and Send Chat reply decisions observable with a small, stable structured record that excludes raw message/payload text.
- Normalize reply `reason_code` semantics so callers (and runtime announcements) receive a consistent enum including `success`, `suppressed_by_level`, `preflight_rejected`, and `api_failure`.

### Description
- Add a sanitized structured log in `_process_eventsub_chat_notification` that emits `channel`, `canonical_command`, `eventsub_message_id`, a normalized `outcome_category` (`passed`, `suppressed`, `failed`, `rejected_non_command`), and optional `reason_code` immediately after command execution/decision.
- Tighten the larger webhook comparison log to only include parse/outcome summary fields (`canonical`, `alias`, `parse_reason`) and an outcome summary (`status`, `command`, `reason_code`) to avoid logging payload/body text.
- Update `_send_eventsub_chat_reply` to consistently surface `reason_code` values and emit a sanitized delivery decision log with `channel`, `decision_result`, and `reason_code`, and return `success` when the send is accepted.
- Surface `success` as a first-class `reason_code` in the `BotRuntimeAnnouncementOut` model and in the cast at runtime, and preserve existing TODO/cleanup markers for websocket-only paths.
- Update `docs/backend_api.md` to document the stable `reason_code` enum and the new sanitized structured logging semantics for reply/command decisions.

### Testing
- Ran `python -m py_compile backend_app.py` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d221e0d63c8328b9687a270b458921)