### PR TITLE
Emit startup ingress health log and add channel sync summary log

### DIFF
--- a/backend_app.py
+++ b/backend_app.py
@@ -1535,7 +1535,72 @@ def _evaluate_ingress_runtime_invariants(db: Session, *, now: datetime) -> dict[
     }
 
 
-def run_ingress_guard_startup_check() -> None:
+def _startup_connected_channel_summary(db: Session) -> dict[str, Any]:
+    """Build a compact startup snapshot of currently connected channels.
+
+    Dependencies: Reads ``ActiveChannel`` rows with owner relationship state.
+    Code customers: ``emit_startup_ingress_health_log`` startup diagnostics.
+    Used variables/origin: channel identifiers come from ``active_channels`` and
+    owner-token presence from ``twitch_users.access_token``.
+    """
+
+    channels = (
+        db.query(ActiveChannel)
+        .options(joinedload(ActiveChannel.owner))
+        .order_by(ActiveChannel.id.asc())
+        .all()
+    )
+    connected = [
+        channel
+        for channel in channels
+        if bool(channel.join_active) and bool(channel.authorized) and bool(channel.owner and channel.owner.access_token)
+    ]
+    return {
+        "count": len(connected),
+        "channels": [str(channel.channel_name or "").strip() for channel in connected if str(channel.channel_name or "").strip()],
+        "channel_ids": [str(channel.channel_id or "").strip() for channel in connected if str(channel.channel_id or "").strip()],
+    }
+
+
+def _startup_conduit_shard_health_summary(db: Session, guard: dict[str, Any]) -> dict[str, Any]:
+    """Assemble startup conduit + shard health details for operator logs.
+
+    Dependencies: Reads ``TwitchConduitShard`` status plus chat subscription
+    conduit assignments, and merges guard runtime invariant counters.
+    Code customers: ``emit_startup_ingress_health_log`` structured startup log.
+    Used variables/origin: shard state from ``twitch_conduit_shards`` and
+    assignment IDs from enabled conduit ``event_subscriptions`` rows.
+    """
+
+    shard_rows = db.query(TwitchConduitShard).order_by(TwitchConduitShard.id.asc()).all()
+    healthy_shards = sum(1 for shard in shard_rows if str(shard.status or "").strip().lower() == "enabled")
+    assignment_rows = (
+        db.query(EventSubscription.conduit_id, EventSubscription.shard_id)
+        .filter(
+            EventSubscription.type == EVENTSUB_CONDUIT_CHAT_TYPE,
+            EventSubscription.transport == "conduit",
+            EventSubscription.status == "enabled",
+        )
+        .all()
+    )
+    conduit_ids = sorted(
+        {
+            str(conduit_id or "").strip()
+            for conduit_id, _ in assignment_rows
+            if str(conduit_id or "").strip()
+        }
+    )
+    runtime_invariants = guard.get("runtime_invariants", {}) if isinstance(guard, dict) else {}
+    return {
+        "conduit_ids": conduit_ids,
+        "assignment_count": len(assignment_rows),
+        "shards_total": len(shard_rows),
+        "shards_healthy": healthy_shards,
+        "unresolved_assignment_count": int(runtime_invariants.get("unresolved_assignment_count") or 0),
+    }
+
+
+def run_ingress_guard_startup_check() -> dict[str, Any]:
     """Run startup ingress guard checks, including runtime invariant validation.
 
     Dependencies: Uses ``SessionLocal`` and ``_evaluate_ingress_guard``.
@@ -1547,10 +1612,58 @@ def run_ingress_guard_startup_check() -> None:
     db = SessionLocal()
     try:
         if get_chat_ingress_mode() != "webhook_conduit":
-            return
-        _evaluate_ingress_guard(db, datetime.utcnow(), apply_fallback=True)
+            return {"status": "skipped", "reason": "ingress_mode_not_webhook_conduit"}
+        guard = _evaluate_ingress_guard(db, datetime.utcnow(), apply_fallback=True)
+        return {"status": "ok", "guard": guard}
     except Exception:
         logger.exception("Ingress guard startup check failed")
+        return {"status": "error", "reason": "startup_guard_exception"}
+    finally:
+        db.close()
+
+
+def emit_startup_ingress_health_log(guard_startup_result: dict[str, Any]) -> None:
+    """Emit one structured startup health log for ingress/guard/channel state.
+
+    Dependencies: Reads runtime mode/settings, startup guard result, and
+    database-backed channel/conduit state snapshots.
+    Code customers: module startup bootstrap after guard + worker initialization.
+    Used variables/origin: guard output from ``run_ingress_guard_startup_check``
+    and worker alive state from singleton worker thread handles.
+    """
+
+    db = SessionLocal()
+    try:
+        guard = guard_startup_result.get("guard", {}) if isinstance(guard_startup_result, dict) else {}
+        guard_status = "skipped"
+        guard_reasons: list[str] = []
+        if isinstance(guard, dict):
+            guard_status = "degraded" if bool(guard.get("degraded")) else "healthy"
+            guard_reasons = [str(reason) for reason in guard.get("reasons", [])]
+        elif isinstance(guard_startup_result, dict):
+            guard_status = str(guard_startup_result.get("status") or "unknown")
+            guard_reasons = [str(guard_startup_result.get("reason") or "")]
+
+        payload = {
+            "event": "INGRESS_STARTUP_HEALTH",
+            "ingress_mode": get_chat_ingress_mode(),
+            "guard": {
+                "startup_status": str(guard_startup_result.get("status") if isinstance(guard_startup_result, dict) else "unknown"),
+                "status": guard_status,
+                "reasons": [reason for reason in guard_reasons if reason],
+            },
+            "conduit_shards": _startup_conduit_shard_health_summary(db, guard if isinstance(guard, dict) else {}),
+            "connected_channels": _startup_connected_channel_summary(db),
+            "workers": {
+                "bot_token_refresh_worker_alive": bool(_BOT_TOKEN_REFRESH_WORKER and _BOT_TOKEN_REFRESH_WORKER.is_alive()),
+                "ingress_guard_repair_watcher_alive": bool(
+                    _INGRESS_GUARD_REPAIR_WORKER and _INGRESS_GUARD_REPAIR_WORKER.is_alive()
+                ),
+            },
+        }
+        logger.info("INGRESS_STARTUP_HEALTH %s", json.dumps(payload, sort_keys=True, default=str))
+    except Exception:
+        logger.exception("Failed to emit structured ingress startup health log")
     finally:
         db.close()
 
@@ -4632,9 +4745,10 @@ bootstrap_settings_from_env()
 backfill_twitch_send_chat_auth_mode_setting()
 cleanup_conduit_subscription_secret_semantics()
 _validate_startup_symbol_order()
-run_ingress_guard_startup_check()
+startup_guard_result = run_ingress_guard_startup_check()
 start_bot_token_refresh_worker()
 start_ingress_guard_repair_watcher()
+emit_startup_ingress_health_log(startup_guard_result)
 
 # =====================================
 # Schemas

--- a/bot/bot_app.py
+++ b/bot/bot_app.py
@@ -716,6 +716,16 @@ class SongBot(commands.Bot):
                     allowed[login] = row
             current_keys = set(self.channel_map.keys())
             allowed_keys = set(allowed.keys())
+            added_preview = sorted(allowed_keys - current_keys)
+            removed_preview = sorted(current_keys - allowed_keys)
+            logger.info(
+                "CHANNEL_SYNC_SUMMARY considered=%s listened=%s rollback_websocket=%s added=%s removed=%s",
+                len(rows),
+                len(current_keys),
+                rollback_enabled,
+                added_preview,
+                removed_preview,
+            )
 
             removed = current_keys - allowed_keys
             for key in removed:

--- a/docs/README.md
+++ b/docs/README.md
@@ -101,6 +101,15 @@ unlocks the API for the bot, queue manager, and public web frontend.
   health), then applies least-disruptive repair in order
   `reconcile -> shard_repair -> rebuild`, with cooldown + max-attempt caps to
   prevent infinite repair loops.
+- Startup now emits one structured operator log event
+  `INGRESS_STARTUP_HEALTH` after ingress guard + worker initialization with:
+  - `ingress_mode`,
+  - `guard.startup_status`, `guard.status`, and `guard.reasons`,
+  - `conduit_shards` summary (`conduit_ids`, `assignment_count`,
+    `shards_total`, `shards_healthy`, `unresolved_assignment_count`),
+  - `connected_channels` summary (`count`, `channels`, `channel_ids`),
+  - startup worker alive flags (`bot_token_refresh_worker_alive`,
+    `ingress_guard_repair_watcher_alive`).
 - Startup import now validates ingress-guard symbol availability before running
   the guard so symbol-order regressions fail fast during process boot.
 - Conduit shard metadata now persists `twitch_conduit_shards.transport_secret`
@@ -216,6 +225,10 @@ unlocks the API for the bot, queue manager, and public web frontend.
   - Historical comparison-only webhook command code paths are now deprecated
     and explicitly marked in outcome reason codes until fully removed
     (`random_request` is the remaining websocket-only cleanup candidate).
+  - Bot channel sync now emits compact cycle logs:
+    `CHANNEL_SYNC_SUMMARY considered=<count> listened=<count>
+    rollback_websocket=<bool> added=[...] removed=[...]` so operators can
+    quickly inspect channel lifecycle churn and rollback websocket posture.
 - Shadow mode behavior:
   - With `chat_ingress_shadow_mode=true`, webhook chat ingress runs in
     non-authoritative observe/compare mode (no queue mutations and no reply

--- a/docs/backend_api.md
+++ b/docs/backend_api.md
@@ -66,6 +66,33 @@ This document summarizes the REST endpoints exposed by `backend_app.py`.
   - callback error threshold: 5 errors / 5 minutes,
   - minimum healthy shards: 1 (or expected shard count for larger deployments).
 
+### Startup/operator log events (non-API)
+- `INGRESS_STARTUP_HEALTH` (backend startup):
+  - `ingress_mode`: effective startup mode (`webhook_conduit` or `websocket`).
+  - `guard.startup_status`: startup check result (`ok`, `skipped`, `error`).
+  - `guard.status`: normalized guard health (`healthy`, `degraded`, `skipped`).
+  - `guard.reasons`: degradation/skip reasons (if any).
+  - `conduit_shards`: startup conduit/shard snapshot:
+    - `conduit_ids` (active conduit IDs seen in enabled chat subscriptions),
+    - `assignment_count`,
+    - `shards_total`,
+    - `shards_healthy`,
+    - `unresolved_assignment_count`.
+  - `connected_channels`: startup channel connectivity summary:
+    - `count`,
+    - `channels` (channel names),
+    - `channel_ids` (Twitch broadcaster IDs).
+  - `workers`: startup worker alive flags:
+    - `bot_token_refresh_worker_alive`,
+    - `ingress_guard_repair_watcher_alive`.
+
+- `CHANNEL_SYNC_SUMMARY` (bot runtime `sync_channels` cycle):
+  - `considered`: number of backend channel rows evaluated this cycle.
+  - `listened`: channels currently tracked/listened by bot before diff apply.
+  - `rollback_websocket`: value of `chat_websocket_fallback_legacy_enabled`.
+  - `added`: channels entering allowed set this cycle.
+  - `removed`: channels leaving allowed set this cycle.
+
 ### EventSub callback URL reliability requirements
 - Twitch EventSub webhook registration must use a **publicly reachable HTTPS callback URL**.
 - Callback validation enforces:


### PR DESCRIPTION
### Motivation
- Provide operators a single structured startup health event summarizing ingress mode, guard health/reasons, conduit/shard coverage, connected channel counts, and worker liveness to simplify incident triage. 
- Surface compact, per-sync telemetry from the bot runtime about channel lifecycle churn and websocket rollback posture to aid runtime debugging.

### Description
- Add startup helpers `_startup_connected_channel_summary` and `_startup_conduit_shard_health_summary` and a new `emit_startup_ingress_health_log` to build and emit a single structured `INGRESS_STARTUP_HEALTH` info log after the ingress guard check and worker startup. 
- Change `run_ingress_guard_startup_check` to return a structured result (`ok`/`skipped`/`error`) so the startup log can include guard startup status and reasons. 
- Add a compact `CHANNEL_SYNC_SUMMARY` log line in `bot/bot_app.py::SongBot.sync_channels` immediately after allowed-channel computation that reports channels considered, channels currently listened to, the rollback websocket flag, and added/removed channel lists for the sync cycle. 
- Update operator documentation in `docs/README.md` and `docs/backend_api.md` to describe both `INGRESS_STARTUP_HEALTH` and `CHANNEL_SYNC_SUMMARY` events and the fields they emit; new functions include docstrings describing purpose, dependencies, code-customers, and used variables/origin. 

### Testing
- Ran Python byte-compile on modified modules with `python -m py_compile backend_app.py bot/bot_app.py` which completed successfully. 
- No other automated unit tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d222d3b8548328b04e88e9e67c74a5)