### PR TITLE
Hot-swap bot tokens without full restart

### DIFF
--- a/bot/bot_app.py
+++ b/bot/bot_app.py
@@ -558,6 +558,14 @@ class SongBot(commands.Bot):
         return self._configured_login
 
     async def load_tokens(self, path: Optional[str] = None) -> None:
+        """Register startup tokens with TwitchIO and persist normalized metadata.
+
+        Dependencies: TwitchIO ``add_token`` API and backend ``update_bot_tokens``.
+        Code customers: initial bot startup and credential bootstrap paths.
+        Used variables/origin: reads ``self._user_token`` / ``self._refresh_token``
+        set from backend `/bot/config` settings and stores refreshed scopes/expiry.
+        """
+
         if not self._user_token or not self._refresh_token:
             raise RuntimeError('Bot credentials are unavailable')
         payload = await super().add_token(self._user_token, self._refresh_token)
@@ -572,6 +580,39 @@ class SongBot(commands.Bot):
     async def save_tokens(self, path: Optional[str] = None) -> None:
         # Tokens are persisted to the backend, so skip file writes.
         return None
+
+    async def refresh_runtime_tokens(
+        self,
+        *,
+        access_token: str,
+        refresh_token: str,
+        scopes: Optional[List[str]] = None,
+        expires_in: Optional[int] = None,
+    ) -> None:
+        """Hot-swap runtime tokens without rebuilding the bot process.
+
+        Dependencies: TwitchIO ``add_token`` registration and backend token
+        persistence.
+        Code customers: ``BotService.apply_settings`` token-only credential churn
+        path and websocket rollback ``event_token_refreshed`` compatibility flow.
+        Used variables/origin: accepts backend-provided bot token deltas and
+        optional scope/expiry metadata, then updates in-memory token state.
+        """
+
+        if not access_token or not refresh_token:
+            raise RuntimeError('Bot token hot-swap requires access and refresh tokens')
+        payload = await super().add_token(access_token, refresh_token)
+        normalized_scopes = sorted(dict.fromkeys(scopes if scopes is not None else list(payload.scopes)))
+        resolved_expires_in = expires_in if expires_in is not None else payload.expires_in
+        self._user_token = access_token
+        self._refresh_token = refresh_token
+        self._scopes = normalized_scopes
+        await self._persist_tokens(
+            access_token=access_token,
+            refresh_token=refresh_token,
+            expires_in=resolved_expires_in,
+            scopes=normalized_scopes,
+        )
 
     async def _persist_tokens(
         self,
@@ -604,14 +645,11 @@ class SongBot(commands.Bot):
         # session lifecycle are now legacy because backend_app runs an
         # authoritative refresh worker for webhook_conduit mode. Keep this path
         # as rollback compatibility until worker stability is confirmed.
-        self._user_token = payload.token
-        self._refresh_token = payload.refresh_token
-        self._scopes = list(payload.scopes)
-        await self._persist_tokens(
+        await self.refresh_runtime_tokens(
             access_token=payload.token,
             refresh_token=payload.refresh_token,
+            scopes=list(payload.scopes),
             expires_in=payload.expires_in,
-            scopes=self._scopes,
         )
         for login in list(self.joined):
             await self._send_catalog_message(
@@ -1482,6 +1520,16 @@ class BotService:
             await asyncio.sleep(self.poll_interval)
 
     async def apply_settings(self, settings: BotSettings):
+        """Apply backend bot settings and decide between restart vs hot-swap.
+
+        Dependencies: backend `/bot/config` polling loop, ``SongBot`` lifecycle
+        methods (restart/shutdown/token hot-swap), and lifecycle console logging.
+        Code customers: ``BotService.run`` periodic reconciliation loop.
+        Used variables/origin: compares backend-provided credential/identity
+        fields against cached ``self._current_*`` state to choose safe runtime
+        transition behavior.
+        """
+
         required_fields = {
             'access_token': settings.token,
             'refresh_token': settings.refresh_token,
@@ -1529,17 +1577,16 @@ class BotService:
         token = _format_token(settings.token)
         refresh = settings.refresh_token or ''
         scopes_sorted = sorted(settings.scopes or [])
-        requires_restart = (
+        requires_identity_restart = (
             self._bot is None
-            or token != self._current_token
-            or refresh != self._current_refresh
             or settings.login != self._current_login
             or settings.client_id != self._current_client_id
             or settings.client_secret != self._current_client_secret
             or settings.bot_user_id != self._current_bot_id
             or scopes_sorted != self._current_scopes
         )
-        if requires_restart:
+        token_changed_only = token != self._current_token or refresh != self._current_refresh
+        if requires_identity_restart:
             await self._restart_bot(
                 token=token,
                 refresh_token=refresh,
@@ -1550,6 +1597,44 @@ class BotService:
                 bot_user_id=settings.bot_user_id,
                 scopes=settings.scopes or [],
             )
+        elif token_changed_only and self._bot:
+            try:
+                await self._bot.refresh_runtime_tokens(
+                    access_token=token,
+                    refresh_token=refresh,
+                    scopes=settings.scopes or [],
+                )
+                self._current_token = token
+                self._current_refresh = refresh
+                await push_console_event(
+                    'info',
+                    'Bot token hot-swap applied without restart',
+                    event='lifecycle',
+                    metadata={
+                        'event': 'token_hot_swap_succeeded',
+                        'reason_code': 'token_changed_only',
+                    },
+                )
+            except Exception as exc:
+                await push_console_event(
+                    'error',
+                    f'Bot token hot-swap failed; falling back to restart ({exc})',
+                    event='lifecycle',
+                    metadata={
+                        'event': 'token_hot_swap_failed',
+                        'reason_code': 'token_hot_swap_failed',
+                    },
+                )
+                await self._restart_bot(
+                    token=token,
+                    refresh_token=refresh,
+                    login=settings.login,
+                    enabled=settings.enabled,
+                    client_id=settings.client_id,
+                    client_secret=settings.client_secret,
+                    bot_user_id=settings.bot_user_id,
+                    scopes=settings.scopes or [],
+                )
         elif self._bot:
             await self._bot.update_enabled(settings.enabled)
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -521,6 +521,12 @@ Expected:
   membership state.
 - Backend now runs a dedicated token refresh worker (60s poll, refresh at
   `expires_at - 5m`) while webhook/conduit remains authoritative ingress.
+- Token-only credential deltas (`access_token` / `refresh_token`) are hot-swapped
+  in-place via TwitchIO `add_token` registration and no longer force a full bot
+  restart when identity/config fields are unchanged.
+- Bot restarts are still required for identity/config deltas (`login`,
+  `client_id`, `client_secret`, `bot_user_id`, `scopes`) or when token hot-swap
+  fails and the runtime falls back to the safe restart path.
 - Legacy websocket rollback keeps only minimal `subscribe_websocket` hooks;
   prior websocket subscription reuse/recovery loops are intentionally disabled
   to avoid accidental authoritative use during normal operations.

--- a/docs/backend_api.md
+++ b/docs/backend_api.md
@@ -367,6 +367,8 @@ Channel settings include queue intake controls:
   2. Token refresh triggers at `T-5m` before `expires_at`.
   3. On success, backend persists `access_token`, `refresh_token`,
      `expires_at`, and refreshed `scopes`.
+  4. Bot runtime polling applies token-only deltas through in-place hot-swap;
+     identity/config changes still trigger a full bot restart.
 - **Failure alarms**:
   1. `token_refresh_healthy=false` in `/system/health`.
   2. `token_refresh_unhealthy` appears in

--- a/docs/websocket_pruning_ledger.md
+++ b/docs/websocket_pruning_ledger.md
@@ -12,6 +12,14 @@ Use this ledger whenever websocket-only code/tests are removed.
 
 ## Entries
 
+### 2026-04-05 — Stop restarting bot on token-only backend refresh churn
+- **removed modules/functions**: `bot/bot_app.py` `BotService.apply_settings` token-delta restart requirement (`access_token` / `refresh_token` changes no longer force `_restart_bot`).
+- **replacement path**: token-only updates now execute `SongBot.refresh_runtime_tokens` hot-swap (`add_token` registration + backend token persistence), with restart fallback only on hot-swap failure.
+- **deprecation decision date**: 2026-04-05
+- **rollback implications**: behavioral removal; rollback would restore restart-on-token-delta churn and increased stop/start disruption during backend refresh-worker cadence.
+- **classification**: behavioral removal
+- **archived rationale link**: [Archived websocket deprecation rationale](./archive/websocket_deprecation_rationale.md)
+
 ### 2026-04-05 — Remove websocket rollback subscription gates and webhook random-request transition
 - **removed modules/functions**: `bot/bot_app.py` `SongBot._extract_subscription_id`, `SongBot._find_existing_subscription_id`, and rollback-only websocket subscription management paths (`_subscribe_for_channel`, `_unsubscribe_channel`, `_websocket_fallback_enabled`, `_subscription_ids`); `backend_app.py` legacy webhook rejection branch for canonical `random_request` plus transitional TODO(removal) command-unification note in `_dispatch_eventsub_chat_command`.
 - **replacement path**: bot channel sync now relies solely on backend queue-stream listeners (`SongBot.sync_channels` + `SongBot.listen_backend`), while webhook chat commands execute `random_request` through `backend_app._eventsub_execute_random_request_command` -> `random_playlist_request`.

--- a/tests/test_bot_service.py
+++ b/tests/test_bot_service.py
@@ -29,6 +29,7 @@ class BotServiceTests(unittest.IsolatedAsyncioTestCase):
             bot.close = AsyncMock()
             bot.shutdown = AsyncMock()
             bot.update_enabled = AsyncMock()
+            bot.refresh_runtime_tokens = AsyncMock()
             ready_event = asyncio.Event()
             ready_event.set()
             bot.ready_event = ready_event
@@ -196,6 +197,113 @@ class BotServiceTests(unittest.IsolatedAsyncioTestCase):
         )
         bot.shutdown.assert_awaited()
         bot.close.assert_not_awaited()
+
+    async def test_apply_settings_token_delta_hot_swaps_without_restart(self) -> None:
+        service = bot_app.BotService(
+            self.backend,
+            bot_factory=self.bot_factory,
+            task_factory=asyncio.create_task,
+        )
+        bot = MagicMock()
+        bot.update_enabled = AsyncMock()
+        bot.refresh_runtime_tokens = AsyncMock()
+        service._bot = bot
+        service._current_token = "old-token"
+        service._current_refresh = "old-refresh"
+        service._current_login = "nick"
+        service._current_client_id = "client"
+        service._current_client_secret = "secret"
+        service._current_bot_id = "1"
+        service._current_scopes = ["scope"]
+        service._restart_bot = AsyncMock()
+
+        await service.apply_settings(
+            bot_app.BotSettings(
+                token="new-token",
+                refresh_token="new-refresh",
+                login="nick",
+                client_id="client",
+                client_secret="secret",
+                bot_user_id="1",
+                scopes=["scope"],
+                enabled=True,
+            )
+        )
+
+        service._restart_bot.assert_not_awaited()
+        bot.refresh_runtime_tokens.assert_awaited_once()
+        self.assertEqual(service._current_token, "new-token")
+        self.assertEqual(service._current_refresh, "new-refresh")
+
+    async def test_apply_settings_identity_change_still_restarts(self) -> None:
+        service = bot_app.BotService(
+            self.backend,
+            bot_factory=self.bot_factory,
+            task_factory=asyncio.create_task,
+        )
+        bot = MagicMock()
+        bot.update_enabled = AsyncMock()
+        bot.refresh_runtime_tokens = AsyncMock()
+        service._bot = bot
+        service._current_token = "token"
+        service._current_refresh = "refresh"
+        service._current_login = "nick"
+        service._current_client_id = "client"
+        service._current_client_secret = "secret"
+        service._current_bot_id = "1"
+        service._current_scopes = ["scope"]
+        service._restart_bot = AsyncMock()
+
+        await service.apply_settings(
+            bot_app.BotSettings(
+                token="token",
+                refresh_token="refresh",
+                login="newnick",
+                client_id="client",
+                client_secret="secret",
+                bot_user_id="1",
+                scopes=["scope"],
+                enabled=True,
+            )
+        )
+
+        service._restart_bot.assert_awaited_once()
+        bot.refresh_runtime_tokens.assert_not_awaited()
+
+    async def test_apply_settings_hot_swap_failure_falls_back_to_restart(self) -> None:
+        service = bot_app.BotService(
+            self.backend,
+            bot_factory=self.bot_factory,
+            task_factory=asyncio.create_task,
+        )
+        bot = MagicMock()
+        bot.update_enabled = AsyncMock()
+        bot.refresh_runtime_tokens = AsyncMock(side_effect=RuntimeError("boom"))
+        service._bot = bot
+        service._current_token = "token"
+        service._current_refresh = "refresh"
+        service._current_login = "nick"
+        service._current_client_id = "client"
+        service._current_client_secret = "secret"
+        service._current_bot_id = "1"
+        service._current_scopes = ["scope"]
+        service._restart_bot = AsyncMock()
+
+        await service.apply_settings(
+            bot_app.BotSettings(
+                token="token-new",
+                refresh_token="refresh-new",
+                login="nick",
+                client_id="client",
+                client_secret="secret",
+                bot_user_id="1",
+                scopes=["scope"],
+                enabled=True,
+            )
+        )
+
+        bot.refresh_runtime_tokens.assert_awaited_once()
+        service._restart_bot.assert_awaited_once()
 
     async def test_sync_channels_subscribes_backend_channels(self) -> None:
         song_bot = bot_app.SongBot.__new__(bot_app.SongBot)


### PR DESCRIPTION
### Motivation
- Reduce noisy bot restarts caused by frequent backend-managed token refreshes while preserving existing restart semantics for identity/config changes (login, client_id, client_secret, bot_user_id, scopes).
- Keep a safe fallback by retaining full restart behavior if an in-place token hot-swap fails.

### Description
- Refactor `BotService.apply_settings` to split the previous single `requires_restart` check into `requires_identity_restart` (identity/config changes) and `token_changed_only`, with token-only deltas now attempted as an in-place hot-swap instead of forcing `_restart_bot` (file: `bot/bot_app.py`).
- Add `SongBot.refresh_runtime_tokens(...)` to re-register tokens via TwitchIO `add_token`, update in-memory token fields (`_user_token`, `_refresh_token`, `_scopes`) and persist normalized `scopes`/`expires_at` metadata through the backend (file: `bot/bot_app.py`).
- Route legacy `event_token_refreshed` to the new hot-swap method, emit lifecycle observability events `token_hot_swap_succeeded` and `token_hot_swap_failed`, and fall back to a full restart when hot-swap raises an exception (file: `bot/bot_app.py`).
- Add unit tests covering token-only hot-swap success, identity-change restart behavior, and hot-swap failure fallback, and update the test bot factory to mock `refresh_runtime_tokens` (file: `tests/test_bot_service.py`).
- Update documentation to describe the new runtime behavior and ledger the behavioral change (`docs/README.md`, `docs/backend_api.md`, `docs/websocket_pruning_ledger.md`).

### Testing
- Ran unit tests: `pytest -q tests/test_bot_service.py`, all tests passed (23 passed, 5 warnings).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d2e8499e208328b784ed59d1cbf59e)