### PR TITLE
Add per-channel bot message templates (DB, API, bot sync)

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,15 @@ See the [docs](docs/README.md) for a full project overview and setup instruction
 - The Users view now ships with a debounced search box that filters usernames client-side while still passing the term to the backend source.
 - Pagination is limited to 25 names per page with accessible Previous/Next controls and a live page indicator.
 - Channel owners and the special playlist automation requester (`__playlist__`) are excluded from both the rendered list and the API totals by default.
+
+## Per-channel bot message templates
+- Bot message templates are now stored per channel in the backend database (`channel_bot_messages` keyed by `channel_id + message_id`).
+- New API endpoints:
+  - `GET /channels/{channel}/bot/messages`
+  - `PUT /channels/{channel}/bot/messages/{message_id}`
+  - `POST /channels/{channel}/bot/messages/bulk` (bulk update/reset)
+- Channel creation seeds template rows from backend defaults with `bot/messages.yml` compatibility fallback.
+- Runtime fallback order is:
+  1. Channel DB override.
+  2. Channel seeded DB default.
+  3. Bot `DEFAULT_MESSAGES` constant.

--- a/backend_app.py
+++ b/backend_app.py
@@ -230,6 +230,7 @@ BOT_MESSAGE_DEFAULT_TEMPLATES: dict[str, str] = {
     "action_failed_debug": "Debug failure in {action}: {error}",
 }
 BOT_MESSAGE_LEVEL_RANK: dict[str, int] = {"mute": 0, "normal": 1, "verbose": 2, "debug": 3}
+BOT_MESSAGES_YAML_PATH = FilePath(__file__).resolve().parent / "bot" / "messages.yml"
 TWITCH_SEND_CHAT_MESSAGE_MAX_LENGTH = 500
 TWITCH_SEND_CHAT_AUTH_MODE_APP = "app_token"
 TWITCH_SEND_CHAT_AUTH_MODE_BOT_USER = "bot_user_token"
@@ -507,6 +508,69 @@ def ensure_eventsub_conduit_schema() -> None:
                     """
                 )
             )
+
+
+def ensure_channel_bot_messages_schema() -> None:
+    """Ensure per-channel bot message template table exists and is seeded.
+
+    Dependencies: executes additive SQL migrations through ``engine.begin`` and
+    performs seed writes via ``SessionLocal`` using ``_seed_channel_bot_messages``.
+    Code customers: startup bootstrap and legacy database compatibility paths.
+    Used variables/origin: schema targets ``channel_bot_messages`` keyed by
+    ``channel_id`` + ``message_id`` for catalog-driven template overrides.
+    """
+
+    with engine.begin() as conn:
+        inspector = inspect(conn)
+        table_names = set(inspector.get_table_names())
+        if "channel_bot_messages" not in table_names:
+            conn.execute(
+                text(
+                    """
+                    CREATE TABLE channel_bot_messages (
+                        id INTEGER PRIMARY KEY,
+                        channel_id INTEGER NOT NULL REFERENCES active_channels(id) ON DELETE CASCADE,
+                        message_id VARCHAR NOT NULL,
+                        template TEXT NOT NULL,
+                        enabled BOOLEAN DEFAULT 1,
+                        created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                        updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+                    )
+                    """
+                )
+            )
+            conn.execute(
+                text(
+                    "CREATE UNIQUE INDEX IF NOT EXISTS uq_channel_bot_message "
+                    "ON channel_bot_messages(channel_id, message_id)"
+                )
+            )
+        else:
+            columns = {col["name"] for col in inspector.get_columns("channel_bot_messages")}
+            if "enabled" not in columns:
+                conn.execute(text("ALTER TABLE channel_bot_messages ADD COLUMN enabled BOOLEAN DEFAULT 1"))
+            if "created_at" not in columns:
+                conn.execute(text("ALTER TABLE channel_bot_messages ADD COLUMN created_at DATETIME"))
+                conn.execute(text("UPDATE channel_bot_messages SET created_at = CURRENT_TIMESTAMP WHERE created_at IS NULL"))
+            if "updated_at" not in columns:
+                conn.execute(text("ALTER TABLE channel_bot_messages ADD COLUMN updated_at DATETIME"))
+                conn.execute(text("UPDATE channel_bot_messages SET updated_at = CURRENT_TIMESTAMP WHERE updated_at IS NULL"))
+            conn.execute(
+                text(
+                    "CREATE UNIQUE INDEX IF NOT EXISTS uq_channel_bot_message "
+                    "ON channel_bot_messages(channel_id, message_id)"
+                )
+            )
+            conn.execute(text("UPDATE channel_bot_messages SET enabled = 1 WHERE enabled IS NULL"))
+
+    db = SessionLocal()
+    try:
+        channel_ids = [row.id for row in db.query(ActiveChannel.id).all()]
+        for channel_pk in channel_ids:
+            _seed_channel_bot_messages(db, channel_pk)
+        db.commit()
+    finally:
+        db.close()
 
 
 def backfill_missing_channel_keys() -> None:
@@ -2386,6 +2450,99 @@ def _render_eventsub_reply_text(reply: dict[str, Any]) -> str:
         return template.format(**template_vars)
     except Exception:
         return template
+
+
+@lru_cache(maxsize=1)
+def _load_bot_messages_yml_defaults() -> dict[str, str]:
+    """Load optional bot/messages.yml defaults used for DB seed compatibility.
+
+    Dependencies: reads ``BOT_MESSAGES_YAML_PATH`` and parses YAML using
+    ``yaml.safe_load``.
+    Code customers: channel bot message seed helpers and template fallback
+    resolution.
+    Used variables/origin: source file values come from repository-managed
+    ``bot/messages.yml`` and may omit newer catalog keys.
+    """
+
+    if not BOT_MESSAGES_YAML_PATH.exists():
+        return {}
+    try:
+        raw = yaml.safe_load(BOT_MESSAGES_YAML_PATH.read_text(encoding="utf-8")) or {}
+    except Exception:
+        return {}
+    result: dict[str, str] = {}
+    if isinstance(raw, dict):
+        for key, value in raw.items():
+            if isinstance(key, str) and isinstance(value, str):
+                result[key] = value
+    return result
+
+
+def _resolve_bot_template_default(message_id: str) -> str:
+    """Resolve canonical default template for a bot ``message_id``.
+
+    Dependencies: consults in-memory ``BOT_MESSAGE_DEFAULT_TEMPLATES`` and
+    optional ``bot/messages.yml`` fallback data.
+    Code customers: channel seed/create flows and bot message reset endpoint.
+    Used variables/origin: ``message_id`` comes from catalog rows and endpoint
+    path parameters.
+    """
+
+    yaml_defaults = _load_bot_messages_yml_defaults()
+    return (
+        BOT_MESSAGE_DEFAULT_TEMPLATES.get(message_id)
+        or yaml_defaults.get(message_id)
+        or message_id
+    )
+
+
+def _seed_channel_bot_messages(db: Session, channel_pk: int) -> None:
+    """Ensure a channel has one seeded template row for every catalog entry.
+
+    Dependencies: reads ``BOT_MESSAGE_CATALOG`` and writes
+    ``ChannelBotMessage`` rows with the provided SQLAlchemy ``Session``.
+    Code customers: channel creation and startup backfill/bootstrap paths.
+    Used variables/origin: ``channel_pk`` is the ``ActiveChannel.id`` primary
+    key resolved by channel provisioning APIs.
+    """
+
+    existing_ids = {
+        row.message_id
+        for row in db.query(ChannelBotMessage.message_id).filter(ChannelBotMessage.channel_id == channel_pk).all()
+    }
+    for message_row in BOT_MESSAGE_CATALOG:
+        message_id = str(message_row.get("id") or "").strip()
+        if not message_id or message_id in existing_ids:
+            continue
+        db.add(
+            ChannelBotMessage(
+                channel_id=channel_pk,
+                message_id=message_id,
+                template=_resolve_bot_template_default(message_id),
+                enabled=True,
+            )
+        )
+
+
+def _channel_bot_message_payload(rows: Sequence["ChannelBotMessage"]) -> dict[str, dict[str, Any]]:
+    """Serialize channel bot message rows for API responses and bot sync.
+
+    Dependencies: pure serialization helper.
+    Code customers: ``list_channels`` and channel bot message endpoints.
+    Used variables/origin: ``rows`` are ORM model instances loaded for a
+    specific channel.
+    """
+
+    payload: dict[str, dict[str, Any]] = {}
+    for row in rows:
+        payload[row.message_id] = {
+            "message_id": row.message_id,
+            "template": row.template,
+            "enabled": bool(row.enabled) if row.enabled is not None else True,
+            "created_at": row.created_at,
+            "updated_at": row.updated_at,
+        }
+    return payload
 
 
 def _should_send_eventsub_reply(channel: ActiveChannel, visibility: str) -> bool:
@@ -4461,6 +4618,11 @@ class ActiveChannel(Base):
         uselist=False,
         cascade="all, delete-orphan",
     )
+    bot_messages = relationship(
+        "ChannelBotMessage",
+        back_populates="channel",
+        cascade="all, delete-orphan",
+    )
     playlists = relationship("Playlist", back_populates="channel", cascade="all, delete-orphan")
 
     @property
@@ -4488,6 +4650,23 @@ class ChannelBotState(Base):
     updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow, nullable=False)
 
     channel = relationship("ActiveChannel", back_populates="bot_state")
+
+
+class ChannelBotMessage(Base):
+    __tablename__ = "channel_bot_messages"
+    id = Column(Integer, primary_key=True)
+    channel_id = Column(Integer, ForeignKey("active_channels.id", ondelete="CASCADE"), nullable=False)
+    message_id = Column(String, nullable=False)
+    template = Column(Text, nullable=False)
+    enabled = Column(Boolean, nullable=True, default=True)
+    created_at = Column(DateTime, default=datetime.utcnow, nullable=False)
+    updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow, nullable=False)
+
+    channel = relationship("ActiveChannel", back_populates="bot_messages")
+
+    __table_args__ = (
+        UniqueConstraint("channel_id", "message_id", name="uq_channel_bot_message"),
+    )
 
 class ChannelSettings(Base):
     __tablename__ = "channel_settings"
@@ -4858,6 +5037,7 @@ def _validate_startup_symbol_order() -> None:
 ensure_channel_settings_schema()
 _ensure_playlist_schema()
 ensure_eventsub_conduit_schema()
+ensure_channel_bot_messages_schema()
 bootstrap_settings_from_env()
 backfill_twitch_send_chat_auth_mode_setting()
 cleanup_conduit_subscription_secret_semantics()
@@ -4884,6 +5064,7 @@ class ChannelOut(BaseModel):
     bot_active: bool
     bot_last_error: Optional[str] = None
     bot_message_level: Literal["mute", "normal", "verbose", "debug"] = "normal"
+    bot_message_templates: Dict[str, Dict[str, Any]] = Field(default_factory=dict)
 
     class Config:
         from_attributes = True
@@ -5032,6 +5213,29 @@ class BotMessageCatalogEntryOut(BaseModel):
 class BotMessageCatalogOut(BaseModel):
     levels: List[BotMessageLevelDetailOut]
     messages: List[BotMessageCatalogEntryOut]
+
+
+class ChannelBotMessageOut(BaseModel):
+    message_id: str
+    template: str
+    enabled: bool = True
+    created_at: Optional[datetime] = None
+    updated_at: Optional[datetime] = None
+
+
+class ChannelBotMessagesOut(BaseModel):
+    channel: str
+    messages: List[ChannelBotMessageOut]
+
+
+class ChannelBotMessageUpdateIn(BaseModel):
+    template: Optional[str] = None
+    enabled: Optional[bool] = None
+
+
+class ChannelBotMessagesBulkUpdateIn(BaseModel):
+    messages: Dict[str, ChannelBotMessageUpdateIn] = Field(default_factory=dict)
+    reset_to_defaults: bool = False
 
 
 class BotTokenUpdateIn(BaseModel):
@@ -8306,7 +8510,10 @@ def list_channels(db: Session = Depends(get_db)):
         if not channel.bot_state:
             channel.bot_state = get_or_create_bot_state(db, channel.id)
         settings = get_or_create_settings(db, channel.id)
+        _seed_channel_bot_messages(db, channel.id)
         channel.bot_message_level = settings.bot_message_level or "normal"
+        channel.bot_message_templates = _channel_bot_message_payload(channel.bot_messages)
+    db.commit()
     return channels
 
 
@@ -8392,12 +8599,172 @@ def add_channel(payload: ChannelIn, db: Session = Depends(get_db)):
     db.flush()
     get_or_create_settings(db, ch.id)
     get_or_create_bot_state(db, ch.id)
+    _seed_channel_bot_messages(db, ch.id)
     _create_default_favorites_playlist(db, ch.id)
     db.commit()
     db.refresh(ch)
+    ch.bot_message_templates = _channel_bot_message_payload(ch.bot_messages)
     channel_pk = ch.id
     publish_queue_changed(channel_pk)
     return ch
+
+
+@app.get(
+    "/channels/{channel}/bot/messages",
+    response_model=ChannelBotMessagesOut,
+    dependencies=[Depends(require_token)],
+)
+def get_channel_bot_messages(channel: str, db: Session = Depends(get_db)):
+    """Return channel-scoped bot message templates persisted in the database.
+
+    Dependencies: resolves channel identity via ``get_channel_pk`` and ensures
+    seed rows via ``_seed_channel_bot_messages`` before querying
+    ``ChannelBotMessage``.
+    Code customers: admin UI and bot sync/debug workflows.
+    Used variables/origin: ``channel`` path parameter supports channel name,
+    channel ID, or numeric primary key aliases.
+    """
+
+    channel_pk = get_channel_pk(channel, db)
+    _seed_channel_bot_messages(db, channel_pk)
+    db.commit()
+    rows = (
+        db.query(ChannelBotMessage)
+        .filter(ChannelBotMessage.channel_id == channel_pk)
+        .order_by(ChannelBotMessage.message_id.asc())
+        .all()
+    )
+    return ChannelBotMessagesOut(
+        channel=channel,
+        messages=[
+            ChannelBotMessageOut(
+                message_id=row.message_id,
+                template=row.template,
+                enabled=bool(row.enabled) if row.enabled is not None else True,
+                created_at=row.created_at,
+                updated_at=row.updated_at,
+            )
+            for row in rows
+        ],
+    )
+
+
+@app.put(
+    "/channels/{channel}/bot/messages/{message_id}",
+    response_model=ChannelBotMessageOut,
+    dependencies=[Depends(require_token)],
+)
+def update_channel_bot_message(
+    channel: str,
+    message_id: str,
+    payload: ChannelBotMessageUpdateIn,
+    db: Session = Depends(get_db),
+):
+    """Update a single channel bot message template/enabled override row.
+
+    Dependencies: validates message identifiers against
+    ``BOT_MESSAGE_CATALOG_BY_ID`` and mutates ``ChannelBotMessage`` records.
+    Code customers: admin UI message editor and API automation.
+    Used variables/origin: ``payload.template`` and ``payload.enabled`` come
+    from request JSON; omitted fields preserve existing values.
+    """
+
+    normalized_message_id = message_id.strip()
+    if normalized_message_id not in BOT_MESSAGE_CATALOG_BY_ID:
+        raise HTTPException(status_code=404, detail="unknown bot message id")
+    channel_pk = get_channel_pk(channel, db)
+    _seed_channel_bot_messages(db, channel_pk)
+    row = (
+        db.query(ChannelBotMessage)
+        .filter(
+            ChannelBotMessage.channel_id == channel_pk,
+            ChannelBotMessage.message_id == normalized_message_id,
+        )
+        .one_or_none()
+    )
+    if not row:
+        raise HTTPException(status_code=404, detail="channel bot message not found")
+    if payload.template is not None:
+        row.template = payload.template
+    if payload.enabled is not None:
+        row.enabled = bool(payload.enabled)
+    row.updated_at = datetime.utcnow()
+    db.commit()
+    db.refresh(row)
+    return ChannelBotMessageOut(
+        message_id=row.message_id,
+        template=row.template,
+        enabled=bool(row.enabled) if row.enabled is not None else True,
+        created_at=row.created_at,
+        updated_at=row.updated_at,
+    )
+
+
+@app.post(
+    "/channels/{channel}/bot/messages/bulk",
+    response_model=ChannelBotMessagesOut,
+    dependencies=[Depends(require_token)],
+)
+def bulk_update_channel_bot_messages(
+    channel: str,
+    payload: ChannelBotMessagesBulkUpdateIn,
+    db: Session = Depends(get_db),
+):
+    """Bulk update channel bot messages or reset templates to defaults.
+
+    Dependencies: iterates catalog-validated identifiers and writes
+    ``ChannelBotMessage`` rows, using ``_resolve_bot_template_default`` for
+    reset operations.
+    Code customers: admin bulk-save/reset UX flows.
+    Used variables/origin: ``payload.messages`` keyed by message ID with
+    partial template/enabled updates and ``payload.reset_to_defaults`` flag.
+    """
+
+    channel_pk = get_channel_pk(channel, db)
+    _seed_channel_bot_messages(db, channel_pk)
+    rows = (
+        db.query(ChannelBotMessage)
+        .filter(ChannelBotMessage.channel_id == channel_pk)
+        .all()
+    )
+    row_by_id = {row.message_id: row for row in rows}
+    if payload.reset_to_defaults:
+        for row in row_by_id.values():
+            row.template = _resolve_bot_template_default(row.message_id)
+            row.enabled = True
+            row.updated_at = datetime.utcnow()
+    for update_message_id, update_payload in payload.messages.items():
+        normalized_message_id = update_message_id.strip()
+        if normalized_message_id not in BOT_MESSAGE_CATALOG_BY_ID:
+            raise HTTPException(status_code=404, detail=f"unknown bot message id: {normalized_message_id}")
+        row = row_by_id.get(normalized_message_id)
+        if not row:
+            continue
+        if update_payload.template is not None:
+            row.template = update_payload.template
+        if update_payload.enabled is not None:
+            row.enabled = bool(update_payload.enabled)
+        row.updated_at = datetime.utcnow()
+    db.commit()
+    refreshed_rows = (
+        db.query(ChannelBotMessage)
+        .filter(ChannelBotMessage.channel_id == channel_pk)
+        .order_by(ChannelBotMessage.message_id.asc())
+        .all()
+    )
+    return ChannelBotMessagesOut(
+        channel=channel,
+        messages=[
+            ChannelBotMessageOut(
+                message_id=row.message_id,
+                template=row.template,
+                enabled=bool(row.enabled) if row.enabled is not None else True,
+                created_at=row.created_at,
+                updated_at=row.updated_at,
+            )
+            for row in refreshed_rows
+        ],
+    )
 
 def _set_channel_conduit_subscription_state(
     db: Session,

--- a/bot/bot_app.py
+++ b/bot/bot_app.py
@@ -389,6 +389,7 @@ class BotMessageCatalogEntry:
     level: BotMessageLevel
     description: str
     group: Optional[str] = None
+    enabled: bool = True
 
 
 DEFAULT_MESSAGE_CATALOG: Dict[str, BotMessageCatalogEntry] = {
@@ -894,6 +895,36 @@ class SongBot(commands.Bot):
                 raw_level = settings.get('bot_message_level')
         return self._coerce_message_level(raw_level)
 
+    def _resolve_channel_message_templates(self, channel_login: str) -> Dict[str, str]:
+        """Resolve channel-aware message template map with DB/template fallback.
+
+        Dependencies: combines ``DEFAULT_MESSAGES``, startup-loaded
+        ``self.messages`` values, and ``bot_message_templates`` metadata from
+        ``self.channel_map``.
+        Code customers: command context construction and catalog message
+        rendering.
+        Used variables/origin: ``channel_login`` originates from incoming chat
+        events or channel loop iterators.
+        """
+
+        merged: Dict[str, str] = DEFAULT_MESSAGES.copy()
+        loaded_messages = getattr(self, 'messages', DEFAULT_MESSAGES) or DEFAULT_MESSAGES
+        merged.update(loaded_messages)
+        channel_info = (getattr(self, 'channel_map', {}) or {}).get(self._channel_login(channel_login), {})
+        template_rows = channel_info.get('bot_message_templates') if isinstance(channel_info, dict) else {}
+        if isinstance(template_rows, dict):
+            for message_id, row in template_rows.items():
+                if not isinstance(message_id, str) or not isinstance(row, dict):
+                    continue
+                enabled = row.get('enabled')
+                if enabled is False:
+                    merged[message_id] = ''
+                    continue
+                template_value = row.get('template')
+                if isinstance(template_value, str):
+                    merged[message_id] = template_value
+        return merged
+
     def _resolve_message_catalog_entry(
         self,
         channel_login: str,
@@ -920,11 +951,18 @@ class SongBot(commands.Bot):
             override = {}
         template_key = str(override.get('template_key') or entry.template_key)
         level_value = self._coerce_message_level(override.get('level', entry.level))
+        template_rows = channel_info.get('bot_message_templates') if isinstance(channel_info, dict) else {}
+        enabled = True
+        if isinstance(template_rows, dict):
+            row = template_rows.get(message_id)
+            if isinstance(row, dict) and row.get('enabled') is False:
+                enabled = False
         return BotMessageCatalogEntry(
             template_key=template_key,
             level=level_value,
             description=entry.description,
             group=entry.group,
+            enabled=enabled,
         )
 
     async def _send_catalog_message(
@@ -940,7 +978,9 @@ class SongBot(commands.Bot):
         """Send a logical message by catalog ID with templating and level policy."""
 
         entry = self._resolve_message_catalog_entry(channel_login, message_id)
-        message_templates = getattr(self, 'messages', DEFAULT_MESSAGES) or DEFAULT_MESSAGES
+        if not entry.enabled:
+            return
+        message_templates = self._resolve_channel_message_templates(channel_login)
         template = message_templates.get(entry.template_key)
         if not template:
             return
@@ -981,7 +1021,7 @@ class SongBot(commands.Bot):
         delegates delivery to `_send_message`; always emits backend console logs
         through `push_console_event` for observability. Code customers: all bot
         command and event handlers. Used variables/origin: message content comes
-        from `message_or_key` (literal text or `self.messages` key), while
+        from `message_or_key` (literal text or resolved per-channel template key), while
         `level` is declared at each call site. Visibility rule: `MUTE`
         channels always suppress chat, otherwise messages are allowed when the
         resolved message level is less than or equal to the configured channel
@@ -991,7 +1031,8 @@ class SongBot(commands.Bot):
         resolved_level = self._coerce_message_level(level)
         threshold = self._resolve_channel_message_threshold(channel_login)
         allow_chat = threshold != BotMessageLevel.MUTE and resolved_level <= threshold
-        message_text = self.messages.get(message_or_key, '') if message_key else message_or_key
+        channel_templates = self._resolve_channel_message_templates(channel_login)
+        message_text = channel_templates.get(message_or_key, '') if message_key else message_or_key
         if not message_text:
             return
         policy_meta = {
@@ -1246,7 +1287,7 @@ class SongBot(commands.Bot):
             fallback_partial=fallback_partial,
         )
 
-    def _build_chat_command_context(self) -> ChatCommandContext:
+    def _build_chat_command_context(self, channel_login: Optional[str] = None) -> ChatCommandContext:
         """Build command-core dependency adapters from the current bot state.
 
         Dependencies: runtime command config, message templates, backend client,
@@ -1255,9 +1296,14 @@ class SongBot(commands.Bot):
         current `SongBot` instance attributes.
         """
 
+        resolved_messages = (
+            self._resolve_channel_message_templates(channel_login)
+            if channel_login
+            else (getattr(self, 'messages', DEFAULT_MESSAGES) or DEFAULT_MESSAGES)
+        )
         return ChatCommandContext(
             backend=backend,
-            messages=getattr(self, 'messages', DEFAULT_MESSAGES),
+            messages=resolved_messages,
             commands_map=getattr(self, 'commands_map', {k: ([v] if not isinstance(v, list) else v) for k, v in DEFAULT_COMMANDS.items()}),
             currency_plural=getattr(self, 'currency_plural', 'points'),
             channel_map=getattr(self, 'channel_map', {}),
@@ -1289,7 +1335,7 @@ class SongBot(commands.Bot):
         if parsed.canonical == 'archive':
             await self.handle_archive(message)
             return
-        await dispatch_chat_command(chat_input, parsed, self._build_chat_command_context())
+        await dispatch_chat_command(chat_input, parsed, self._build_chat_command_context(chat_input.channel_login))
 
     async def handle_request(self, msg, arg: str) -> None:
         """Compatibility wrapper executing request logic via normalized core.
@@ -1300,7 +1346,7 @@ class SongBot(commands.Bot):
         """
 
         chat_input = self._normalize_twitch_chat_input(msg)
-        await execute_request(chat_input, arg, self._build_chat_command_context())
+        await execute_request(chat_input, arg, self._build_chat_command_context(chat_input.channel_login))
 
     async def handle_random_request(self, msg, arg: str) -> None:
         """Compatibility wrapper executing random logic via normalized core.
@@ -1310,7 +1356,7 @@ class SongBot(commands.Bot):
         """
 
         chat_input = self._normalize_twitch_chat_input(msg)
-        await execute_random_request(chat_input, arg, self._build_chat_command_context())
+        await execute_random_request(chat_input, arg, self._build_chat_command_context(chat_input.channel_login))
 
     async def handle_playlist_request(self, msg, arg: str) -> None:
         """Compatibility wrapper executing playlist logic via normalized core.
@@ -1321,7 +1367,7 @@ class SongBot(commands.Bot):
         """
 
         chat_input = self._normalize_twitch_chat_input(msg)
-        await execute_playlist_request(chat_input, arg, self._build_chat_command_context())
+        await execute_playlist_request(chat_input, arg, self._build_chat_command_context(chat_input.channel_login))
 
     async def handle_prioritize(self, msg, arg: str) -> None:
         """Compatibility wrapper executing prioritize logic via shared core.
@@ -1332,7 +1378,7 @@ class SongBot(commands.Bot):
         """
 
         chat_input = self._normalize_twitch_chat_input(msg)
-        await execute_prioritize(chat_input, arg, self._build_chat_command_context())
+        await execute_prioritize(chat_input, arg, self._build_chat_command_context(chat_input.channel_login))
 
     async def handle_points(self, msg) -> None:
         """Compatibility wrapper executing points logic via normalized core.
@@ -1343,7 +1389,7 @@ class SongBot(commands.Bot):
         """
 
         chat_input = self._normalize_twitch_chat_input(msg)
-        await execute_points(chat_input, '', self._build_chat_command_context())
+        await execute_points(chat_input, '', self._build_chat_command_context(chat_input.channel_login))
 
     async def handle_remove(self, msg) -> None:
         """Compatibility wrapper executing remove logic via normalized core.
@@ -1354,26 +1400,24 @@ class SongBot(commands.Bot):
         """
 
         chat_input = self._normalize_twitch_chat_input(msg)
-        await execute_remove(chat_input, '', self._build_chat_command_context())
+        await execute_remove(chat_input, '', self._build_chat_command_context(chat_input.channel_login))
 
     async def handle_archive(self, msg) -> None:
+        login = self._channel_login(msg.broadcaster.name)
         if not (msg.chatter.moderator or msg.chatter.broadcaster):
-            await self._send_bot_message(
-                self._channel_login(msg.broadcaster.name),
-                self.messages['archive_denied'],
-                level=BotMessageLevel.NORMAL,
+            await self._send_catalog_message(
+                login,
+                'archive_denied',
                 metadata={'channel': msg.broadcaster.name, 'command': 'archive'},
                 reply_to=msg.id,
                 fallback_partial=msg.broadcaster,
             )
             return
-        login = self._channel_login(msg.broadcaster.name)
         row = self.channel_map.get(login)
         if not row:
-            await self._send_bot_message(
+            await self._send_catalog_message(
                 login,
-                self.messages['channel_not_registered'],
-                level=BotMessageLevel.NORMAL,
+                'channel_not_registered',
                 metadata={'channel': msg.broadcaster.name, 'command': 'archive'},
                 reply_to=msg.id,
                 fallback_partial=msg.broadcaster,
@@ -1383,10 +1427,9 @@ class SongBot(commands.Bot):
         try:
             await backend.archive_stream(channel)
             await self.process_backend_update(channel)
-            await self._send_bot_message(
+            await self._send_catalog_message(
                 login,
-                self.messages['archive_success'],
-                level=BotMessageLevel.NORMAL,
+                'archive_success',
                 metadata={'channel': channel, 'command': 'archive'},
                 reply_to=msg.id,
                 fallback_partial=msg.broadcaster,
@@ -1397,10 +1440,10 @@ class SongBot(commands.Bot):
                 f'Failed to archive queue for {msg.chatter.name}: {exc}',
                 metadata={'channel': channel, 'command': 'archive'},
             )
-            await self._send_bot_message(
+            await self._send_catalog_message(
                 login,
-                self.messages['failed'].format(error=exc),
-                level=BotMessageLevel.NORMAL,
+                'failed',
+                template_vars={'error': exc},
                 metadata={'channel': channel, 'command': 'archive'},
                 reply_to=msg.id,
                 fallback_partial=msg.broadcaster,
@@ -1899,13 +1942,14 @@ class BotService:
             if new_prio and not was_prio:
                 song = await backend.get_song(ch_name, req['song_id'])
                 user = await backend.get_user(ch_name, req['user_id'])
-                await self._send_bot_message(
+                await self._send_catalog_message(
                     chan,
-                    self.messages['bump_free'].format(
-                        artist=song.get('artist', '?'),
-                        title=song.get('title', '?'),
-                        user=user.get('username', '?'),
-                    ),
+                    'bump_free',
+                    template_vars={
+                        'artist': song.get('artist', '?'),
+                        'title': song.get('title', '?'),
+                        'user': user.get('username', '?'),
+                    },
                     metadata={'channel': ch_name, 'event': 'bump'},
                 )
 
@@ -1938,19 +1982,18 @@ class BotService:
             if delta == 1
             else f"these {delta} {self.currency_plural}"
         )
-        template = self.messages.get(f"award_{etype}")
-        if template:
-            await self._send_bot_message(
-                chan,
-                template.format(
-                    username=user.get('username', ''),
-                    word=word,
-                    points=user.get('prio_points', 0),
-                    currency_plural=self.currency_plural,
-                    **extra,
-                ),
-                metadata={'channel': ch_name, 'event': etype},
-            )
+        await self._send_catalog_message(
+            chan,
+            f"award_{etype}",
+            template_vars={
+                'username': user.get('username', ''),
+                'word': word,
+                'points': user.get('prio_points', 0),
+                'currency_plural': self.currency_plural,
+                **extra,
+            },
+            metadata={'channel': ch_name, 'event': etype},
+        )
 
 # ---- entry ----
 async def main():

--- a/docs/backend_api.md
+++ b/docs/backend_api.md
@@ -234,6 +234,9 @@ This document summarizes the REST endpoints exposed by `backend_app.py`.
 | GET | `/channels` | List all configured channels. |
 | POST | `/channels` | Add a new channel (requires admin token) and initialize seeded Favorites. |
 | PUT | `/channels/{channel}` | Update whether the bot should join a channel (admin). |
+| GET | `/channels/{channel}/bot/messages` | Fetch per-channel bot message templates (`channel_id + message_id` rows). |
+| PUT | `/channels/{channel}/bot/messages/{message_id}` | Update one per-channel bot message template and/or enabled flag. |
+| POST | `/channels/{channel}/bot/messages/bulk` | Bulk update per-channel templates or reset all to defaults. |
 | GET | `/channels/{channel}/settings` | Retrieve channel configuration. |
 | PUT | `/channels/{channel}/settings` | Update channel configuration (admin). |
 
@@ -242,10 +245,34 @@ existing record so omitted fields keep their persisted values. Frontend callers
 should prefer sending the full current state when possible or rely on the
 backend merge behavior to avoid unintentionally resetting values to defaults.
 
+`GET /channels` includes `bot_message_templates` per channel so bot workers can
+sync resolved template text and enabled flags without additional round-trips.
+
 `POST /channels` also ensures a manual `Favorites` playlist exists and seeds
 missing defaults idempotently (`Night Drive`, `Strobe`, and
 `LONG DISTANCE CALLING - Voices`), so repeated onboarding does not duplicate
-tracks.
+tracks. Channel creation also seeds `channel_bot_messages` rows for every
+catalog `message_id`.
+
+Per-channel bot message storage model:
+
+- Table: `channel_bot_messages`.
+- Key: unique (`channel_id`, `message_id`).
+- Columns: `template` (required), `enabled` (optional boolean, default `true`),
+  `created_at`, `updated_at`.
+- Seed source order for initial rows:
+  1. `BOT_MESSAGE_DEFAULT_TEMPLATES` in `backend_app.py`.
+  2. `bot/messages.yml` fallback values when a key is missing in the Python
+     default map.
+
+Bot runtime fallback order for final template selection:
+
+1. Per-channel DB row (`channel_bot_messages.template`) when enabled.
+2. Seeded DB default row for that channel/message.
+3. Bot process `DEFAULT_MESSAGES` hardcoded fallback.
+
+If no override exists yet, behavior matches historical `bot/messages.yml`
+defaults.
 
 Channel settings include queue intake controls:
 

--- a/migrations/20260409_channel_bot_messages.sql
+++ b/migrations/20260409_channel_bot_messages.sql
@@ -1,0 +1,12 @@
+CREATE TABLE IF NOT EXISTS channel_bot_messages (
+    id INTEGER PRIMARY KEY,
+    channel_id INTEGER NOT NULL REFERENCES active_channels(id) ON DELETE CASCADE,
+    message_id VARCHAR NOT NULL,
+    template TEXT NOT NULL,
+    enabled BOOLEAN DEFAULT 1,
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT uq_channel_bot_message UNIQUE (channel_id, message_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_channel_bot_messages_channel_id ON channel_bot_messages(channel_id);

--- a/tests/test_bot_config.py
+++ b/tests/test_bot_config.py
@@ -83,6 +83,72 @@ class BotConfigApiTests(unittest.TestCase):
         self.assertEqual(data["scopes"], backend_app.get_bot_app_scopes())
         self.assertFalse(data["token_present"])
 
+    def test_add_channel_seeds_channel_bot_messages(self) -> None:
+        """Channel creation should seed per-message template rows for every catalog entry."""
+
+        response = self.client.post(
+            "/channels",
+            headers={"X-Admin-Token": backend_app.ADMIN_TOKEN},
+            json={"channel_name": "Seeded", "channel_id": "7001", "join_active": 1},
+        )
+        self.assertEqual(response.status_code, 200)
+
+        messages_response = self.client.get(
+            "/channels/Seeded/bot/messages",
+            headers={"X-Admin-Token": backend_app.ADMIN_TOKEN},
+        )
+        self.assertEqual(messages_response.status_code, 200)
+        payload = messages_response.json()
+        messages = payload["messages"]
+        self.assertEqual(len(messages), len(backend_app.BOT_MESSAGE_CATALOG))
+        by_id = {row["message_id"]: row for row in messages}
+        self.assertEqual(
+            by_id["request_added"]["template"],
+            backend_app.BOT_MESSAGE_DEFAULT_TEMPLATES["request_added"],
+        )
+        self.assertTrue(by_id["request_added"]["enabled"])
+
+    def test_channel_bot_message_update_and_bulk_reset(self) -> None:
+        """Single-item updates and bulk reset should mutate persisted templates."""
+
+        create_response = self.client.post(
+            "/channels",
+            headers={"X-Admin-Token": backend_app.ADMIN_TOKEN},
+            json={"channel_name": "TemplateChannel", "channel_id": "7002", "join_active": 1},
+        )
+        self.assertEqual(create_response.status_code, 200)
+
+        update_response = self.client.put(
+            "/channels/TemplateChannel/bot/messages/request_added",
+            headers={"X-Admin-Token": backend_app.ADMIN_TOKEN},
+            json={"template": "Custom added: {artist} - {title}", "enabled": False},
+        )
+        self.assertEqual(update_response.status_code, 200)
+        self.assertEqual(update_response.json()["template"], "Custom added: {artist} - {title}")
+        self.assertFalse(update_response.json()["enabled"])
+
+        channels_response = self.client.get("/channels")
+        self.assertEqual(channels_response.status_code, 200)
+        channel_payload = channels_response.json()[0]
+        self.assertEqual(
+            channel_payload["bot_message_templates"]["request_added"]["template"],
+            "Custom added: {artist} - {title}",
+        )
+        self.assertFalse(channel_payload["bot_message_templates"]["request_added"]["enabled"])
+
+        reset_response = self.client.post(
+            "/channels/TemplateChannel/bot/messages/bulk",
+            headers={"X-Admin-Token": backend_app.ADMIN_TOKEN},
+            json={"reset_to_defaults": True},
+        )
+        self.assertEqual(reset_response.status_code, 200)
+        by_id = {row["message_id"]: row for row in reset_response.json()["messages"]}
+        self.assertEqual(
+            by_id["request_added"]["template"],
+            backend_app.BOT_MESSAGE_DEFAULT_TEMPLATES["request_added"],
+        )
+        self.assertTrue(by_id["request_added"]["enabled"])
+
     def test_runtime_announcement_uses_send_chat_pipeline(self) -> None:
         """Runtime announcements should reuse the authoritative Send Chat path."""
 

--- a/tests/test_bot_service.py
+++ b/tests/test_bot_service.py
@@ -674,6 +674,44 @@ class BotServiceTests(unittest.IsolatedAsyncioTestCase):
         sent_calls = [call.args[1] for call in song_bot._send_message.await_args_list]
         self.assertEqual(sent_calls, ["Added: Artist - Title", "Added: Artist - Title"])
 
+    async def test_channel_template_resolution_prefers_channel_db_then_defaults(self) -> None:
+        """Catalog rendering should use channel DB template overrides before global defaults."""
+
+        song_bot = bot_app.SongBot.__new__(bot_app.SongBot)
+        song_bot.messages = bot_app.DEFAULT_MESSAGES.copy()
+        song_bot.message_catalog = bot_app.DEFAULT_MESSAGE_CATALOG.copy()
+        song_bot.channel_map = {
+            "chan": {
+                "channel_name": "Chan",
+                "bot_message_level": "debug",
+                "bot_message_templates": {
+                    "request_added": {
+                        "message_id": "request_added",
+                        "template": "DB Added: {artist}::{title}",
+                        "enabled": True,
+                    }
+                },
+            },
+            "plain": {"channel_name": "Plain", "bot_message_level": "debug", "bot_message_templates": {}},
+        }
+        song_bot._channel_login = bot_app.SongBot._channel_login.__get__(song_bot, bot_app.SongBot)
+        song_bot._send_message = AsyncMock()
+
+        with patch.object(bot_app, "push_console_event", AsyncMock()):
+            await song_bot._send_catalog_message(
+                "chan",
+                "request_added",
+                template_vars={"artist": "A", "title": "T"},
+            )
+            await song_bot._send_catalog_message(
+                "plain",
+                "request_added",
+                template_vars={"artist": "A", "title": "T"},
+            )
+
+        sent_calls = [call.args[1] for call in song_bot._send_message.await_args_list]
+        self.assertEqual(sent_calls, ["DB Added: A::T", "Added: A - T"])
+
     def test_default_message_catalog_levels_match_intended_groups(self) -> None:
         """Ensure command/background/diagnostic messages retain expected severities."""
         catalog = bot_app.DEFAULT_MESSAGE_CATALOG


### PR DESCRIPTION
### Motivation
- Provide per-channel overrideable bot message templates so channels can customize bot replies without changing global files.
- Seed channel templates from existing defaults to preserve current `bot/messages.yml` behavior and avoid breaking older deployments.
- Expose CRUD endpoints so admin UI and automation can manage per-channel templates and bulk reset to defaults.
- Ensure the running bot resolves templates by channel with a clear fallback chain to preserve compatibility with existing behavior.

### Description
- Persistence and migration: added `ChannelBotMessage` SQLAlchemy model and relationship on `ActiveChannel`, a startup migration helper `ensure_channel_bot_messages_schema()`, and a SQL migration file `migrations/20260409_channel_bot_messages.sql` that creates `channel_bot_messages` with a unique key on `(channel_id, message_id)` and timestamps.
- Seeding and defaults: added `_load_bot_messages_yml_defaults()`, `_resolve_bot_template_default()`, and `_seed_channel_bot_messages()` to seed every catalog message for each channel from `BOT_MESSAGE_DEFAULT_TEMPLATES` with `bot/messages.yml` fallback; seeding runs on startup/backfill and during `add_channel` and `GET /channels`.
- API surface: added endpoints `GET /channels/{channel}/bot/messages`, `PUT /channels/{channel}/bot/messages/{message_id}`, and `POST /channels/{channel}/bot/messages/bulk` with request/response Pydantic models and a bulk reset option that uses the seed fallback logic.
- Bot runtime changes: updated `SongBot` to resolve per-channel message templates via `_resolve_channel_message_templates()`, changed `_send_catalog_message`/`_send_bot_message` to use channel-aware templates and honor `enabled=false`, and injected resolved templates into `ChatCommandContext` so command handlers use channel-specific text while preserving historical defaults.
- Surface and docs: included `bot_message_templates` in the `/channels` response for bot sync, updated `docs/backend_api.md` and `README.md` with the new model/endpoints/fallback rules, and added tests for seeding, per-channel update/reset, and template resolution parity.

### Testing
- Ran unit tests targeting the changed areas with `pytest -q tests/test_bot_config.py tests/test_bot_service.py` and all tests passed. The run reported `44 passed` with warnings only.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d7d2b157108328a43d639b4682d50f)