### PR TITLE
Enforce webhook-only ingress and healthy-shard conduit assignment

### DIFF
--- a/backend_app.py
+++ b/backend_app.py
@@ -964,43 +964,59 @@ def get_bot_app_scopes() -> list[str]:
 
 
 def get_chat_ingress_mode() -> str:
-    """Return the configured chat ingress mode with a safe fallback.
+    """Return the enforced authoritative ingress mode.
 
-    Dependencies: Reads persisted values through ``get_setting``.
-    Code customers: ``/system/config`` payload consumers and chat ingress
-    workers deciding websocket vs webhook/conduit intake.
-    Used variables/origin: Pulls the ``chat_ingress_mode`` app setting and
-    normalizes unsupported values back to ``websocket``.
+    Dependencies: Optionally reads legacy persisted setting for deprecation
+    logging only.
+    Code customers: ``/system/config`` payload consumers and webhook command
+    handlers that require deterministic authoritative mode semantics.
+    Used variables/origin: Legacy ``chat_ingress_mode`` setting is inspected to
+    surface stale non-authoritative values during migration cleanup.
     """
 
-    value = (get_setting("chat_ingress_mode", "websocket") or "websocket").strip().lower()
-    if value not in {"websocket", "webhook_conduit"}:
-        return "websocket"
-    return value
+    legacy_mode = (get_setting("chat_ingress_mode", "webhook_conduit") or "webhook_conduit").strip().lower()
+    if legacy_mode != "webhook_conduit":
+        logger.warning(
+            "Ignoring deprecated non-authoritative chat_ingress_mode setting value=%s; forcing webhook_conduit",
+            legacy_mode,
+        )
+    return "webhook_conduit"
 
 
 def get_chat_ingress_shadow_mode() -> bool:
-    """Return whether dual-run ingress shadow mode is enabled.
+    """Return the enforced shadow-mode state for webhook-only ingress.
 
-    Dependencies: Uses ``get_setting`` plus ``_env_flag`` for boolean parsing.
-    Code customers: ``/system/config`` responses and chat validation workers.
-    Used variables/origin: Reads the ``chat_ingress_shadow_mode`` app setting
-    and interprets string truthy values such as ``1``/``true``/``yes``.
+    Dependencies: Optionally reads legacy persisted setting for deprecation
+    logging only.
+    Code customers: ``/system/config`` and chat-notification execution paths.
+    Used variables/origin: Legacy ``chat_ingress_shadow_mode`` setting is read
+    only to warn when stale toggles still exist.
     """
 
-    return _env_flag(get_setting("chat_ingress_shadow_mode", "0"))
+    legacy_shadow = _env_flag(get_setting("chat_ingress_shadow_mode", "0"))
+    if legacy_shadow:
+        logger.warning(
+            "Ignoring deprecated chat_ingress_shadow_mode=true setting; shadow mode is removed in webhook-only operation",
+        )
+    return False
 
 
 def get_chat_websocket_fallback_legacy_enabled() -> bool:
-    """Return whether legacy websocket ingress fallback is explicitly enabled.
+    """Return the enforced websocket-fallback state after deprecation.
 
-    Dependencies: Uses ``get_setting`` and ``_env_flag``.
-    Code customers: Bot runtime subscription gating and ``/system/config``.
-    Used variables/origin: Reads ``chat_websocket_fallback_legacy_enabled`` from
-    app settings to keep rollback explicit and operator-controlled.
+    Dependencies: Optionally reads legacy persisted setting for deprecation
+    warning visibility.
+    Code customers: ``/system/config`` diagnostics and ingress-guard payload.
+    Used variables/origin: Legacy setting is inspected only to flag stale
+    rollout-era configuration that is now ignored.
     """
 
-    return _env_flag(get_setting("chat_websocket_fallback_legacy_enabled", "0"))
+    legacy_enabled = _env_flag(get_setting("chat_websocket_fallback_legacy_enabled", "0"))
+    if legacy_enabled:
+        logger.warning(
+            "Ignoring deprecated chat_websocket_fallback_legacy_enabled=true setting; websocket fallback is retired",
+        )
+    return False
 
 
 def get_twitch_send_chat_auth_mode() -> Literal["app_token", "bot_user_token"]:
@@ -1214,7 +1230,7 @@ def _evaluate_ingress_guard(db: Session, now: datetime, *, apply_fallback: bool)
     if not invariants.get("token_refresh_healthy", True):
         degraded_reasons.append("token_refresh_unhealthy")
     degraded = bool(degraded_reasons)
-    auto_fallback_enabled = _env_flag(get_setting("chat_ingress_guard_auto_fallback_enabled", "0"))
+    auto_fallback_enabled = False
     fallback_applied = False
     if degraded:
         _record_ingress_metric("guard_degraded", timestamp=now)
@@ -1224,10 +1240,8 @@ def _evaluate_ingress_guard(db: Session, now: datetime, *, apply_fallback: bool)
             healthy_shards,
             callback_errors,
         )
-        if apply_fallback and auto_fallback_enabled and get_chat_ingress_mode() == "webhook_conduit":
-            set_settings(db, {"chat_ingress_mode": "websocket"})
-            fallback_applied = True
-            logger.error("INGRESS_GUARD_AUTO_FALLBACK applied chat_ingress_mode=websocket")
+        if apply_fallback:
+            logger.info("INGRESS_GUARD_AUTO_FALLBACK_DISABLED webhook_only_mode=true")
     return {
         "degraded": degraded,
         "reasons": degraded_reasons,
@@ -1613,7 +1627,7 @@ def run_ingress_guard_startup_check() -> dict[str, Any]:
     try:
         if get_chat_ingress_mode() != "webhook_conduit":
             return {"status": "skipped", "reason": "ingress_mode_not_webhook_conduit"}
-        guard = _evaluate_ingress_guard(db, datetime.utcnow(), apply_fallback=True)
+        guard = _evaluate_ingress_guard(db, datetime.utcnow(), apply_fallback=False)
         return {"status": "ok", "guard": guard}
     except Exception:
         logger.exception("Ingress guard startup check failed")
@@ -1874,6 +1888,16 @@ def start_ingress_guard_repair_watcher() -> None:
 
 
 def _system_config_payload() -> Dict[str, Any]:
+    """Return runtime system configuration with webhook-only ingress semantics.
+
+    Dependencies: pulls persisted setup/OAuth values through helper getters and
+    normalizes deprecated ingress toggles to fixed authoritative values.
+    Code customers: ``GET /system/config`` and response payload reuse in
+    ``PUT /system/config``.
+    Used variables/origin: Reads persisted settings for credentials/URLs/scopes;
+    ingress-mode fields are emitted as enforced constants.
+    """
+
     return {
         "setup_complete": is_setup_complete(),
         "twitch_client_id": get_twitch_client_id(),
@@ -1887,7 +1911,7 @@ def _system_config_payload() -> Dict[str, Any]:
         "chat_ingress_mode": get_chat_ingress_mode(),
         "chat_ingress_shadow_mode": get_chat_ingress_shadow_mode(),
         "chat_websocket_fallback_legacy_enabled": get_chat_websocket_fallback_legacy_enabled(),
-        "chat_ingress_guard_auto_fallback_enabled": _env_flag(get_setting("chat_ingress_guard_auto_fallback_enabled", "0")),
+        "chat_ingress_guard_auto_fallback_enabled": False,
     }
 
 
@@ -3424,7 +3448,7 @@ def _process_eventsub_chat_notification(
         else:
             outcome = _eventsub_outcome("rejected", command=None, reason_code="parse_non_command")
             webhook_result = "ignored_non_command"
-    elif webhook_authoritative:
+    else:
         try:
             outcome = _dispatch_eventsub_chat_command(db, channel, parsed=parsed, event_payload=event_payload)
             reply_contract = ((outcome.get("metadata") or {}).get("response") if isinstance(outcome.get("metadata"), dict) else None)
@@ -3481,14 +3505,6 @@ def _process_eventsub_chat_notification(
                 "EventSub authoritative chat command execution failed",
                 extra={"eventsub_message_id": message_id, "channel": channel.channel_name, "parsed": parsed},
             )
-    else:
-        outcome = _eventsub_outcome(
-            "rejected",
-            command=parsed.get("canonical"),
-            reason_code="shadow_mode_observe_only",
-            detail="authoritative execution disabled",
-        )
-        webhook_result = "shadow_observe_only"
 
     canonical_command = str(
         outcome.get("command")
@@ -4235,7 +4251,14 @@ def reconcile_eventsub_conduit_subscriptions(request: Optional[FastAPIRequest], 
     )
     result["errors"].extend(shard_errors)
     result["shards"] = [{"id": shard_id, "status": status} for shard_id, status in sorted(assignment.items())]
-    shard_ids = sorted(assignment.keys()) or ["0"]
+    enabled_shard_ids = [
+        shard_id
+        for shard_id, status in sorted(assignment.items())
+        if str(status or "").strip().lower() == "enabled"
+    ]
+    if not enabled_shard_ids:
+        result["warnings"].append("no_enabled_shards_available_for_assignment")
+    shard_ids = enabled_shard_ids or (sorted(assignment.keys()) or ["0"])
 
     for index, channel in enumerate(connected_channels):
         channel_result: dict[str, Any] = {
@@ -5040,7 +5063,7 @@ class SystemConfigOut(BaseModel):
     public_backend_origin: Optional[str]
     twitch_scopes: List[str]
     bot_app_scopes: List[str]
-    chat_ingress_mode: Literal["websocket", "webhook_conduit"]
+    chat_ingress_mode: Literal["webhook_conduit"]
     chat_ingress_shadow_mode: bool
     chat_websocket_fallback_legacy_enabled: bool
     chat_ingress_guard_auto_fallback_enabled: bool
@@ -5055,7 +5078,7 @@ class SystemConfigUpdate(BaseModel):
     public_backend_origin: Optional[str] = None
     twitch_scopes: Optional[List[str]] = None
     bot_app_scopes: Optional[List[str]] = None
-    chat_ingress_mode: Optional[Literal["websocket", "webhook_conduit"]] = None
+    chat_ingress_mode: Optional[Literal["webhook_conduit"]] = None
     chat_ingress_shadow_mode: Optional[bool] = None
     chat_websocket_fallback_legacy_enabled: Optional[bool] = None
     chat_ingress_guard_auto_fallback_enabled: Optional[bool] = None
@@ -6906,6 +6929,11 @@ def _send_catalog_announcement(
         visibility = "normal"
     template_key = str(catalog_row.get("template_key") or normalized_message_id)
     if not bool(getattr(channel, "join_active", 1)):
+        logger.info(
+            "Runtime announcement decision channel=%s message_id=%s result=suppressed reason_code=suppressed_disconnected",
+            channel.channel_name,
+            normalized_message_id,
+        )
         return BotRuntimeAnnouncementOut(
             success=True,
             sent=False,
@@ -6929,6 +6957,13 @@ def _send_catalog_announcement(
         reply,
         reply_parent_message_id=None,
         return_reason=True,
+    )
+    logger.info(
+        "Runtime announcement decision channel=%s message_id=%s result=%s reason_code=%s",
+        channel.channel_name,
+        normalized_message_id,
+        "sent" if sent else "suppressed_or_failed",
+        reason_code or "unknown",
     )
     return BotRuntimeAnnouncementOut(
         success=True,
@@ -8093,6 +8128,15 @@ def update_system_config(
     payload: SystemConfigUpdate,
     x_admin_token: Optional[str] = Header(None),
 ):
+    """Update mutable system configuration with webhook-only ingress enforcement.
+
+    Dependencies: validates admin token, normalizes payload fields, and writes
+    persisted settings via ``set_settings``.
+    Code customers: Queue Manager/admin setup and operations tooling.
+    Used variables/origin: ``payload`` values come from validated request JSON;
+    deprecated ingress toggles are accepted for compatibility but ignored.
+    """
+
     if x_admin_token != ADMIN_TOKEN:
         raise HTTPException(status_code=401, detail="invalid admin token")
 
@@ -8122,14 +8166,17 @@ def update_system_config(
     if payload.bot_app_scopes is not None:
         normalized_bot_scopes = _normalize_scope_list(payload.bot_app_scopes)
         updates["bot_app_scopes"] = " ".join(normalized_bot_scopes) if normalized_bot_scopes else None
-    if payload.chat_ingress_mode is not None:
-        updates["chat_ingress_mode"] = payload.chat_ingress_mode
-    if payload.chat_ingress_shadow_mode is not None:
-        updates["chat_ingress_shadow_mode"] = "1" if payload.chat_ingress_shadow_mode else "0"
-    if payload.chat_websocket_fallback_legacy_enabled is not None:
-        updates["chat_websocket_fallback_legacy_enabled"] = "1" if payload.chat_websocket_fallback_legacy_enabled else "0"
-    if payload.chat_ingress_guard_auto_fallback_enabled is not None:
-        updates["chat_ingress_guard_auto_fallback_enabled"] = "1" if payload.chat_ingress_guard_auto_fallback_enabled else "0"
+    # Enforce webhook-only ingress and ignore deprecated transition toggles.
+    updates["chat_ingress_mode"] = "webhook_conduit"
+    updates["chat_ingress_shadow_mode"] = "0"
+    updates["chat_websocket_fallback_legacy_enabled"] = "0"
+    updates["chat_ingress_guard_auto_fallback_enabled"] = "0"
+    if payload.chat_ingress_shadow_mode is not None and payload.chat_ingress_shadow_mode:
+        logger.warning("Ignoring deprecated system config update chat_ingress_shadow_mode=true")
+    if payload.chat_websocket_fallback_legacy_enabled is not None and payload.chat_websocket_fallback_legacy_enabled:
+        logger.warning("Ignoring deprecated system config update chat_websocket_fallback_legacy_enabled=true")
+    if payload.chat_ingress_guard_auto_fallback_enabled is not None and payload.chat_ingress_guard_auto_fallback_enabled:
+        logger.warning("Ignoring deprecated system config update chat_ingress_guard_auto_fallback_enabled=true")
 
     current = settings_store.snapshot()
     merged: Dict[str, Optional[str]] = dict(current)

--- a/docs/backend_api.md
+++ b/docs/backend_api.md
@@ -5,8 +5,8 @@ This document summarizes the REST endpoints exposed by `backend_app.py`.
 ## Canonical chat architecture
 - **Ingress**: EventSub webhook + conduit transport on
   `/twitch/eventsub/callback`.
-- **Execution**: shared chat command core used by webhook and websocket parsing
-  paths for consistent command semantics.
+- **Execution**: shared chat command core used by webhook parsing for
+  authoritative command semantics.
 - **Outbound**: Twitch Send Chat Message API (`POST /helix/chat/messages`) for
   bot replies.
 
@@ -15,28 +15,25 @@ This document summarizes the REST endpoints exposed by `backend_app.py`.
 | Method | Path | Description |
 |--------|------|-------------|
 | GET | `/system/health` | Health check that verifies database connectivity plus global EventSub webhook/conduit coverage, shard state, and ingress guard telemetry. |
-| GET | `/system/config` | Read deployment configuration defaults and ingress mode toggles. |
-| PUT | `/system/config` | Update deployment configuration, scopes, and ingress mode toggles (admin token required). |
+| GET | `/system/config` | Read deployment configuration defaults and enforced webhook-only ingress settings. |
+| PUT | `/system/config` | Update deployment configuration and scopes (admin token required); deprecated ingress transition toggles are ignored. |
 
 ### `/system/config`
 - **GET response fields**
   - Existing setup/OAuth fields (`setup_complete`, client IDs/secrets, redirect URIs, scopes).
   - `eventsub_callback_override`: optional admin-managed full callback override URL (example: `https://api.example.com/twitch/eventsub/callback`).
   - `public_backend_origin`: canonical public backend origin used for EventSub callback URL generation (example: `https://api.example.com`).
-  - `chat_ingress_mode`: `webhook_conduit` (default authoritative) or `websocket` (legacy fallback).
-  - `chat_ingress_shadow_mode`: boolean dual-run switch for validation mode (default `false`).
-  - `chat_websocket_fallback_legacy_enabled`: explicit rollback flag for websocket EventSub chat subscriptions in bot runtime.
-    When `chat_ingress_mode=webhook_conduit` and this flag is `false`, bot
-    runtime websocket lifecycle is not required and workers avoid steady-state
-    `/bot/config` polling churn.
-  - `chat_ingress_guard_auto_fallback_enabled`: if `true`, degraded authoritative ingress can auto-switch mode to `websocket`.
+  - `chat_ingress_mode`: always `webhook_conduit` (authoritative and enforced).
+  - `chat_ingress_shadow_mode`: always `false` (shadow mode removed).
+  - `chat_websocket_fallback_legacy_enabled`: always `false` (websocket fallback retired).
+  - `chat_ingress_guard_auto_fallback_enabled`: always `false` (no automatic mode fallback).
 - **PUT payload additions**
   - `eventsub_callback_override?: string`
   - `public_backend_origin?: string`
-  - `chat_ingress_mode?: "websocket" | "webhook_conduit"`
-  - `chat_ingress_shadow_mode?: boolean`
-  - `chat_websocket_fallback_legacy_enabled?: boolean`
-  - `chat_ingress_guard_auto_fallback_enabled?: boolean`
+  - `chat_ingress_mode?: "webhook_conduit"`
+  - `chat_ingress_shadow_mode?: boolean` (deprecated/ignored)
+  - `chat_websocket_fallback_legacy_enabled?: boolean` (deprecated/ignored)
+  - `chat_ingress_guard_auto_fallback_enabled?: boolean` (deprecated/ignored)
 
 ### `/system/health` ingress summary
 - `eventsub.ingress_summary` includes compact operational counters:
@@ -51,7 +48,7 @@ This document summarizes the REST endpoints exposed by `backend_app.py`.
   - conduit shard status transitions,
   - last reply preflight failure reason (`last_errors.reply_preflight_failure_reason_code`),
   - recent callback throughput + last error timestamps/diagnostic snippets.
-- `eventsub.authoritative_guard` includes degradation reasons (`missing_healthy_shards`, `callback_errors_spike`, `token_refresh_unhealthy`) and whether fallback was applied.
+- `eventsub.authoritative_guard` includes degradation reasons (`missing_healthy_shards`, `callback_errors_spike`, `token_refresh_unhealthy`) in webhook-only mode (no websocket fallback path).
 - The backend repair watcher evaluates these guard reasons every 60 seconds and
   applies least-disruptive repair in order: `reconcile`, `shard_repair`,
   `rebuild` (with cooldown + attempt caps to avoid loops).
@@ -68,7 +65,7 @@ This document summarizes the REST endpoints exposed by `backend_app.py`.
 
 ### Startup/operator log events (non-API)
 - `INGRESS_STARTUP_HEALTH` (backend startup):
-  - `ingress_mode`: effective startup mode (`webhook_conduit` or `websocket`).
+  - `ingress_mode`: effective startup mode (`webhook_conduit`).
   - `guard.startup_status`: startup check result (`ok`, `skipped`, `error`).
   - `guard.status`: normalized guard health (`healthy`, `degraded`, `skipped`).
   - `guard.reasons`: degradation/skip reasons (if any).
@@ -89,7 +86,7 @@ This document summarizes the REST endpoints exposed by `backend_app.py`.
 - `CHANNEL_SYNC_SUMMARY` (bot runtime `sync_channels` cycle):
   - `considered`: number of backend channel rows evaluated this cycle.
   - `listened`: channels currently tracked/listened by bot before diff apply.
-  - `rollback_websocket`: value of `chat_websocket_fallback_legacy_enabled`.
+  - `rollback_websocket`: always `false` (legacy field retained for compatibility during cleanup).
   - `added`: channels entering allowed set this cycle.
   - `removed`: channels leaving allowed set this cycle.
 
@@ -118,25 +115,14 @@ This document summarizes the REST endpoints exposed by `backend_app.py`.
   includes a remediation string describing how to fix the callback source.
 - **Important**: relying on a `301` redirect from `http://...` to `https://...` is **not** considered a reliable or supported substitute for EventSub callback registration.
 
-### EventSub pre-cutover operational verification
+### EventSub operational verification (webhook-only)
 1. Confirm `public_backend_origin` is set to an HTTPS origin in system config:
    ```bash
    curl -sS http://localhost:7070/system/config | jq '{public_backend_origin, chat_ingress_mode, chat_ingress_shadow_mode}'
    ```
 2. Confirm expected callback URL format before enabling conduit ingress:
    - `https://<public-backend-origin>/twitch/eventsub/callback`
-3. Rollback playbook:
-   - Enable `chat_websocket_fallback_legacy_enabled=true` for immediate websocket subscription restore.
-   - If required, switch `chat_ingress_mode=websocket`.
-   - Bot runtime treats websocket as rollback-only in authoritative mode: no
-     websocket subscription reuse/recovery loops should be considered canonical.
-   - Keep at least one rollback smoke check (`!request` or `!points`) active in
-     staging for one additional release window before deleting websocket test
-     fixtures.
-   - If product decision explicitly confirms **no websocket rollback supported**,
-     declare rollback EOL and remove both the smoke harness and websocket toggle
-     path together.
-   - Re-run conduit reconcile + callback validation before returning to authoritative mode.
+3. Ensure shard assignment uses healthy shards and monitor `/system/health.eventsub.shards` for pending/disabled statuses before live command validation.
 
 ## Authentication
 | Method | Path | Description |

--- a/docs/websocket_pruning_ledger.md
+++ b/docs/websocket_pruning_ledger.md
@@ -36,6 +36,14 @@ Use this ledger whenever websocket-only code/tests are removed.
 - **classification**: behavioral removal
 - **archived rationale link**: [Archived websocket deprecation rationale](./archive/websocket_deprecation_rationale.md)
 
+### 2026-04-05 — Enforce webhook-only ingress and disable transition toggles
+- **removed modules/functions**: `backend_app.py` websocket/shadow runtime fallback behavior in ingress mode getters and guard auto-fallback branch (`_evaluate_ingress_guard` mode-switch path)
+- **replacement path**: webhook-conduit authoritative execution in `backend_app._process_eventsub_chat_notification` and fixed `/system/config` webhook-only emission
+- **deprecation decision date**: 2026-04-05
+- **rollback implications**: behavioral tightening; rollback would require restoring configurable ingress mode/shadow/fallback toggles and websocket fallback branch.
+- **classification**: behavioral removal
+- **archived rationale link**: [Archived websocket deprecation rationale](./archive/websocket_deprecation_rationale.md)
+
 ### 2026-04-04 — Remove websocket runtime announcement rollback fallback/gate
 - **removed modules/functions**: `bot/bot_app.py` `SongBot._announce_backend_runtime_event` websocket fallback branch, `SongBot` queue/event polling announcers (`check_played`, `check_bumps`, `check_queue_position_changes`, `announce_event`), and `BotService._requires_runtime` gate branch from `BotService.run`.
 - **replacement path**: backend-authoritative catalog announcement dispatch in `backend_app._send_catalog_announcement`, called directly from `move_request`, `mark_played`, and `_persist_channel_event`.

--- a/tests/test_channel_events.py
+++ b/tests/test_channel_events.py
@@ -2230,8 +2230,8 @@ remove:
         finally:
             db.close()
 
-    def test_ingress_guard_degradation_can_auto_fallback_websocket_mode(self) -> None:
-        """Auto-fallback to websocket mode when authoritative ingress is degraded."""
+    def test_ingress_guard_degradation_keeps_webhook_authoritative_mode(self) -> None:
+        """Guard degradation should not switch away from webhook-conduit mode."""
 
         _setup_channel()
         db = backend_app.SessionLocal()
@@ -2248,8 +2248,8 @@ remove:
             backend_app._record_ingress_metric("callback_status", key="5xx")
             guard = backend_app._evaluate_ingress_guard(db, backend_app.datetime.utcnow(), apply_fallback=True)
             self.assertTrue(guard["degraded"])
-            self.assertTrue(guard["auto_fallback_applied"])
-            self.assertEqual(backend_app.get_chat_ingress_mode(), "websocket")
+            self.assertFalse(guard["auto_fallback_applied"])
+            self.assertEqual(backend_app.get_chat_ingress_mode(), "webhook_conduit")
         finally:
             db.close()
 


### PR DESCRIPTION
## Summary
- enforce webhook-conduit as the only ingress mode and ignore deprecated transition toggles (`shadow`, websocket fallback, auto-fallback)
- remove runtime guard mode-switch fallback behavior to keep webhook mode authoritative under degradation
- update EventSub conduit reconciliation to assign channel chat subscriptions only to currently enabled shards (with warning fallback when none are enabled)
- add explicit runtime-announcement decision logs for backend-triggered catalog messages (including suppressed disconnected cases)
- update API docs and websocket pruning ledger for the webhook-only policy
- adjust ingress-guard test expectations to assert no websocket auto-fallback

## Why
The reported production behavior showed command non-responsiveness while runtime announcements still worked. The health payload indicated only one shard was enabled while multiple shards were pending. Previous assignment logic could still place subscriptions onto non-enabled shards, which can starve command callbacks. In parallel, legacy transition toggles allowed non-authoritative paths that are now explicitly out of policy.

## Validation
- `python -m py_compile backend_app.py tests/test_channel_events.py`

## Notes
- Full integration tests were not run in this environment because the repository expects a runtime DB path (`/data/db.sqlite`) and stack services that are not present in this sandbox.
- Deprecated config fields are still accepted by the API shape for compatibility but are now ignored and forced to webhook-only values.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d19c984e5c83289d6c17cd3e54523c)