### PR TITLE
Prune websocket rollback hooks and route random_request through webhook parity

### DIFF
--- a/backend_app.py
+++ b/backend_app.py
@@ -2941,6 +2941,74 @@ def _eventsub_execute_playlist_request_command(
     )
 
 
+def _eventsub_execute_random_request_command(
+    db: Session,
+    channel: ActiveChannel,
+    *,
+    chatter_user_id: str,
+    chatter_login: str,
+    args: str,
+    actor: dict[str, bool],
+) -> dict[str, Any]:
+    """Execute canonical ``random_request`` command via webhook parity path.
+
+    Description: routes random playlist picks through the canonical
+    ``random_playlist_request`` backend API helper used by authenticated HTTP
+    clients, preserving queue-limit and priority award behavior.
+    Dependencies: ``random_playlist_request`` endpoint helper and
+    ``RandomPlaylistRequestIn`` payload schema.
+    Code customers: ``_dispatch_eventsub_chat_command``.
+    Used variables/origin: chatter identity/flags from EventSub payload and
+    optional keyword text from parsed command args.
+    """
+
+    payload = RandomPlaylistRequestIn(
+        keyword=(args or "").strip() or None,
+        twitch_id=chatter_user_id,
+        username=chatter_login,
+        is_subscriber=bool(actor.get("is_subscriber")),
+    )
+    try:
+        response = random_playlist_request(channel.channel_name, payload, db=db)
+    except HTTPException as exc:
+        detail = str(exc.detail)
+        reason = "not_found" if exc.status_code == 404 else "invalid_args"
+        template_key = "random_not_found" if reason == "not_found" else "failed"
+        template_vars: dict[str, object] = {"error": detail}
+        if reason == "not_found":
+            template_vars = {"keyword": payload.keyword or "default"}
+        return _eventsub_outcome(
+            "rejected",
+            command="random_request",
+            reason_code=reason,
+            detail=detail,
+            metadata={
+                "response": _eventsub_response_contract(
+                    "error",
+                    template_key=template_key,
+                    template_vars=template_vars,
+                    visibility="normal",
+                )
+            },
+        )
+    return _eventsub_outcome(
+        "executed",
+        command="random_request",
+        reason_code="ok",
+        metadata={
+            "mutated": True,
+            "request_id": response.request_id,
+            "playlist_item_id": response.playlist_item_id,
+            "response": _eventsub_response_contract(
+                "success",
+                template_key="random_request_added",
+                template_vars={"artist": response.song.artist, "title": response.song.title},
+                visibility="normal",
+            ),
+        },
+    )
+
+
 def _eventsub_actor_context(event_payload: dict[str, Any], channel: ActiveChannel) -> dict[str, bool]:
     """Normalize EventSub chatter permission flags for command rule parity.
 
@@ -3278,10 +3346,15 @@ def _dispatch_eventsub_chat_command(
             chatter_login=chatter_login,
         ),
         "archive": lambda: _eventsub_outcome("rejected", command="archive", reason_code="permission_denied", detail="archive requires moderator authorization"),
-        "random_request": lambda: _eventsub_outcome("rejected", command="random_request", reason_code="legacy_websocket_only", detail="cleanup_candidate: migrate websocket-only random request routine"),
+        "random_request": lambda: _eventsub_execute_random_request_command(
+            db,
+            channel,
+            chatter_user_id=chatter_user_id,
+            chatter_login=chatter_login,
+            args=args,
+            actor=actor,
+        ),
     }
-    # TODO(removal): fold per-command webhook executors into a unified shared
-    # command context once DB/session adapters are parity-tested.
     handler = resolve_command_handler(str(canonical or ""), dispatch_map)
     if not handler:
         return _eventsub_outcome("rejected", command=canonical, reason_code="parse_unknown_alias")

--- a/bot/bot_app.py
+++ b/bot/bot_app.py
@@ -8,7 +8,6 @@ from datetime import datetime, timedelta
 from command_resolution import default_commands_map, load_commands_map
 
 import aiohttp
-from twitchio import eventsub
 from twitchio.ext import commands
 from twitchio.payloads import TokenRefreshedPayload
 if __package__:
@@ -163,18 +162,6 @@ class Backend:
 
     async def get_channels(self):
         return await self._req('GET', "/channels")
-
-    async def get_system_config(self) -> dict:
-        """Return backend system config used for ingress runtime gating.
-
-        Dependencies: calls the backend ``/system/config`` endpoint.
-        Code customers: ``SongBot.sync_channels`` websocket fallback decisions.
-        Used variables/origin: uses admin-authenticated API response fields such
-        as ``chat_ingress_mode`` and ``chat_websocket_fallback_legacy_enabled``.
-        """
-
-        payload = await self._req('GET', "/system/config")
-        return payload if isinstance(payload, dict) else {}
 
     async def add_channel(self, channel_name: str, channel_id: str, join_active: int = 1):
         return await self._req('POST', "/channels", {
@@ -563,10 +550,8 @@ class SongBot(commands.Bot):
         self._user_token = token
         self._refresh_token = refresh_token
         self._scopes = list(scopes or [])
-        self._subscription_ids: Dict[str, str] = {}
         self._update_locks: Dict[str, asyncio.Lock] = {}
         self._refresher_task: Optional[asyncio.Task] = None
-        self._websocket_fallback_enabled = False
 
     @property
     def configured_login(self) -> Optional[str]:
@@ -679,33 +664,21 @@ class SongBot(commands.Bot):
         return self.channel_map.get(self._channel_login(login))
 
     async def sync_channels(self) -> None:
-        """Synchronize channel listeners and optional websocket rollback hooks.
+        """Synchronize channel listeners and backend queue stream tasks.
 
         Description: refresh channel authorization state, keep backend queue
-        listeners aligned, and only enable websocket chat subscriptions when an
-        explicit rollback flag allows legacy ingress.
-        Dependencies: backend ``/system/config`` and ``/channels`` APIs plus
-        SongBot listener/subscription lifecycle helpers.
+        listeners aligned, and start/stop per-channel queue listeners.
+        Dependencies: backend ``/channels`` API plus SongBot listener lifecycle
+        helpers.
         Code customers: ``event_ready``, periodic ``channel_refresher``, and
         runtime enable/disable transitions.
-        Used variables/origin: ``chat_ingress_mode`` and
-        ``chat_websocket_fallback_legacy_enabled`` from system config drive
-        websocket fallback gating; channel rows from ``backend.get_channels``.
+        Used variables/origin: channel rows from ``backend.get_channels``.
         """
 
         if not self.enabled:
             await self._disable_all_channels()
             return
         async with self._sync_lock:
-            config = await backend.get_system_config()
-            ingress_mode = str(config.get("chat_ingress_mode") or "").strip().lower()
-            rollback_enabled = bool(config.get("chat_websocket_fallback_legacy_enabled"))
-            self._websocket_fallback_enabled = rollback_enabled
-            if ingress_mode == "webhook_conduit":
-                logger.info(
-                    "Canonical chat ingress is webhook_conduit; websocket EventSub chat subscriptions are rollback-only (enabled=%s)",
-                    rollback_enabled,
-                )
             rows = await backend.get_channels()
             allowed: Dict[str, Dict] = {}
             for row in rows:
@@ -719,10 +692,9 @@ class SongBot(commands.Bot):
             added_preview = sorted(allowed_keys - current_keys)
             removed_preview = sorted(current_keys - allowed_keys)
             logger.info(
-                "CHANNEL_SYNC_SUMMARY considered=%s listened=%s rollback_websocket=%s added=%s removed=%s",
+                "CHANNEL_SYNC_SUMMARY considered=%s listened=%s added=%s removed=%s",
                 len(rows),
                 len(current_keys),
-                rollback_enabled,
                 added_preview,
                 removed_preview,
             )
@@ -735,7 +707,6 @@ class SongBot(commands.Bot):
                 task = self.listeners.pop(key, None)
                 if task:
                     task.cancel()
-                await self._unsubscribe_channel(broadcaster_id)
                 if key in self.joined:
                     await self._announce_left(key)
                     self.joined.discard(key)
@@ -756,25 +727,6 @@ class SongBot(commands.Bot):
             for key in new_keys:
                 row = allowed[key]
                 channel_name = row['channel_name']
-                broadcaster_id = str(row.get('channel_id') or '')
-                try:
-                    await self._subscribe_for_channel(broadcaster_id)
-                except Exception as exc:
-                    await backend.set_bot_status(channel_name, False, str(exc))
-                    await push_console_event(
-                        'error',
-                        f'Failed to subscribe channel {channel_name}: {exc}',
-                        event='join_error',
-                        metadata={'channel': channel_name, 'error': str(exc)},
-                    )
-                    await self._announce_debug_failure(
-                        key,
-                        action='subscribe_channel',
-                        error=exc,
-                        metadata={'channel': channel_name},
-                    )
-                    self.channel_map.pop(key, None)
-                    continue
                 await backend.set_bot_status(channel_name, True)
                 await push_console_event(
                     'info',
@@ -804,128 +756,6 @@ class SongBot(commands.Bot):
                         'queue': initial_queue,
                         'last_event': datetime.utcnow().isoformat(),
                     }
-                await self._subscribe_for_channel(str(row.get('channel_id') or ''))
-
-    def _extract_subscription_id(self, response: object) -> Optional[str]:
-        """[deprecated/unused] Extract websocket subscription IDs from TwitchIO responses.
-
-        Description: retained temporary parser for old websocket recovery flows.
-        Dependencies: TwitchIO response payload shape.
-        Code customers: none in authoritative webhook-conduit mode.
-        Used variables/origin: ``response`` object from historical
-        ``subscribe_websocket`` calls.
-        TODO(removal): delete when websocket rollback harness is retired.
-        """
-
-        if not response:
-            return None
-        if isinstance(response, dict):
-            data = response.get('data')
-            if isinstance(data, list) and data:
-                first = data[0]
-                if isinstance(first, dict):
-                    sub_id = first.get('id')
-                    if sub_id:
-                        return str(sub_id)
-        subscription = getattr(response, 'subscription', None)
-        sub_id = getattr(subscription, 'id', None)
-        if sub_id:
-            return str(sub_id)
-        sub_id = getattr(response, 'id', None)
-        if sub_id:
-            return str(sub_id)
-        return None
-
-    async def _find_existing_subscription_id(self, broadcaster_id: str) -> Optional[str]:
-        """[deprecated/unused] Lookup existing websocket chat subscription ID.
-
-        Description: legacy helper formerly used by subscription recovery loops.
-        Dependencies: TwitchIO websocket/EventSub subscription fetch APIs.
-        Code customers: none after removing websocket reuse/recovery loops.
-        Used variables/origin: ``broadcaster_id`` from backend channel rows and
-        ``self.bot_user_id`` from bot credentials.
-        TODO(removal): remove with websocket fallback end-of-life.
-        """
-
-        for existing_id, details in self.websocket_subscriptions().items():
-            condition = getattr(details, 'condition', {}) or {}
-            sub_type = getattr(details, 'type', None)
-            if (
-                sub_type == eventsub.SubscriptionType.ChannelChatMessage
-                and condition.get('broadcaster_user_id') == broadcaster_id
-                and condition.get('user_id') == self.bot_user_id
-            ):
-                return str(existing_id)
-        try:
-            events = await self.fetch_eventsub_subscriptions(
-                token_for=self.bot_user_id,
-                type=eventsub.SubscriptionType.ChannelChatMessage.value,
-            )
-        except Exception:
-            return None
-        if not events:
-            return None
-        async for subscription in events.subscriptions:
-            condition = getattr(subscription, 'condition', {}) or {}
-            if (
-                condition.get('broadcaster_user_id') == broadcaster_id
-                and condition.get('user_id') == self.bot_user_id
-            ):
-                sub_id = getattr(subscription, 'id', None)
-                if sub_id:
-                    return str(sub_id)
-        return None
-
-    async def _subscribe_for_channel(self, broadcaster_id: str) -> None:
-        """Create websocket chat subscription only for explicit rollback mode.
-
-        Description: authoritative ``webhook_conduit`` mode never depends on
-        websocket ingress; this hook exists solely for emergency rollback.
-        Dependencies: TwitchIO ``subscribe_websocket`` API and
-        ``self._websocket_fallback_enabled`` from ``sync_channels`` policy.
-        Code customers: ``sync_channels`` channel lifecycle during rollback.
-        Used variables/origin: ``broadcaster_id`` from backend channel config
-        and ``self.bot_user_id`` from loaded bot credentials.
-        """
-
-        if not broadcaster_id:
-            raise RuntimeError('Channel missing broadcaster id')
-        if not self._websocket_fallback_enabled:
-            return
-        if broadcaster_id in self._subscription_ids:
-            return
-        payload = eventsub.ChatMessageSubscription(
-            broadcaster_user_id=broadcaster_id,
-            user_id=self.bot_user_id,
-        )
-        response = await self.subscribe_websocket(payload=payload, as_bot=True)
-        sub_id = self._extract_subscription_id(response)
-        if not sub_id:
-            raise RuntimeError('Subscription id unavailable')
-        self._subscription_ids[broadcaster_id] = sub_id
-        logger.info(
-            "Created new websocket subscription %s for broadcaster %s",
-            sub_id,
-            broadcaster_id,
-        )
-
-    async def _unsubscribe_channel(self, broadcaster_id: str) -> None:
-        """Delete a rollback websocket subscription for the given broadcaster.
-
-        Description: best-effort cleanup for legacy websocket fallback only.
-        Dependencies: TwitchIO ``delete_websocket_subscription`` API.
-        Code customers: channel removal and bot shutdown flows.
-        Used variables/origin: ``broadcaster_id`` from channel config and
-        ``self._subscription_ids`` populated by ``_subscribe_for_channel``.
-        """
-
-        sub_id = self._subscription_ids.pop(broadcaster_id, None)
-        if not sub_id:
-            return
-        try:
-            await self.delete_websocket_subscription(sub_id, force=True)
-        except Exception:
-            pass
 
     async def _disable_all_channels(self) -> None:
         listener_tasks = list(self.listeners.values())
@@ -938,7 +768,6 @@ class SongBot(commands.Bot):
             await asyncio.gather(*awaitables, return_exceptions=True)
         self.listeners.clear()
         for key, row in list(self.channel_map.items()):
-            await self._unsubscribe_channel(str(row.get('channel_id') or ''))
             if key in self.joined:
                 await self._announce_left(key)
                 self.joined.discard(key)
@@ -1177,27 +1006,15 @@ class SongBot(commands.Bot):
         reply_to: Optional[str] = None,
         fallback_partial: Optional[object] = None,
     ) -> None:
-        """Send a websocket-runtime chat message using bot-user token contract.
+        """Send a chat message using the bot-user token contract.
 
-        Description: rollback-only websocket egress helper; authoritative
-        webhook/conduit ingress should use backend Send Chat transport instead.
-        Dependencies: TwitchIO ``PartialUser.send_message`` and runtime
-        ``self._websocket_fallback_enabled`` policy flag.
-        Code customers: websocket ingress command handlers and debug/catalog
-        responses emitted during rollback operation.
+        Description: emits Twitch chat responses for bot runtime handlers.
+        Dependencies: TwitchIO ``PartialUser.send_message`` bot identity token.
+        Code customers: command handlers and debug/catalog responses.
         Used variables/origin: ``channel_login`` and ``message`` come from
         command dispatch flows; ``self.bot_user_id`` is persisted bot identity
         used for both ``sender`` and ``token_for`` in TwitchIO sends.
         """
-
-        if not self._websocket_fallback_enabled:
-            await push_console_event(
-                'warning',
-                f'Skipped websocket send for {channel_login}: fallback mode disabled',
-                event='message_skipped',
-                metadata={**(metadata or {}), 'channel': channel_login, 'reason_code': 'websocket_fallback_disabled'},
-            )
-            return
         info = self._channel_info(channel_login)
         partial = None
         channel_label = channel_login

--- a/docs/websocket_pruning_ledger.md
+++ b/docs/websocket_pruning_ledger.md
@@ -12,6 +12,14 @@ Use this ledger whenever websocket-only code/tests are removed.
 
 ## Entries
 
+### 2026-04-05 — Remove websocket rollback subscription gates and webhook random-request transition
+- **removed modules/functions**: `bot/bot_app.py` `SongBot._extract_subscription_id`, `SongBot._find_existing_subscription_id`, and rollback-only websocket subscription management paths (`_subscribe_for_channel`, `_unsubscribe_channel`, `_websocket_fallback_enabled`, `_subscription_ids`); `backend_app.py` legacy webhook rejection branch for canonical `random_request` plus transitional TODO(removal) command-unification note in `_dispatch_eventsub_chat_command`.
+- **replacement path**: bot channel sync now relies solely on backend queue-stream listeners (`SongBot.sync_channels` + `SongBot.listen_backend`), while webhook chat commands execute `random_request` through `backend_app._eventsub_execute_random_request_command` -> `random_playlist_request`.
+- **deprecation decision date**: 2026-04-05
+- **rollback implications**: behavioral removal; restoring websocket rollback now requires reintroducing EventSub websocket subscription lifecycle code in `SongBot` and re-adding the webhook `legacy_websocket_only` random-request rejection branch.
+- **classification**: behavioral removal
+- **archived rationale link**: [Archived websocket deprecation rationale](./archive/websocket_deprecation_rationale.md)
+
 ### 2026-04-04 — Verify mute-level silence on backend runtime announcements
 - **removed modules/functions**: none (verification + automated coverage update)
 - **replacement path**: `POST /bot/runtime/announcements` -> `backend_app._send_catalog_announcement` -> `_send_eventsub_chat_reply` mute suppression gate.

--- a/tests/test_bot_service.py
+++ b/tests/test_bot_service.py
@@ -208,8 +208,6 @@ class BotServiceTests(unittest.IsolatedAsyncioTestCase):
         song_bot._announce_joined = AsyncMock()
         song_bot._announce_left = AsyncMock()
         song_bot.listen_backend = AsyncMock(return_value=None)
-        song_bot._subscribe_for_channel = AsyncMock()
-        song_bot._unsubscribe_channel = AsyncMock()
         song_bot._send_message = AsyncMock()
 
         channel_rows = [
@@ -239,15 +237,13 @@ class BotServiceTests(unittest.IsolatedAsyncioTestCase):
         self.assertIn("bar", song_bot.joined)
         self.backend.set_bot_status.assert_any_await("Foo", True)
         self.backend.set_bot_status.assert_any_await("Bar", True)
-        song_bot._subscribe_for_channel.assert_any_await("1")
-        song_bot._subscribe_for_channel.assert_any_await("2")
         song_bot.listen_backend.assert_any_call("Foo")
         song_bot.listen_backend.assert_any_call("Bar")
         song_bot._announce_joined.assert_any_call("foo")
         song_bot._announce_joined.assert_any_call("bar")
         self.assertEqual(len(create_tasks), 4)
 
-    async def test_sync_channels_logs_subscription_errors(self) -> None:
+    async def test_sync_channels_emits_join_events_without_subscription_hooks(self) -> None:
         song_bot = bot_app.SongBot.__new__(bot_app.SongBot)
         song_bot.channel_map = {}
         song_bot.state = {}
@@ -255,8 +251,6 @@ class BotServiceTests(unittest.IsolatedAsyncioTestCase):
         song_bot.joined = set()
         song_bot._sync_lock = asyncio.Lock()
         song_bot.enabled = True
-        song_bot._subscribe_for_channel = AsyncMock(side_effect=RuntimeError("boom"))
-        song_bot._unsubscribe_channel = AsyncMock()
         song_bot.listen_backend = AsyncMock()
         song_bot._announce_joined = AsyncMock()
         song_bot._announce_left = AsyncMock()
@@ -277,14 +271,14 @@ class BotServiceTests(unittest.IsolatedAsyncioTestCase):
             await song_bot.sync_channels()
 
         self.assertGreaterEqual(push_event.await_count, 1)
-        args, kwargs = push_event.await_args_list[0]
-        self.assertEqual(args[0], "error")
-        self.assertIn("Failed to subscribe channel Foo", args[1])
-        self.assertEqual(kwargs.get("metadata"), {"channel": "Foo", "error": "boom"})
-        self.assertEqual(kwargs.get("event"), "join_error")
-        self.assertNotIn("foo", song_bot.joined)
-        self.backend.set_bot_status.assert_awaited_once_with("Foo", False, "boom")
-        song_bot._announce_joined.assert_not_called()
+        join_event = push_event.await_args_list[0]
+        self.assertEqual(join_event.args[0], "info")
+        self.assertIn("Subscribed channel Foo", join_event.args[1])
+        self.assertEqual(join_event.kwargs.get("metadata"), {"channel": "Foo"})
+        self.assertEqual(join_event.kwargs.get("event"), "join")
+        self.assertIn("foo", song_bot.joined)
+        self.backend.set_bot_status.assert_awaited_once_with("Foo", True)
+        song_bot._announce_joined.assert_called_once_with("foo")
 
     async def test_songbot_does_not_assign_readonly_nick(self) -> None:
         commands_map = {k: ([v] if not isinstance(v, list) else v) for k, v in bot_app.DEFAULT_COMMANDS.items()}


### PR DESCRIPTION
### Motivation
- Remove deprecated websocket rollback-only code paths that are no longer needed now that webhook/conduit is authoritative and simplify channel sync and message flows. 
- Ensure webhook (EventSub) parity for the `random_request` command so webhook-driven chat commands use the same backend API path as HTTP clients. 
- Record the pruning in the websocket pruning ledger for operator traceability.

### Description
- Removed legacy websocket rollback helpers and state from `bot/bot_app.py`, including `_extract_subscription_id`, `_find_existing_subscription_id`, subscription lifecycle helpers and the `_websocket_fallback_enabled`/`_subscription_ids` usage, and eliminated the related EventSub import usage. 
- Simplified `SongBot.sync_channels` and shutdown logic to rely solely on backend channel rows and backend queue-stream listeners (`listen_backend`) instead of EventSub websocket rollback subscription flows. 
- Cleared the rollback gate from `_send_message` and updated its description to reflect the unified chat-send behavior. 
- Added `_eventsub_execute_random_request_command` in `backend_app.py` and wired `_dispatch_eventsub_chat_command` to execute `random_request` via the canonical `random_playlist_request` endpoint instead of rejecting it as websocket-only. 
- Updated `docs/websocket_pruning_ledger.md` with a new dated entry (`2026-04-05`) documenting removed functions/modules, replacement paths, rollback implications, and archived rationale link. 
- Updated unit test expectations in `tests/test_bot_service.py` to reflect the removal of websocket subscription hooks and to assert join-event behavior under the simplified sync model.

### Testing
- Compiled modified modules with `python -m py_compile bot/bot_app.py backend_app.py tests/test_bot_service.py` and the compile step succeeded. 
- Ran `pytest -q tests/test_bot_service.py` and all tests in that file passed (`20 passed`). 
- Attempted `pytest -q tests/test_channel_events.py -k random_request` to validate the webhook `random_request` path but test collection failed in this environment with `ModuleNotFoundError: No module named 'backend_app'` (environment import path issue), so full integration tests could not be run here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d224e21fa48328950bbee335d30396)